### PR TITLE
Add font and .npmrc to storybook

### DIFF
--- a/apps/storybook-react/.npmrc
+++ b/apps/storybook-react/.npmrc
@@ -1,0 +1,2 @@
+@equinor-internal:registry=https://npm.equinor.com/
+//npm.equinor.com/:_authToken=${EQUINOR_INTERNAL_NPM_TOKEN}

--- a/apps/storybook-react/package.json
+++ b/apps/storybook-react/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@eds-ui/core-react": "^0.0.1",
-    "@equinor-internal/equinor-logo": "^1.0.5",
+    "@equinor-internal/equinor-font": "^1.0.0",
     "@storybook/react": "^5.1.1",
     "babel-runtime": "^6.26.0",
     "core-js": "2",

--- a/apps/storybook-react/pnpm-lock.yaml
+++ b/apps/storybook-react/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 dependencies:
   '@eds-ui/core-react': 'link:../../libraries/core-react'
-  '@equinor-internal/equinor-logo': 1.0.5
+  '@equinor-internal/equinor-font': 1.0.0
   '@storybook/react': 5.1.9_47c491123fa06df145fcb5ec199efb44
   babel-runtime: 6.26.0
   core-js: 2.6.9
@@ -1640,10 +1640,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
-  /@equinor-internal/equinor-logo/1.0.5:
+  /@equinor-internal/equinor-font/1.0.0:
     dev: false
     resolution:
-      integrity: sha512-ErpDkm2wqxXMuzp5wN9Vt7tEh9eRu+7ouvq7D7+N8mTUlATyr74iEJEcpklz8RWVcOlWTh+b+Yx5cVYQut5giQ==
+      integrity: sha512-NQa3LvhyMrSV5K3eKKl7K923DGxtRJsgAT6XK6pBmJ+AiYktMZZN6Rm1YiSfy7Hyx1INUM4qF+qI/zH4OYu9gA==
   /@mrmlnc/readdir-enhanced/2.2.1:
     dependencies:
       call-me-maybe: 1.0.1
@@ -8936,7 +8936,7 @@ packages:
 specifiers:
   '@babel/core': ^7.4.4
   '@eds-ui/core-react': ^0.0.1
-  '@equinor-internal/equinor-logo': ^1.0.5
+  '@equinor-internal/equinor-font': ^1.0.0
   '@storybook/react': ^5.1.1
   babel-loader: ^8.0.6
   babel-runtime: ^6.26.0


### PR DESCRIPTION
- The Equinor font is now installed instead of the logo 🙄 
- An .npmrc file is added to apps/storybook-react – so that it’s possible to install dependencies in the storybook without being logged into https://npm.equinor.com as long as you have an environment variable called EQUINOR_INTERNAL_NPM_TOKEN – both by running `pnpm m i` in the root and also by changing the working directory to apps/storybook-react and running `pnpm i` .