### PR TITLE
Wide Search Setup

### DIFF
--- a/apps/storefront/gatsby-config.js
+++ b/apps/storefront/gatsby-config.js
@@ -110,6 +110,24 @@ module.exports = {
         siteUrl: 'https://eds.equinor.com/',
       },
     },
+    {
+      resolve: `@gatsby-contrib/gatsby-plugin-elasticlunr-search`,
+      options: {
+        // Fields to index
+        fields: [`title`],
+        resolvers: {
+          // For any node of type MarkdownRemark, list how to resolve the fields` values
+          Mdx: {
+            // content: (node) => node.rawBody,
+            currentPage: (node) => node.fields.currentPage,
+            tabs: (node) => node.frontmatter.tabs,
+            slug: (node) => node.fields.slug,
+            title: (node) => node.frontmatter.title,
+            searchTitle: (node) => node.frontmatter.searchTitle,
+          },
+        },
+      },
+    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',

--- a/apps/storefront/package-lock.json
+++ b/apps/storefront/package-lock.json
@@ -919,6 +919,14 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
       "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
     },
+    "@gatsby-contrib/gatsby-plugin-elasticlunr-search": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@gatsby-contrib/gatsby-plugin-elasticlunr-search/-/gatsby-plugin-elasticlunr-search-2.3.0.tgz",
+      "integrity": "sha512-ZClnKcMFzCRJMQhA1pq8OmRJtkUXNqYlzVIxhJpmk3MwskEU2C7Tl0nzdv++5GNbdG3ud9RdL7vLbDeg3sfP0Q==",
+      "requires": {
+        "elasticlunr": "^0.9.5"
+      }
+    },
     "@gatsbyjs/relay-compiler": {
       "version": "2.0.0-printer-fix.2",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/relay-compiler/-/relay-compiler-2.0.0-printer-fix.2.tgz",
@@ -4812,6 +4820,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elasticlunr": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
+      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU="
     },
     "electron-to-chromium": {
       "version": "1.3.120",

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "author": "",
   "dependencies": {
+    "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^2.3.0",
     "@mdx-js/mdx": "^0.20.3",
     "@mdx-js/tag": "^0.20.3",
     "@reach/router": "^1.2.1",

--- a/apps/storefront/src/components/Search/Search.css
+++ b/apps/storefront/src/components/Search/Search.css
@@ -1,0 +1,46 @@
+.SearchWrapper {
+  width: 100%;
+}
+
+.SearchInput {
+  width: 90%;
+  margin-left: 5%;
+  margin-top: 15px;
+  padding-left: 5px;
+  height: 30px;
+  font-size: 1rem;
+}
+
+.SearchWrapper ul {
+  list-style: none;
+  padding: 5px 5px 5px 5px;
+  margin-top: -1px;
+  margin-left: 5%;
+  margin-right: 5%;
+  background-color: whitesmoke;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--borderColor);
+}
+
+.SearchWrapper ul li {
+  padding-bottom: 5px;
+  padding-top: 10px;
+  border-bottom: 1px solid var(--borderColor);
+}
+
+.SearchWrapper ul li:hover {
+  color: black;
+}
+
+.SearchWrapper ul li:first-child {
+  padding-top: 5px;
+}
+
+.SearchWrapper ul li:last-child {
+  border-bottom: none;
+}
+
+.SearchWrapper ul li a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/apps/storefront/src/components/Search/Search.jsx
+++ b/apps/storefront/src/components/Search/Search.jsx
@@ -1,0 +1,64 @@
+import React, { Component } from 'react'
+import { Index } from 'elasticlunr'
+import { Link } from 'gatsby'
+import './search.css'
+
+// Search component
+export default class Search extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      query: ``,
+      results: [],
+    }
+  }
+
+  render() {
+    return (
+      <div className="SearchWrapper">
+        <input
+          className="SearchInput"
+          placeholder="Søk"
+          type="text"
+          value={this.state.query}
+          onChange={this.search}
+        />
+        {this.state.results.length > 0 ? (
+          <ul>
+            {this.state.results.map((page) => (
+              <li key={page.id}>
+                <Link
+                  to={
+                    '/' +
+                    (!page.tabs
+                      ? page.slug.substr(
+                          0,
+                          page.slug.lastIndexOf(page.currentPage),
+                        )
+                      : page.slug)
+                  }
+                >
+                  {page.searchTitle || page.title}
+                  {page.tabs ? ': ' + page.currentPage : null}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    )
+  }
+  getOrCreateIndex = () =>
+    this.index ? this.index : Index.load(this.props.searchIndex)
+
+  search = (evt) => {
+    const query = evt.target.value
+    this.index = this.getOrCreateIndex()
+    this.setState({
+      query,
+      results: this.index
+        .search(query, {})
+        .map(({ ref }) => this.index.documentStore.getDoc(ref)),
+    })
+  }
+}

--- a/apps/storefront/src/components/Search/package.json
+++ b/apps/storefront/src/components/Search/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "Search",
+  "main": "search"
+}

--- a/apps/storefront/src/components/Sidebar/Sidebar.jsx
+++ b/apps/storefront/src/components/Sidebar/Sidebar.jsx
@@ -1,13 +1,17 @@
-import { Link, graphql, useStaticQuery } from 'gatsby'
+import { Link, graphql, useStaticQuery, StaticQuery } from 'gatsby'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import classNames from 'classnames'
 import { kebabify } from '../../utils'
 import './Sidebar.css'
+import Search from '../Search/Search'
 
 const Sidebar = ({ location }) => {
   const data = useStaticQuery(graphql`
     query SidebarQuery {
+      siteSearchIndex {
+        index
+      }
       allNavigationYaml {
         edges {
           node {
@@ -43,6 +47,11 @@ const Sidebar = ({ location }) => {
     <nav className="Sidebar">
       <label className="Sidebar-veil" htmlFor="MenuToggler" />
       <div className="Sidebar-content">
+        <ul className="Sidebar-menu">
+          <li>
+            <Search searchIndex={data.siteSearchIndex.index} />
+          </li>
+        </ul>
         <ul className="Sidebar-menu">
           {data.allNavigationYaml.edges.map((item, index) => (
             <li

--- a/apps/storefront/src/content/getting-started/about/about.mdx
+++ b/apps/storefront/src/content/getting-started/about/about.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 mode: publish
+searchTitle: About
 ---
 
 


### PR DESCRIPTION
**UPDATE**
This has been merged into a branch in the design-system instead of a fork, as i will loose github access to Equinor after this day because of end of contract.

Simple search in Gatsby implemented.

If the search result is part of a tab inside a page, this will be displayed in the search result.

**TEST**
To test the application you have to build it. `npm run build`

**NOTE**

The search is currently indexing on the `.mdx files` "title". This can be edited in the `gatsby-config.js`.
The problem with this is that several pages might have the same `title`. For instance `getting-started.mdx` as well as `about.mdx` has the title Introduction. 

I therefore suggest that the titles of the `.mdx` files has to be more accurate. The *about* page should for instance have the title *about*, not introduction, to make search more logical 

I think this is a better solution then "hacking" the indexing and search functionality.

It works great on components, 