### PR TITLE
Support multiple .add() calls for Icon component library

### DIFF
--- a/libraries/core-react/src/Icon/library.js
+++ b/libraries/core-react/src/Icon/library.js
@@ -1,7 +1,10 @@
 let _icons = {}
 let count = 0
 export const add = (icons) => {
-  _icons = icons
+  _icons = {
+    ..._icons,
+    ...icons,
+  }
 }
 
 export const get = (name) => {


### PR DESCRIPTION
* Added support for calling `add` on Icon library multiple times without loosing previously added icons.

Beneficial when you want to have chunks or pages which load conditionally with icons.
Ran into a problem using storybook where loading icons for `Top Bar` story, broke `Icon` story.
