### PR TITLE
Fixed Storefront image component and encoded urls

### DIFF
--- a/apps/storefront/src/components/image.jsx
+++ b/apps/storefront/src/components/image.jsx
@@ -18,7 +18,7 @@ const ImageBase = styled.img`
   background-color: #2c2c2c;
 `
 
-const Image = ({ url, ...other }) => {
+const Image = ({ url = '', ...other }) => {
   // StaticQuery does not support grapql queries so we have to for all videos and then find it....
   const data = useStaticQuery(graphql`
     {
@@ -36,8 +36,9 @@ const Image = ({ url, ...other }) => {
   let imageUrl = url
 
   if (url.startsWith('images') && data.allFile.edges.length > 0) {
+    const src = decodeURI(url).toLowerCase()
     const image = data.allFile.edges.find(
-      ({ node }) => node.relativePath.toLowerCase() === url.toLowerCase(),
+      ({ node }) => node.relativePath.toLowerCase() === src,
     )
     imageUrl = image ? image.node.publicURL : undefined
   }


### PR DESCRIPTION
A url with cyrilic characters was passed to the image component making the gatsby grapql lookup fail. 

Added uri decoding of passed url to `Image` component in Storefront