### PR TITLE
Update templates, add bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,23 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea
 title: ''
 labels: 'feature request'
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
+
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
+
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/react-component-issue.md
+++ b/.github/ISSUE_TEMPLATE/react-component-issue.md
@@ -4,7 +4,6 @@ about: Use this template to create issues for the React component library
 title: Create [name] component
 labels: react
 assignees: ''
-
 ---
 
 **Description**
@@ -28,6 +27,6 @@ See [COMPONENT_GUIDELINES.md](https://github.com/equinor/design-system/blob/deve
 - [ ] Write tests
 - [ ] Create set of tokens (from base tokens)
 - [ ] Create react component
-- [ ] Accessibility 
+- [ ] Accessibility
 
 _Optional footer which might have a pointer to another issue  (see #000)_

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,0 +1,32 @@
+---
+name: Bug 🐛
+about: Report a bug
+title: ''
+labels: 'bug'
+assignees: ''
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**Steps to reproduce the bug**
+
+1.
+2.
+3.
+4.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Specifications**
+
+- Version: 
+- Browser: 
+- OS: 
+
+**Additional context**
+
+Add any other context or screenshots about the bug.


### PR DESCRIPTION
The Github Slack integration does not allow multiple filters [at this point](https://github.com/integrations/slack/issues/913), so we can’t subscribe to both `feature request` and `bug` labels. We still need a bug template though, so people won’t have to manually remove the `feature request` label and add the `bug` label to their issues. In Slack we’ll now get notified for _all_ issues which isn’t ideal, alternatively we’ll have to use something else.