### PR TITLE
Release eds-icons v0.3.0

### DIFF
--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2020-06-09
+
+### Added
+
+- New icon for `cable` under **Technical**
+
+### Fixed
+
+- Fixed missing circle on `info_circle` icon ([#349](https://github.com/equinor/design-system/issues/349))
+
 ## [0.2.0] - 2020-05-29
 
 ### Added

--- a/libraries/icons/package.json
+++ b/libraries/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Icons from the Equinor Design System",
   "type": "module",
   "main": "dist/icons.esm.js",


### PR DESCRIPTION
## [0.3.0] - 2020-06-09

### Added

- New icon for `cable` under **Technical**

### Fixed

- Fixed missing circle on `info_circle` icon ([#349](https://github.com/equinor/design-system/issues/349))
