### PR TITLE
Popover without close button

### DIFF
--- a/apps/storybook-react/stories/Popover.stories.jsx
+++ b/apps/storybook-react/stories/Popover.stories.jsx
@@ -371,6 +371,59 @@ export function ActivationTypes() {
   )
 }
 
+export function CustomPopover() {
+  const [active, setActive] = React.useState(null)
+
+  const handleClick = (event) => {
+    setActive(event.currentTarget.id)
+  }
+
+  const handleClose = () => {
+    setActive(null)
+  }
+
+  return (
+    <Body>
+      <TextWrapper>
+        <Typography variant="h3">Custom popover</Typography>
+        <Typography variant="body_long">
+          Popover could be used without the close button even though it's not a
+          part of the EDS design. Use the prop disableCloseButton if this is the
+          case for you. You will still be able to dismiss the popover by
+          pressing the ESC key, click outside the popover, or open another
+          popover.
+        </Typography>
+      </TextWrapper>
+      <Wrapper>
+        <Popover onClose={handleClose} open={active === '1'} disableCloseButton>
+          <PopoverAnchor>
+            <Button id="1" onClick={handleClick}>
+              Click me
+            </Button>
+          </PopoverAnchor>
+          <PopoverContent>
+            <Typography variant="body_short">
+              Popover without close button
+            </Typography>
+          </PopoverContent>
+        </Popover>
+        <Popover onClose={handleClose} open={active === '2'} disableCloseButton>
+          <PopoverAnchor>
+            <Button id="2" onClick={handleClick}>
+              Click me too
+            </Button>
+          </PopoverAnchor>
+          <PopoverContent>
+            <Typography variant="body_short">
+              Popover without close button
+            </Typography>
+          </PopoverContent>
+        </Popover>
+      </Wrapper>
+    </Body>
+  )
+}
+
 const ANCHOR_CHOICES = {
   button: <Button variant="ghost">Button</Button>,
   avatar: <Avatar src={catImg} size={48} alt="avatar" />,

--- a/libraries/core-react/src/Popover/Popover.jsx
+++ b/libraries/core-react/src/Popover/Popover.jsx
@@ -28,7 +28,6 @@ export const Popover = forwardRef(function Popover(
   const anchorRef = useRef(null)
 
   let anchorElement
-  let activateCloseButton = false
   const childArray = []
   if (Array.isArray(children)) {
     for (let i = 0; i < children.length; i += 1) {
@@ -41,13 +40,6 @@ export const Popover = forwardRef(function Popover(
         children[i].type.displayName === 'eds-popover-anchor'
       ) {
         anchorElement = children[i]
-      } else if (
-        children[i].type &&
-        children[i].type.displayName === 'eds-popover-title'
-      ) {
-        // Find title to control close button (needed hack to get correct tab index for buttons)
-        childArray.push(children[i])
-        activateCloseButton = true
       } else {
         // Add the remaining children to a new array to display inside <PopoverItem/>
         childArray.push(children[i])
@@ -71,11 +63,7 @@ export const Popover = forwardRef(function Popover(
       </Anchor>
 
       {open && (
-        <PopoverItem
-          {...props}
-          anchorRef={anchorRef}
-          closeButton={activateCloseButton}
-        >
+        <PopoverItem {...props} anchorRef={anchorRef}>
           {childArray}
         </PopoverItem>
       )}
@@ -101,6 +89,8 @@ Popover.propTypes = {
     'left',
     'leftBottom',
   ]),
+  // For the user to control the close button themselves
+  disableCloseButton: PropTypes.bool,
   // On Close function:
   onClose: PropTypes.func,
   // Open activates <PopoverItem/>
@@ -115,4 +105,5 @@ Popover.defaultProps = {
   placement: 'bottom',
   onClose: () => {},
   className: '',
+  disableCloseButton: false,
 }

--- a/libraries/core-react/src/Popover/PopoverItem.jsx
+++ b/libraries/core-react/src/Popover/PopoverItem.jsx
@@ -63,7 +63,15 @@ const StyledCloseButton = styled((props) => <Button {...props} />)`
 `
 
 export const PopoverItem = forwardRef(function EdsPopoverItem(
-  { children, onClose, anchorRef, placement, className, closeButton, ...rest },
+  {
+    children,
+    onClose,
+    anchorRef,
+    placement,
+    className,
+    disableCloseButton,
+    ...rest
+  },
   ref,
 ) {
   const wrapperProps = {
@@ -120,7 +128,7 @@ export const PopoverItem = forwardRef(function EdsPopoverItem(
           <path d="M0.504838 4.86885C-0.168399 4.48524 -0.168399 3.51476 0.504838 3.13115L6 8.59227e-08L6 8L0.504838 4.86885Z" />
         </PopoverArrow>
         {children}
-        {closeButton && (
+        {!disableCloseButton && (
           // Close button is placed last in the DOM order due to tab index rules.
           // This button should always be the last iterable action element in the popover
           <StyledCloseButton onClick={onClose} variant="ghost_icon">
@@ -150,7 +158,8 @@ PopoverItem.propTypes = {
     'left',
     'leftBottom',
   ]),
-  closeButton: PropTypes.bool,
+  // For the user to control the close button themselves
+  disableCloseButton: PropTypes.bool,
   // On Close function:
   onClose: PropTypes.func,
   // Reference to anchor / trigger element
@@ -166,5 +175,5 @@ PopoverItem.defaultProps = {
   onClose: () => {},
   children: undefined,
   className: '',
-  closeButton: false,
+  disableCloseButton: false,
 }


### PR DESCRIPTION
Not sure if bugfix or feature request as popover without close button is not part of the EDS design, but I can see it's valuable for the users to be able to control this button themselves. 

Resolves issue #366 