### PR TITLE
Grid gap correction

### DIFF
--- a/libraries/core-react/src/Button/Button.jsx
+++ b/libraries/core-react/src/Button/Button.jsx
@@ -87,7 +87,7 @@ const ButtonBase = styled.button`
   position: relative;
   cursor: pointer;
   display: grid;
-  grid-gap: 12px;
+  grid-gap: 8px;
   grid-auto-flow: column;
   align-items: center;
   &::before {


### PR DESCRIPTION
Had a typo in my previous branch.

`12px` corrected to `8px` grid gap (gap between icons and text inside `Button`)