### PR TITLE
Bump storefront redesign version

### DIFF
--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equinor/eds-storefront",
   "description": "The storefront for the Equinor Design System",
-  "version": "0.0.1",
+  "version": "1.0.0-beta",
   "engines": {
     "pnpm": ">=4",
     "node": ">=10.0.0"


### PR DESCRIPTION
Bumping version number to `1.0.0-beta` to have the [badge](https://github.com/equinor/design-system/issues/395) show correct version number.