### PR TITLE
Set eslint error level to warn for stories

### DIFF
--- a/apps/storybook-react/.eslintrc.yaml
+++ b/apps/storybook-react/.eslintrc.yaml
@@ -1,0 +1,5 @@
+extends: ../../.eslintrc.yaml
+rules:
+  import/no-default-export:
+    - off
+

--- a/apps/storybook-react/.eslintrc.yaml
+++ b/apps/storybook-react/.eslintrc.yaml
@@ -1,5 +1,18 @@
-extends: ../../.eslintrc.yaml
+# no need to extend when running eslint from the root
 rules:
+  # storybook expects both default and named exports in the stories
   import/no-default-export:
     - off
+  # the following rules have a warn level of error in the main config,
+  # and should be set back to error once the problems have been solved
+  no-unused-vars:
+    - warn
+  react/no-unescaped-entities:
+    - warn
+  react/jsx-boolean-value:
+    - warn
+  import/newline-after-import:
+    - warn
+  prettier/prettier:
+    - warn
 

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,9 @@ name: eds
 engines:
   pnpm: '>=4'
 scripts:
-  lint: 'eslint . --ext jsx --ext js'
+  lint: 'eslint --ext jsx --ext js'
+  lint:all: 'pnpm run lint .'
+  lint:stories: 'pnpm run lint ./apps/storybook-react/stories'
   init: pnpm multi install --force && pnpm run build
   build: pnpm --filter @equinor/eds-core-react run build
   'bump:core-react': >-

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ engines:
 scripts:
   lint: 'eslint --ext jsx --ext js'
   lint:all: 'pnpm run lint .'
-  lint:stories: 'pnpm run lint ./apps/storybook-react/stories'
+  lint:storybook: 'pnpm run lint ./apps/storybook-react/stories'
   init: pnpm multi install --force && pnpm run build
   build: pnpm --filter @equinor/eds-core-react run build
   'bump:core-react': >-


### PR DESCRIPTION
- Sets eslint error level temporarily to warn
- Disables the no-default rule for the stories (from 101 to 69 ~errors~ warnings)
- Adds eslint shortcuts to root package.yaml
- `pnpm run lint` only includes the file suffixes (js and jsx) and now expects a path

_NB! The node_modules in the root must be installed._

**Lint some folder one-off**

```sh
pnpm run lint ./libraries/some-sub-folder
```

**Lint all the things** 🤘 

```sh
pnpm run lint:all
```

**Lint the stories**

```sh
pnpm run lint:storybook
```

related to #403 