### PR TITLE
Bugfix - Left aligned table header text

### DIFF
--- a/libraries/core-react/src/Table/Head.jsx
+++ b/libraries/core-react/src/Table/Head.jsx
@@ -2,7 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-const TableBase = styled.thead``
+const TableBase = styled.thead`
+  text-align: left;
+`
 
 export const Head = (props) => {
   const { children } = props


### PR DESCRIPTION
Table header text changed from center aligned to left aligned

**Edit:** resolves #407 