### PR TITLE
Don’t override table styles

### DIFF
--- a/apps/storefront/pnpm-lock.yaml
+++ b/apps/storefront/pnpm-lock.yaml
@@ -16065,7 +16065,7 @@ packages:
 specifiers:
   '@equinor/eds-core-react': 'workspace:*'
   '@equinor/eds-icons': 'workspace:*'
-  '@equinor/eds-tokens': 'workspace:^0.2.0'
+  '@equinor/eds-tokens': 'workspace:*'
   '@mdx-js/mdx': ^1.6.5
   '@mdx-js/react': ^1.6.5
   '@mdx-js/tag': ^0.20.3

--- a/apps/storefront/src/components/ComponentStatus/ComponentStatus.jsx
+++ b/apps/storefront/src/components/ComponentStatus/ComponentStatus.jsx
@@ -41,12 +41,7 @@ const ComponentStatus = () => {
       <Head>
         <Row>
           {headers.map((text) => (
-            <Cell
-              as="th"
-              style={{ textAlign: 'left' }}
-              key={camelify(text)}
-              scope="col"
-            >
+            <Cell as="th" key={camelify(text)} scope="col">
               {text}
             </Cell>
           ))}
@@ -55,16 +50,7 @@ const ComponentStatus = () => {
       <Body>
         {components.map((component, index) => (
           <Row key={component.component + index}>
-            <Cell
-              as="th"
-              key={component.component + index}
-              scope="row"
-              style={{
-                textAlign: 'left',
-                backgroundColor: 'white',
-                borderBottomWidth: '1px',
-              }}
-            >
+            <Cell as="th" key={component.component + index} scope="row">
               <Link
                 to={`/components/${kebabify(component.component)}`}
                 style={{ color: 'var(--moss-green)', fontSize: '0.875em' }}


### PR DESCRIPTION
Removes style overrides of table component as this is now fixed in #454 