### PR TITLE
Update Typography component

### DIFF
--- a/apps/storybook-react/stories/Typography.stories.jsx
+++ b/apps/storybook-react/stories/Typography.stories.jsx
@@ -75,11 +75,21 @@ export const custom = () => (
     <Typography group="table" variant="cell_text">
       Table / Cell / Text
     </Typography>
+    <Typography group="table" variant="cell_text" fontWeight="medium">
+      Table / Cell / Text / Medium
+    </Typography>
     <Typography group="table" variant="cell_text" bold>
       Table / Cell / Text / Bold
     </Typography>
     <Typography group="table" variant="cell_text" link>
-      Table / Cell / Text / Bold
+      Table / Cell / Text / Bold / Link
+    </Typography>
+
+    <Typography variant="h3" fontWeight="bold">
+      Heading 3 Bold
+    </Typography>
+    <Typography variant="ingress" fontWeight="bold">
+      Ingress Bold
     </Typography>
   </Wrapper>
 )

--- a/apps/storybook-react/stories/Typography.stories.jsx
+++ b/apps/storybook-react/stories/Typography.stories.jsx
@@ -102,5 +102,17 @@ export const custom = () => (
     <Typography variant="ingress" fontWeight="bold">
       Ingress Bold
     </Typography>
+    <Typography
+      token={{
+        color: 'purple',
+        fontFamily: 'Arial',
+        fontSize: '1.875rem',
+        fontWeight: 300,
+        lineHeight: '1.714em',
+        textTransform: 'uppercase',
+      }}
+    >
+      Custom token
+    </Typography>
   </Wrapper>
 )

--- a/apps/storybook-react/stories/Typography.stories.jsx
+++ b/apps/storybook-react/stories/Typography.stories.jsx
@@ -64,6 +64,17 @@ export const paragraphs = () => (
   </Wrapper>
 )
 
+export const colors = () => (
+  <Wrapper>
+    <Typography color="primary"> Primary</Typography>
+    <Typography color="secondary">Secondary</Typography>
+    <Typography color="danger">Danger</Typography>
+    <Typography color="warning">Warning</Typography>
+    <Typography color="success">Success</Typography>
+    <Typography color="disabled">Disabled</Typography>
+  </Wrapper>
+)
+
 export const custom = () => (
   <Wrapper>
     <Typography group="navigation" variant="label">

--- a/apps/storybook-react/stories/Typography.stories.jsx
+++ b/apps/storybook-react/stories/Typography.stories.jsx
@@ -86,7 +86,11 @@ export const custom = () => (
     <Typography group="table" variant="cell_text">
       Table / Cell / Text
     </Typography>
-    <Typography group="table" variant="cell_text" fontWeight="medium">
+    <Typography
+      group="table"
+      variant="cell_text"
+      token={{ fontWeight: 'medium' }}
+    >
       Table / Cell / Text / Medium
     </Typography>
     <Typography group="table" variant="cell_text" bold>
@@ -96,10 +100,10 @@ export const custom = () => (
       Table / Cell / Text / Bold / Link
     </Typography>
 
-    <Typography variant="h3" fontWeight="bold">
+    <Typography variant="h3" token={{ fontWeight: 700 }}>
       Heading 3 Bold
     </Typography>
-    <Typography variant="ingress" fontWeight="bold">
+    <Typography variant="ingress" token={{ fontWeight: 'bold' }}>
       Ingress Bold
     </Typography>
     <Typography

--- a/apps/storybook-react/stories/Typography.stories.jsx
+++ b/apps/storybook-react/stories/Typography.stories.jsx
@@ -5,6 +5,9 @@ import './../style.css'
 
 const Wrapper = styled.div`
   margin: 32px;
+`
+
+const Grid = styled(Wrapper)`
   display: grid;
   grid-gap: 32px;
 `
@@ -15,7 +18,7 @@ export default {
 }
 
 export const headings = () => (
-  <Wrapper>
+  <Grid>
     <Typography variant="h1" bold>
       Heading 1 bold
     </Typography>
@@ -25,11 +28,11 @@ export const headings = () => (
     <Typography variant="h4">Heading 4</Typography>
     <Typography variant="h5">Heading 5</Typography>
     <Typography variant="h6">Heading 6</Typography>
-  </Wrapper>
+  </Grid>
 )
 
 export const paragraphs = () => (
-  <Wrapper>
+  <Grid>
     <Typography variant="body_short" link>
       Body short link
     </Typography>
@@ -61,22 +64,22 @@ export const paragraphs = () => (
     <Typography variant="ingress">Ingress</Typography>
     <Typography variant="caption">Caption</Typography>
     <Typography variant="meta">Meta</Typography>
-  </Wrapper>
+  </Grid>
 )
 
 export const colors = () => (
-  <Wrapper>
+  <Grid>
     <Typography color="primary"> Primary</Typography>
     <Typography color="secondary">Secondary</Typography>
     <Typography color="danger">Danger</Typography>
     <Typography color="warning">Warning</Typography>
     <Typography color="success">Success</Typography>
     <Typography color="disabled">Disabled</Typography>
-  </Wrapper>
+  </Grid>
 )
 
 export const custom = () => (
-  <Wrapper>
+  <Grid>
     <Typography group="navigation" variant="label">
       Navigation / Label
     </Typography>
@@ -117,6 +120,22 @@ export const custom = () => (
       }}
     >
       Custom token
+    </Typography>
+  </Grid>
+)
+
+export const Lines = () => (
+  <Wrapper>
+    <Typography variant="body_long" lines={2}>
+      Cupcake ipsum dolor sit amet caramels powder. Chocolate powder donut
+      bonbon candy canes brownie donut wafer. Cake topping oat cake cheesecake.
+      Candy canes tiramisu apple pie cookie. Pastry marshmallow candy canes.
+      Cookie jelly-o fruitcake caramels sweet. Brownie pastry sweet roll.
+      Caramels tiramisu cotton candy carrot cake jujubes cheesecake bear claw.
+      Candy caramels dessert caramels. Lollipop marshmallow wafer marzipan.
+      Sesame snaps wafer apple pie sweet roll chocolate bar fruitcake. Bear claw
+      lollipop cake. Jelly-o bonbon marshmallow powder carrot cake icing carrot
+      cake. Cheesecake brownie jelly beans soufflé icing.
     </Typography>
   </Wrapper>
 )

--- a/apps/storybook-react/stories/Typography.stories.jsx
+++ b/apps/storybook-react/stories/Typography.stories.jsx
@@ -63,3 +63,23 @@ export const paragraphs = () => (
     <Typography variant="meta">Meta</Typography>
   </Wrapper>
 )
+
+export const custom = () => (
+  <Wrapper>
+    <Typography group="navigation" variant="label">
+      Navigation / Label
+    </Typography>
+    <Typography group="navigation" variant="menu_title">
+      Navigation / Menu / Title
+    </Typography>
+    <Typography group="table" variant="cell_text">
+      Table / Cell / Text
+    </Typography>
+    <Typography group="table" variant="cell_text" bold>
+      Table / Cell / Text / Bold
+    </Typography>
+    <Typography group="table" variant="cell_text" link>
+      Table / Cell / Text / Bold
+    </Typography>
+  </Wrapper>
+)

--- a/libraries/core-react/src/Typography/README.md
+++ b/libraries/core-react/src/Typography/README.md
@@ -24,7 +24,7 @@ Use `group` along with `variant` to render any typography style in EDS.
 
 Use the `as` prop to change the underlying html element.
 ```jsx
-<Typography variant="h2" as="a">H2 link</Typography>
+<Typography variant="h4" as="h3">h3 styled as h4</Typography>
 <ul>
   <Typography group="navigation" variant="breadcrumb" as="li">Breadcrumb</Typography>
 </ul>

--- a/libraries/core-react/src/Typography/README.md
+++ b/libraries/core-react/src/Typography/README.md
@@ -4,53 +4,35 @@ Typography component used to help render typography in EDS
 
 ## Usage
 
-### Quick
+### Quick & easy
 
-Simple access to heading and paragraph styles
+Simple access to `headings` and `paragraph` styles with colors
 ```jsx
-
-<Typography variant="h1">Text</Typography>
-<Typography variant="body_short">Text</Typography>
-<Typography variant="ingress">Text</Typography>
-<Typography variant="caption">Text</Typography>
+<Typography variant="h1" color="primary" bold>Text</Typography>
+<Typography variant="body_short" link>Text</Typography>
 ```
 ### Advanced
 
 #### Group
-Props `group` along with `variant` can be used to render any typography style.
+Use `group` along with `variant` to render any typography style in EDS.
 ```jsx
 <Typography group="ui" variant="chart">Text</Typography>
 <Typography group="table" variant="cell_text">Text</Typography>
-<Typography variant="ingress">Text</Typography>
-<Typography variant="caption">Text</Typography>
 ```
 
 #### Semantic html
 
-Use the `as` prop to change the underlying html element used to render the text
+Use the `as` prop to change the underlying html element.
 ```jsx
 <Typography variant="h2" as="a">H2 link</Typography>
 <ul>
-<Typography group="navigation" variant="breadcrumb" as="li">Breadcrumb</Typography>
+  <Typography group="navigation" variant="breadcrumb" as="li">Breadcrumb</Typography>
 </ul>
-```
-
-#### Colors
-
-Colors can be set by using the `color` prop
-
-```jsx
-<Typography color="primary"> Primary</Typography>
-<Typography color="secondary">Secondary</Typography>
-<Typography color="danger">Danger</Typography>
-<Typography color="warning">Warning</Typography>
-<Typography color="success">Success</Typography>
-<Typography color="disabled">Disabled</Typography>
 ```
 
 #### Custom
 
-If for any reason none of the typography styles work, you can set the underlying token used for rendering typography by using the `token` prop
+Use the `token` prop to extend/override the typography token used for rendering text.
 
 ```jsx
     <Typography

--- a/libraries/core-react/src/Typography/README.md
+++ b/libraries/core-react/src/Typography/README.md
@@ -1,0 +1,78 @@
+# Typography
+
+Typography component used to help render typography in EDS
+
+## Usage
+
+### Quick
+
+Simple access to heading and paragraph styles
+```jsx
+
+<Typography variant="h1">Text</Typography>
+<Typography variant="body_short">Text</Typography>
+<Typography variant="ingress">Text</Typography>
+<Typography variant="caption">Text</Typography>
+```
+### Advanced
+
+
+
+#### Font weight
+
+You can easily change the font weight by using the `fontWeight` prop
+```jsx
+<Typography variant="body_short" fontWeight="medium">Paragraph Medium </Typography>
+<Typography variant="ingress" fontWeight="bold">Ingress Bold</Typography>
+```
+
+#### Group
+Props `group` along with `variant` can be used to render any typography style.
+```jsx
+<Typography group="ui" variant="chart">Text</Typography>
+<Typography group="table" variant="cell_text">Text</Typography>
+<Typography variant="ingress">Text</Typography>
+<Typography variant="caption">Text</Typography>
+```
+
+#### Semantic html
+
+Use the `as` prop to change the underlying html element used to render the text
+```jsx
+<Typography variant="h2" as="a">H2 link</Typography>
+<ul>
+<Typography group="navigation" variant="breadcrumb" as="li">Breadcrumb</Typography>
+</ul>
+```
+
+#### Colors
+
+Colors can be set by using the `color` prop
+
+```jsx
+<Typography color="primary"> Primary</Typography>
+<Typography color="secondary">Secondary</Typography>
+<Typography color="danger">Danger</Typography>
+<Typography color="warning">Warning</Typography>
+<Typography color="success">Success</Typography>
+<Typography color="disabled">Disabled</Typography>
+```
+
+#### Custom
+
+If for any reason none of the typography styles work, you can set the underlying token used for rendering typography by using the `token` prop
+
+```jsx
+    <Typography
+      token={{
+        color: 'purple',
+        fontFamily: 'Arial',
+        fontSize: '1.875rem',
+        fontWeight: 300,
+        lineHeight: '1.714em',
+        textTransform: 'uppercase',
+      }}
+    >
+      Custom token
+    </Typography>
+```

--- a/libraries/core-react/src/Typography/README.md
+++ b/libraries/core-react/src/Typography/README.md
@@ -16,16 +16,6 @@ Simple access to heading and paragraph styles
 ```
 ### Advanced
 
-
-
-#### Font weight
-
-You can easily change the font weight by using the `fontWeight` prop
-```jsx
-<Typography variant="body_short" fontWeight="medium">Paragraph Medium </Typography>
-<Typography variant="ingress" fontWeight="bold">Ingress Bold</Typography>
-```
-
 #### Group
 Props `group` along with `variant` can be used to render any typography style.
 ```jsx
@@ -68,7 +58,7 @@ If for any reason none of the typography styles work, you can set the underlying
         color: 'purple',
         fontFamily: 'Arial',
         fontSize: '1.875rem',
-        fontWeight: 300,
+        fontWeight: 900,
         lineHeight: '1.714em',
         textTransform: 'uppercase',
       }}

--- a/libraries/core-react/src/Typography/README.md
+++ b/libraries/core-react/src/Typography/README.md
@@ -13,6 +13,16 @@ Simple access to `headings` and `paragraph` styles with colors
 ```
 ### Advanced
 
+### Lines
+
+Use `lines` to limit how many lines of text are show. Ends text with ellipsis.
+
+```jsx
+<Typography variant="body_long" lines={2}>
+Sweet roll croissant sweet tiramisu ice cream lollipop. Tart bonbon tart marzipan sweet roll cake apple pie gummi bears pie. Carrot cake topping sweet. Apple pie topping candy jujubes muffin apple pie ice cream muffin macaroon. Bonbon liquorice wafer tart jelly sweet lollipop carrot cake. Brownie cotton candy topping. Donut candy canes liquorice icing lemon drops pastry danish. Lemon drops cheesecake cake tootsie roll apple pie candy canes jelly beans candy canes cupcake.
+</Typography>
+```
+
 #### Group
 Use `group` along with `variant` to render any typography style in EDS.
 ```jsx

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -85,7 +85,7 @@ Typography.propTypes = {
   /** @ignore */
   className: PropTypes.string,
   /** @ignore */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /** Specifies which variant to use */
   variant: PropTypes.oneOf(variantNames),
   /** Specifices which typography group to use  */
@@ -106,6 +106,7 @@ Typography.propTypes = {
 
 Typography.defaultProps = {
   variant: 'body_short',
+  children: undefined,
   group: undefined,
   bold: false,
   italic: false,

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -51,6 +51,18 @@ const toVariantName = (variant, bold = false, italic = false, link = false) =>
 const StyledTypography = styled.p`
   ${({ typography, link }) => typographyTemplate(typography, link)}
   ${({ color }) => css({ color: colors[color] })}
+  ${({ lines }) =>
+    //https://caniuse.com/#feat=css-line-clamp
+    lines > 0 &&
+    css`
+      & {
+        display: -webkit-box;
+        -webkit-line-clamp: ${lines};
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    `}
 `
 
 export const Typography = forwardRef(function EdsTypography(
@@ -100,6 +112,8 @@ Typography.propTypes = {
   color: PropTypes.oneOf(colorNames),
   /** Specifies which typography token to use */
   token: PropTypes.object,
+  /** Specifies how many  */
+  lines: PropTypes.number,
 }
 
 Typography.defaultProps = {
@@ -112,6 +126,7 @@ Typography.defaultProps = {
   className: '',
   color: undefined,
   token: undefined,
+  lines: undefined,
 }
 
 Typography.displayName = 'eds-typography'

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -1,25 +1,15 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { tokens } from '@equinor/eds-tokens'
 import { typographyTemplate } from '../_common/templates'
-
-const { heading, paragraph } = tokens.typography
-
-const groupNames = Object.keys(tokens.typography)
-
-// Only used for propTypes as groups have duplicate variants
-const variantNames = Object.keys(
-  Object.entries({ ...tokens.typography }).reduce(
-    (acc, [, val]) => ({ ...acc, ...val }),
-    {},
-  ),
-)
-
-const quickVariants = {
-  ...heading,
-  ...paragraph,
-}
+import {
+  groupNames,
+  variantNames,
+  colorNames,
+  quickVariants,
+  colors,
+  typography,
+} from './Typography.tokens'
 
 const getElementType = (variant, link) => {
   if (link) {
@@ -50,7 +40,7 @@ const findTypography = (variantName, group) => {
     return quickVariants[variantName]
   }
 
-  return tokens.typography[group][variantName]
+  return typography[group][variantName]
 }
 
 const toVariantName = (variant, bold = false, italic = false, link = false) =>
@@ -60,7 +50,7 @@ const toVariantName = (variant, bold = false, italic = false, link = false) =>
 
 const StyledTypography = styled.p`
   ${({ typography, link }) => typographyTemplate(typography, link)}
-  ${({ fontWeight }) => css({ fontWeight })}
+  ${({ fontWeight, color }) => css({ fontWeight, color: colors[color] })}
 `
 
 export const Typography = forwardRef(function EdsTypography(
@@ -108,6 +98,8 @@ Typography.propTypes = {
   link: PropTypes.bool,
   /** Sets font weight */
   fontWeight: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+  /** Specifies which color to use */
+  color: PropTypes.oneOf(colorNames),
 }
 
 Typography.defaultProps = {
@@ -118,6 +110,7 @@ Typography.defaultProps = {
   link: false,
   className: '',
   fontWeight: undefined,
+  color: undefined,
 }
 
 Typography.displayName = 'eds-typography'

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -112,7 +112,7 @@ Typography.propTypes = {
   color: PropTypes.oneOf(colorNames),
   /** Specifies which typography token to use */
   token: PropTypes.object,
-  /** Specifies how many  */
+  /** Specifies how many lines of text are shown */
   lines: PropTypes.number,
 }
 

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -74,9 +74,9 @@ export const Typography = forwardRef(function EdsTypography(
 
   if (typeof typography === 'undefined') {
     throw new Error(
-      `Typography variant not found for variant "${variantName}" ("${variant}") & group "${group}". \n\nPlease use of the following
-      \n variants: \n ${variantNames.toString()}
-      \n groups: \n ${groupNames.toString()}`,
+      `Typography variant not found for variant "${variantName}" ("${variant}") & group "${
+        group || ''
+      }"`,
     )
   }
   return (

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -59,9 +59,8 @@ const toVariantName = (variant, bold = false, italic = false, link = false) =>
   }`
 
 const StyledTypography = styled.p`
-  ${({ typography, link }) => css`
-    ${typographyTemplate(typography, link)}
-  `}
+  ${({ typography, link }) => typographyTemplate(typography, link)}
+  ${({ fontWeight }) => css({ fontWeight })}
 `
 
 export const Typography = forwardRef(function EdsTypography(
@@ -107,6 +106,8 @@ Typography.propTypes = {
   italic: PropTypes.bool,
   /** Specifies if text should be a link */
   link: PropTypes.bool,
+  /** Sets font weight */
+  fontWeight: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
 }
 
 Typography.defaultProps = {
@@ -116,6 +117,7 @@ Typography.defaultProps = {
   italic: false,
   link: false,
   className: '',
+  fontWeight: undefined,
 }
 
 Typography.displayName = 'eds-typography'

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -54,12 +54,12 @@ const StyledTypography = styled.p`
 `
 
 export const Typography = forwardRef(function EdsTypography(
-  { variant, children, bold, italic, link, group, ...other },
+  { variant, children, bold, italic, link, group, token, ...other },
   ref,
 ) {
   const as = getElementType(variant, link)
   const variantName = toVariantName(variant, bold, italic, link)
-  let typography = findTypography(variantName, group)
+  let typography = token ? token : findTypography(variantName, group)
 
   if (typeof typography === 'undefined') {
     throw new Error(
@@ -100,6 +100,8 @@ Typography.propTypes = {
   fontWeight: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
   /** Specifies which color to use */
   color: PropTypes.oneOf(colorNames),
+  /** Specifies which typography token to use */
+  token: PropTypes.object,
 }
 
 Typography.defaultProps = {
@@ -111,6 +113,7 @@ Typography.defaultProps = {
   className: '',
   fontWeight: undefined,
   color: undefined,
+  token: undefined,
 }
 
 Typography.displayName = 'eds-typography'

--- a/libraries/core-react/src/Typography/Typography.jsx
+++ b/libraries/core-react/src/Typography/Typography.jsx
@@ -50,7 +50,7 @@ const toVariantName = (variant, bold = false, italic = false, link = false) =>
 
 const StyledTypography = styled.p`
   ${({ typography, link }) => typographyTemplate(typography, link)}
-  ${({ fontWeight, color }) => css({ fontWeight, color: colors[color] })}
+  ${({ color }) => css({ color: colors[color] })}
 `
 
 export const Typography = forwardRef(function EdsTypography(
@@ -59,7 +59,7 @@ export const Typography = forwardRef(function EdsTypography(
 ) {
   const as = getElementType(variant, link)
   const variantName = toVariantName(variant, bold, italic, link)
-  let typography = token ? token : findTypography(variantName, group)
+  const typography = findTypography(variantName, group)
 
   if (typeof typography === 'undefined') {
     throw new Error(
@@ -71,7 +71,7 @@ export const Typography = forwardRef(function EdsTypography(
   return (
     <StyledTypography
       as={as}
-      typography={typography}
+      typography={{ ...typography, ...token }}
       link={link}
       ref={ref}
       {...other}
@@ -96,8 +96,6 @@ Typography.propTypes = {
   italic: PropTypes.bool,
   /** Specifies if text should be a link */
   link: PropTypes.bool,
-  /** Sets font weight */
-  fontWeight: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
   /** Specifies which color to use */
   color: PropTypes.oneOf(colorNames),
   /** Specifies which typography token to use */
@@ -112,7 +110,6 @@ Typography.defaultProps = {
   italic: false,
   link: false,
   className: '',
-  fontWeight: undefined,
   color: undefined,
   token: undefined,
 }

--- a/libraries/core-react/src/Typography/Typography.test.jsx
+++ b/libraries/core-react/src/Typography/Typography.test.jsx
@@ -1,0 +1,104 @@
+/* eslint-disable no-undef */
+import React from 'react'
+import { render, cleanup, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import 'jest-styled-components'
+import styled from 'styled-components'
+import { Typography } from '.'
+import { tokens } from '@equinor/eds-tokens'
+
+const StyledTypography = styled(Typography)`
+  margin-top: 16px;
+  margin-bottom: 32px;
+`
+const stripSpaces = (t) => t.replace(/\s/g, '')
+
+const expectToMatchTypography = (element, token) => {
+  const {
+    color,
+    fontFamily,
+    fontSize,
+    fontWeight,
+    lineHeight,
+    fontStyle,
+  } = token
+  expect(element).toHaveStyleRule('color', stripSpaces(color))
+  expect(element).toHaveStyleRule('font-family', fontFamily)
+  expect(element).toHaveStyleRule('font-size', fontSize)
+  expect(element).toHaveStyleRule('font-weight', fontWeight.toString())
+  expect(element).toHaveStyleRule('line-height', lineHeight)
+  expect(element).toHaveStyleRule('font-style', fontStyle)
+}
+
+afterEach(cleanup)
+
+describe('Typography', () => {
+  it('has correct styling when variant is provided', () => {
+    render(<Typography variant="body_short">Test</Typography>)
+
+    const typography = screen.getByText('Test')
+    const token = tokens.typography.paragraph.body_short
+
+    expect(typography.nodeName).toBe('P')
+    expectToMatchTypography(typography, token)
+  })
+  it('has correct styling when variant & group is provided', () => {
+    render(
+      <Typography group="navigation" variant="menu_title" as="span">
+        Test
+      </Typography>,
+    )
+
+    const typography = screen.getByText('Test')
+    const token = tokens.typography.navigation.menu_title
+
+    expect(typography.nodeName).toBe('SPAN')
+    expectToMatchTypography(typography, token)
+  })
+  it('has correct styling when variant is provided with bold & italic', () => {
+    render(
+      <Typography variant="body_short" bold italic>
+        Test
+      </Typography>,
+    )
+
+    const typography = screen.getByText('Test')
+    const token = tokens.typography.paragraph.body_short_bold_italic
+
+    expect(typography.nodeName).toBe('P')
+    expectToMatchTypography(typography, token)
+  })
+  it('has correct element type & styling when link is set', () => {
+    render(
+      <Typography variant="body_short" link>
+        Test
+      </Typography>,
+    )
+
+    const typography = screen.getByText('Test')
+    const token = tokens.typography.paragraph.body_short_link
+
+    expect(typography.nodeName).toBe('A')
+    expectToMatchTypography(typography, token)
+  })
+  it('has correct element type when using "as" prop', () => {
+    render(
+      <Typography variant="h2" as="h4">
+        Test
+      </Typography>,
+    )
+
+    const typography = screen.getByText('Test')
+    const token = tokens.typography.heading.h2
+    expect(typography.nodeName).toBe('H4')
+    expectToMatchTypography(typography, token)
+  })
+  it('can extend the css for the component', () => {
+    render(<StyledTypography>Test</StyledTypography>)
+
+    const typography = screen.getByText('Test')
+
+    expect(typography).toHaveStyleRule('margin-top', '16px')
+    expect(typography).toHaveStyleRule('margin-bottom', '32px')
+  })
+})

--- a/libraries/core-react/src/Typography/Typography.test.jsx
+++ b/libraries/core-react/src/Typography/Typography.test.jsx
@@ -6,6 +6,7 @@ import 'jest-styled-components'
 import styled from 'styled-components'
 import { Typography } from '.'
 import { tokens } from '@equinor/eds-tokens'
+import { colors } from './Typography.tokens.js'
 
 const StyledTypography = styled(Typography)`
   margin-top: 16px;
@@ -42,7 +43,20 @@ describe('Typography', () => {
 
     jest.clearAllMocks()
   })
-  it('has correct styling when variant is provided with weight', () => {
+  it('has correct styling when variant is set with primary color', () => {
+    render(
+      <Typography variant="body_short" color="primary">
+        Test
+      </Typography>,
+    )
+
+    const typography = screen.getByText('Test')
+    const token = tokens.typography.paragraph.body_short
+
+    expect(typography.nodeName).toBe('P')
+    expectToMatchTypography(typography, { ...token, color: colors.primary })
+  })
+  it('has correct styling when variant is set with weight', () => {
     render(
       <Typography variant="body_short" fontWeight="medium">
         Test
@@ -55,7 +69,7 @@ describe('Typography', () => {
     expect(typography.nodeName).toBe('P')
     expectToMatchTypography(typography, { ...token, fontWeight: 'medium' })
   })
-  it('has correct styling when variant is provided', () => {
+  it('has correct styling when variant is set', () => {
     render(<Typography variant="body_short">Test</Typography>)
 
     const typography = screen.getByText('Test')
@@ -64,7 +78,7 @@ describe('Typography', () => {
     expect(typography.nodeName).toBe('P')
     expectToMatchTypography(typography, token)
   })
-  it('has correct styling when variant & group is provided', () => {
+  it('has correct styling when variant & group is set', () => {
     render(
       <Typography group="navigation" variant="menu_title" as="span">
         Test
@@ -77,7 +91,7 @@ describe('Typography', () => {
     expect(typography.nodeName).toBe('SPAN')
     expectToMatchTypography(typography, token)
   })
-  it('has correct styling when variant is provided with bold & italic', () => {
+  it('has correct styling when variant is set with bold & italic', () => {
     render(
       <Typography variant="body_short" bold italic>
         Test
@@ -103,7 +117,7 @@ describe('Typography', () => {
     expect(typography.nodeName).toBe('A')
     expectToMatchTypography(typography, token)
   })
-  it('has correct element type when using "as" prop', () => {
+  it('has correct element type when "as" is set', () => {
     render(
       <Typography variant="h2" as="h4">
         Test

--- a/libraries/core-react/src/Typography/Typography.test.jsx
+++ b/libraries/core-react/src/Typography/Typography.test.jsx
@@ -66,9 +66,9 @@ describe('Typography', () => {
     expect(typography.nodeName).toBe('P')
     expectToMatchTypography(typography, { ...token, color: colors.primary })
   })
-  it('has correct styling when variant is set with weight', () => {
+  it('has correct styling when variant is set & tweaked with token', () => {
     render(
-      <Typography variant="body_short" fontWeight="medium">
+      <Typography variant="body_short" token={{ fontWeight: 'medium' }}>
         Test
       </Typography>,
     )

--- a/libraries/core-react/src/Typography/Typography.test.jsx
+++ b/libraries/core-react/src/Typography/Typography.test.jsx
@@ -42,6 +42,19 @@ describe('Typography', () => {
 
     jest.clearAllMocks()
   })
+  it('has correct styling when variant is provided with weight', () => {
+    render(
+      <Typography variant="body_short" fontWeight="medium">
+        Test
+      </Typography>,
+    )
+
+    const typography = screen.getByText('Test')
+    const token = tokens.typography.paragraph.body_short
+
+    expect(typography.nodeName).toBe('P')
+    expectToMatchTypography(typography, { ...token, fontWeight: 'medium' })
+  })
   it('has correct styling when variant is provided', () => {
     render(<Typography variant="body_short">Test</Typography>)
 

--- a/libraries/core-react/src/Typography/Typography.test.jsx
+++ b/libraries/core-react/src/Typography/Typography.test.jsx
@@ -43,6 +43,16 @@ describe('Typography', () => {
 
     jest.clearAllMocks()
   })
+  it('uses provided typography token', () => {
+    const token = tokens.typography.table.cell_header
+
+    render(<Typography token={token}>Test</Typography>)
+
+    const typography = screen.getByText('Test')
+
+    expect(typography.nodeName).toBe('P')
+    expectToMatchTypography(typography, token)
+  })
   it('has correct styling when variant is set with primary color', () => {
     render(
       <Typography variant="body_short" color="primary">

--- a/libraries/core-react/src/Typography/Typography.test.jsx
+++ b/libraries/core-react/src/Typography/Typography.test.jsx
@@ -33,6 +33,15 @@ const expectToMatchTypography = (element, token) => {
 afterEach(cleanup)
 
 describe('Typography', () => {
+  it('throws error when variant is wrong', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => {
+      render(<Typography variant="label">Test</Typography>)
+    }).toThrowError()
+
+    jest.clearAllMocks()
+  })
   it('has correct styling when variant is provided', () => {
     render(<Typography variant="body_short">Test</Typography>)
 

--- a/libraries/core-react/src/Typography/Typography.tokens.js
+++ b/libraries/core-react/src/Typography/Typography.tokens.js
@@ -1,0 +1,50 @@
+import { tokens } from '@equinor/eds-tokens'
+
+const { typography, colors: colorsToken } = tokens
+const { heading, paragraph } = typography
+
+const {
+  interactive: {
+    primary__resting: { hex: primary },
+    secondary__resting: { hex: secondary },
+    danger__resting: { hex: danger },
+    warning__resting: { hex: warning },
+    success__resting: { hex: success },
+    disabled__text: { hex: disabled },
+  },
+} = colorsToken
+
+const colors = {
+  primary,
+  secondary,
+  danger,
+  warning,
+  success,
+  disabled,
+}
+
+const groupNames = Object.keys(tokens.typography)
+
+// Only used for propTypes as groups have duplicate variants
+const variantNames = Object.keys(
+  Object.entries({ ...tokens.typography }).reduce(
+    (acc, [, val]) => ({ ...acc, ...val }),
+    {},
+  ),
+)
+
+const colorNames = Object.keys(colors)
+
+const quickVariants = {
+  ...heading,
+  ...paragraph,
+}
+
+export {
+  typography,
+  colors,
+  quickVariants,
+  colorNames,
+  groupNames,
+  variantNames,
+}

--- a/libraries/core-react/src/Typography/Typography.tokens.js
+++ b/libraries/core-react/src/Typography/Typography.tokens.js
@@ -5,12 +5,12 @@ const { heading, paragraph } = typography
 
 const {
   interactive: {
-    primary__resting: { hex: primary },
-    secondary__resting: { hex: secondary },
-    danger__resting: { hex: danger },
-    warning__resting: { hex: warning },
-    success__resting: { hex: success },
-    disabled__text: { hex: disabled },
+    primary__resting: { rgba: primary },
+    secondary__resting: { rgba: secondary },
+    danger__resting: { rgba: danger },
+    warning__resting: { rgba: warning },
+    success__resting: { rgba: success },
+    disabled__text: { rgba: disabled },
   },
 } = colorsToken
 


### PR DESCRIPTION
resolves #299 

Done some updates on usage with `Typography` component for easier use with other components and standalone.

Started on documentation here, [README](https://github.com/mimarz/design-system/tree/update/typography-component/libraries/core-react/src/Typography)

Other notable changes
* Children is no longer mandatory
* Removed `margin:0` from component, but its still present in `typographyTemplate` so no margins still as of now
* Kept props `bold`, `italic` and `link` for backwards compatibility and typography lookup (Looking at you `body_short_link` 👀)
* Buuuunch of test ✅
* Updated component structure to as is now in EDS (forwardRef, .tokens etc.)