### PR TITLE
Use rem for font-size in storefront component table

### DIFF
--- a/apps/storefront/src/components/ComponentStatus/ComponentStatus.jsx
+++ b/apps/storefront/src/components/ComponentStatus/ComponentStatus.jsx
@@ -53,7 +53,7 @@ const ComponentStatus = () => {
             <Cell as="th" key={component.component + index} scope="row">
               <Link
                 to={`/components/${kebabify(component.component)}`}
-                style={{ color: 'var(--moss-green)', fontSize: '0.875em' }}
+                style={{ color: 'var(--moss-green)', fontSize: '0.875rem' }}
               >
                 {component.component}
               </Link>


### PR DESCRIPTION
Unfortunate typo here that results in table text being 12.25px instead of 14px