### PR TITLE
Trigger Tooltip on disabled elements

### DIFF
--- a/apps/storybook-react/stories/Tooltip.stories.jsx
+++ b/apps/storybook-react/stories/Tooltip.stories.jsx
@@ -28,7 +28,9 @@ const Wrapper = styled.div`
 
 const TextWrapper = styled.div`
   margin-bottom: 32px;
+  width: 800px;
 `
+
 export default {
   title: 'Components|Tooltip',
   component: Tooltip,
@@ -152,16 +154,30 @@ export const WithKnobs = () => {
   )
 }
 
-export function disabledTest() {
+export function WithDisabledElements() {
   return (
     <Body>
+      <TextWrapper>
+        <Typography variant="h3">Tooltip with disabled elements</Typography>
+        <Typography variant="body_long">
+          Firefox, Edge and Chrome supports tooltip on disabled elements.
+        </Typography>
+        <Typography variant="body_long">
+          If you have Safari users, you will need to add inline style to your
+          disabled element, shown in the example below. This will help trigger
+          the mouse events correctly. Unfortunately, this workaround overwrites
+          the &apos;not-allowed&apos; cursor.
+        </Typography>
+      </TextWrapper>
       <Wrapper>
         <Tooltip title="Tooltip" placement="topLeft">
           <Button disabled>Disabled</Button>
         </Tooltip>
 
         <Tooltip title="Tooltip" placement="topLeft">
-          <Button disabled>Disabled</Button>
+          <Button style={{ pointerEvents: 'none' }} disabled>
+            Disabled for Safari Browser
+          </Button>
         </Tooltip>
       </Wrapper>
     </Body>

--- a/apps/storybook-react/stories/Tooltip.stories.jsx
+++ b/apps/storybook-react/stories/Tooltip.stories.jsx
@@ -151,3 +151,19 @@ export const WithKnobs = () => {
     </Body>
   )
 }
+
+export function disabledTest() {
+  return (
+    <Body>
+      <Wrapper>
+        <Tooltip title="Tooltip" placement="topLeft">
+          <Button disabled>Disabled</Button>
+        </Tooltip>
+
+        <Tooltip title="Tooltip" placement="topLeft">
+          <Button disabled>Disabled</Button>
+        </Tooltip>
+      </Wrapper>
+    </Body>
+  )
+}

--- a/libraries/core-react/src/Button/Button.jsx
+++ b/libraries/core-react/src/Button/Button.jsx
@@ -69,7 +69,6 @@ const Base = ({ base, baseDisabled: disabled }) => {
       background: ${disabled.background};
       color: ${disabled.color};
       fill: ${disabled.color};
-
       border-color: ${disabled.border.color};
 
       &:hover {

--- a/libraries/core-react/src/Tabs/Tab.jsx
+++ b/libraries/core-react/src/Tabs/Tab.jsx
@@ -28,7 +28,7 @@ const focusedStyles = css`
   outline-offset: ${outlineOffset};
 `
 
-const StyledTab = styled.button.attrs(({ active }) => ({
+const StyledTab = styled.button.attrs(({ active, disabled }) => ({
   type: 'button',
   role: 'tab',
   'aria-selected': active,

--- a/libraries/core-react/src/Tabs/Tab.jsx
+++ b/libraries/core-react/src/Tabs/Tab.jsx
@@ -28,7 +28,7 @@ const focusedStyles = css`
   outline-offset: ${outlineOffset};
 `
 
-const StyledTab = styled.button.attrs(({ active, disabled }) => ({
+const StyledTab = styled.button.attrs(({ active }) => ({
   type: 'button',
   role: 'tab',
   'aria-selected': active,

--- a/libraries/core-react/src/Tooltip/Tooltip.jsx
+++ b/libraries/core-react/src/Tooltip/Tooltip.jsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
+//import { Button } from '..'
 import { spacingsTemplate, typographyTemplate } from '../_common/templates'
 import { tooltip as tokens } from './Tooltip.tokens'
 
@@ -61,13 +62,16 @@ export const Tooltip = forwardRef(function Tooltip(
   { className, title, children, placement, open, ...rest },
   ref,
 ) {
+  console.log('tooltip', children)
   const [openState, setOpenState] = useState(open)
 
   const handleOpen = () => {
+    console.log('open')
     setOpenState(true)
   }
 
   const handleClose = () => {
+    console.log('close')
     setOpenState(false)
   }
 
@@ -95,7 +99,12 @@ export const Tooltip = forwardRef(function Tooltip(
   return (
     <Wrapper {...props}>
       <Anchor
+        tabIndex={0}
         onMouseOver={handleOpen}
+        onMouseEnter={handleOpen}
+        onPointerEnter={handleOpen}
+        onPointerLeave={handleClose}
+        onMouseOut={handleClose}
         onMouseLeave={handleClose}
         onBlur={handleClose}
         onFocus={handleOpen}

--- a/libraries/core-react/src/Tooltip/Tooltip.jsx
+++ b/libraries/core-react/src/Tooltip/Tooltip.jsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-//import { Button } from '..'
 import { spacingsTemplate, typographyTemplate } from '../_common/templates'
 import { tooltip as tokens } from './Tooltip.tokens'
 
@@ -62,16 +61,13 @@ export const Tooltip = forwardRef(function Tooltip(
   { className, title, children, placement, open, ...rest },
   ref,
 ) {
-  console.log('tooltip', children)
   const [openState, setOpenState] = useState(open)
 
   const handleOpen = () => {
-    console.log('open')
     setOpenState(true)
   }
 
   const handleClose = () => {
-    console.log('close')
     setOpenState(false)
   }
 


### PR DESCRIPTION
Mouse Events on disabled elements are buggy.

[This is a known issue on Safari and Chrome browsers.](https://github.com/facebook/react/issues/19419) Testing in Firefox gives us the desired outcome.

Trying to find a workaround that goes for all browsers...