### PR TITLE
Add Wenche and Frida to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @mimarz @vnys
+* @mimarz @vnys @wenche @pomfrida
 apps/storefront/docs/** @BeckyBrekke


### PR DESCRIPTION
Adding Wenche and Frida to CODEOWNERS means every time we make a pull request we’re all added as reviewers by default for everything but the documentation – which is owned by @BeckyBrekke.