### PR TITLE
Hide drafts tabs in the storefront

### DIFF
--- a/apps/storefront/docs/updates/release-information/known-issues.mdx
+++ b/apps/storefront/docs/updates/release-information/known-issues.mdx
@@ -8,3 +8,5 @@ tabs:
 mode: draft
 route: /updates/release-information/known-issues/
 ---
+
+Here be dragons…

--- a/apps/storefront/src/gatsby-theme-docz/components/MainContainer/index.js
+++ b/apps/storefront/src/gatsby-theme-docz/components/MainContainer/index.js
@@ -132,24 +132,18 @@ export const MainContainer = ({ children, doc, ...rest }) => {
 
   const isDraft = findByRoute(drafts)
 
-  const reduceIndexed = R.addIndex(R.reduce)
+  const mapIndexed = R.addIndex(R.map)
 
   const toLowerRemoveSpaces = R.pipe(R.toLower, R.replace(/\s/g, '-'))
 
   const publishedTabs = (route) => (tabs) =>
     R.pipe(
-      reduceIndexed(
-        (acc, label, i) => [
-          ...acc,
-          {
-            label,
-            route:
-              route.match(/^\/([a-z-]+\/?){2}/)?.[0] +
-              (i === 0 ? '' : toLowerRemoveSpaces(label) + '/'),
-          },
-        ],
-        [],
-      ),
+      mapIndexed((label, i) => ({
+        label,
+        route:
+          route.match(/^\/([a-z-]+\/?){2}/)?.[0] +
+          (i === 0 ? '' : toLowerRemoveSpaces(label) + '/'),
+      })),
       R.filter(
         (tab) => !(process.env.GATSBY_STAGE === 'prod' && isDraft(tab.route)),
       ),


### PR DESCRIPTION
In [production ](https://eds.equinor.com) pages that are in drafts mode are hidden, while they're visible in [development](https://eds-storefront-development.azurewebsites.net). This pr makes sure tabs that link to pages in drafts mode behave in the same way.