### PR TITLE
Support for directly setting icon on Icon component

### DIFF
--- a/apps/storybook-react/stories/Icon.stories.jsx
+++ b/apps/storybook-react/stories/Icon.stories.jsx
@@ -70,6 +70,24 @@ export const IconExamples = () => (
     <Wrapper>
       <Icon name="grid_off" title="Save me!" />
     </Wrapper>
+    <h2>Using data prop with eds-icon</h2>
+    <Wrapper>
+      <Icon data={save} />
+    </Wrapper>
+    <h2>Using data prop with custom icon</h2>
+    <Wrapper>
+      <Icon
+        title="Its a moon"
+        data={{
+          name: 'moon',
+          prefix: 'starwars',
+          height: '24',
+          width: '24',
+          svgPathData:
+            'M19.629,9.655c-0.021-0.589-0.088-1.165-0.21-1.723h-3.907V7.244h1.378V6.555h-2.756V5.866h2.067V5.177h-0.689V4.488h-1.378V3.799h0.689V3.11h-1.378V2.421h0.689V1.731V1.294C12.88,0.697,11.482,0.353,10,0.353c-5.212,0-9.446,4.135-9.629,9.302H19.629z M6.555,2.421c1.522,0,2.756,1.234,2.756,2.756S8.077,7.933,6.555,7.933S3.799,6.699,3.799,5.177S5.033,2.421,6.555,2.421z M12.067,18.958h-0.689v-0.689h2.067v-0.689h0.689V16.89h2.067v-0.689h0.689v-0.689h-1.378v-0.689h-2.067v-0.689h1.378v-0.689h2.756v-0.689h-1.378v-0.689h3.218c0.122-0.557,0.189-1.134,0.21-1.723H0.371c0.183,5.167,4.418,9.302,9.629,9.302c0.711,0,1.401-0.082,2.067-0.227V18.958z',
+        }}
+      />
+    </Wrapper>
     <h2>With knobs</h2>
     <Wrapper>
       <Icon

--- a/libraries/core-react/src/Icon/Icon.jsx
+++ b/libraries/core-react/src/Icon/Icon.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { get } from './library'
 
+const customIcon = (icon) => ({ icon, count: Math.floor(Math.random() * 1000) })
+
 const transform = ({ rotation }) =>
   rotation ? `transform: rotate(${rotation}deg)` : null
 
@@ -16,22 +18,23 @@ const StyledSvg = styled.svg.attrs(({ height, width, fill }) => ({
   ${transform}
 `
 
-const StyledPath = styled.path.attrs(({ icon, size }) => ({
+const StyledPath = styled.path.attrs(({ height, size }) => ({
   size: null,
   fillRule: 'evenodd',
   clipRule: 'evenodd',
-  d: icon.svgPathData,
-  transform: size / icon.height !== 1 ? `scale(${size / icon.height})` : null,
+  transform: size / height !== 1 ? `scale(${size / height})` : null,
 }))``
 
 export const Icon = forwardRef(function EdsIcon(
-  { size, color, name, className, rotation, title, ...rest },
+  { size, color, name, className, rotation, title, data, ...rest },
   ref,
 ) {
-  const { icon, count } = get(name)
+  const { icon, count } = data !== null ? customIcon(data) : get(name)
 
   if (typeof icon === 'undefined') {
-    throw Error(`Icon "${name}" not found. Have you added it using Icon.add()?`)
+    throw Error(
+      `Icon "${name}" not found. Have you added it using Icon.add() or using data props?`,
+    )
   }
 
   let svgProps = {
@@ -45,8 +48,9 @@ export const Icon = forwardRef(function EdsIcon(
     'aria-hidden': true,
   }
 
-  const iconProps = {
-    icon,
+  const pathProps = {
+    d: icon.svgPathData ? icon.svgPathData : icon.d,
+    height: icon.height ? icon.height : size,
     size,
   }
 
@@ -67,7 +71,7 @@ export const Icon = forwardRef(function EdsIcon(
   return (
     <StyledSvg {...svgProps} {...rest} ref={ref}>
       {title && <title id={titleId}>{title}</title>}
-      <StyledPath data-testid="eds-icon-path" {...iconProps} />
+      <StyledPath data-testid="eds-icon-path" {...pathProps} />
     </StyledSvg>
   )
 })
@@ -77,16 +81,18 @@ Icon.displayName = 'eds-icon'
 Icon.propTypes = {
   /** @ignore */
   className: PropTypes.string,
-  // Title for svg if used semantically
+  /** Title for svg if used semantically */
   title: PropTypes.string,
-  // Valid colors
+  /** color */
   color: PropTypes.string,
-  // Vertical spacing
+  /** Size */
   size: PropTypes.oneOf([16, 24, 32, 40, 48]),
-  // Rotation
+  /** Rotation */
   rotation: PropTypes.oneOf([0, 90, 180, 270]),
-  // Name
-  name: PropTypes.string.isRequired,
+  /** Name */
+  name: PropTypes.string,
+  /** Manually specify which icon data to use*/
+  data: PropTypes.object,
 }
 
 Icon.defaultProps = {
@@ -95,4 +101,6 @@ Icon.defaultProps = {
   color: 'currentColor',
   size: 24,
   rotation: null,
+  data: null,
+  name: '',
 }

--- a/libraries/core-react/src/Icon/Icon.test.jsx
+++ b/libraries/core-react/src/Icon/Icon.test.jsx
@@ -20,6 +20,13 @@ afterEach(cleanup)
 describe('Icon', () => {
   it('Has correct svg data', () => {
     const { queryByTestId } = render(<Icon name="save" />)
+    expect(queryByTestId('eds-icon-path')).toHaveAttribute(
+      'd',
+      save.svgPathData,
+    )
+  })
+  it('Has correct svg data when using data property', () => {
+    const { queryByTestId } = render(<Icon data={save} />)
 
     expect(queryByTestId('eds-icon-path')).toHaveAttribute(
       'd',


### PR DESCRIPTION
* Use `data` property to directly set icon data being rendered
* Provided data object must follow [icon object structure](https://github.com/equinor/design-system/tree/develop/libraries/icons#example-of-javascript-object-data)
* Code housekeeping
* Fixed malformed proptypes description (even though we are changing it soon 🤪)

resolves #584
 