### PR TITLE
Release icons@0.4.0

### DIFF
--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2020-09-11
+
+### Added
+
+- New icon as alternative to `filter` (funnel) called `filter_alt`
+
+### Changed
+
+- Tweaked svg data for `info_circle` & `list`
+
 ## [0.3.0] - 2020-06-09
 
 ### Added

--- a/libraries/icons/package.json
+++ b/libraries/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Icons from the Equinor Design System",
   "type": "module",
   "main": "dist/icons.esm.js",


### PR DESCRIPTION
## [0.4.0] - 2020-09-11

### Added

- New icon as alternative to `filter` (funnel) called `filter_alt`
![image](https://user-images.githubusercontent.com/1070981/92913468-10bfd580-f42b-11ea-98a3-8758d3021daf.png)


### Changed

- Tweaked svg data for `info_circle` & `list`
