### PR TITLE
Release eds-core-react@0.6.2

### DIFF
--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.2] - 2020-09-15
+## [0.6.2] - 2020-09-16
 
 ### Fixed 🐛
 
 - Fixed `onClose` handler not being called when `MenuItem` was used inside `MenuSection` ([#546](https://github.com/equinor/design-system/issues/546))
 - Fixed focus showing when clicking on `MenuItem` ([#544](https://github.com/equinor/design-system/issues/544))
+- Fixed an issue where `Divider` did not stretch to full width ([#608](https://github.com/equinor/design-system/issues/608))
 
 ### Changed
 

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -12,12 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `onClose` handler not being called when `MenuItem` was used inside `MenuSection` ([#546](https://github.com/equinor/design-system/issues/546))
 - Fixed focus showing when clicking on `MenuItem` ([#544](https://github.com/equinor/design-system/issues/544))
 - Fixed an issue where `Divider` did not stretch to full width ([#608](https://github.com/equinor/design-system/issues/608))
+- Fixed `Head` styling when `Table` is set to `width: 100%` ([#610](https://github.com/equinor/design-system/issues/610))
 
 ### Changed
 
 - Added outside click support for closing `Menu`. Outside clicks will now call the `onClose` handler function. ([#548](https://github.com/equinor/design-system/issues/548))
 - Added `data` property to `Icon` component to easily compose icon to be rendered. ([#584](https://github.com/equinor/design-system/issues/584))
-  - See `Icon` [README](/libraries/core-react/src/Icon/README.md) for more information
+  - See `Icon` [README](https://github.com/equinor/design-system/tree/develop/libraries/core-react/src/Icon) for more information
 
 ## [0.6.1] - 2020-09-04
 

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2020-09-15
+
+### Fixed 🐛
+
+- Fixed `onClose` handler not being called when `MenuItem` was used inside `MenuSection` ([#546](https://github.com/equinor/design-system/issues/546))
+- Fixed focus showing when clicking on `MenuItem` ([#544](https://github.com/equinor/design-system/issues/544))
+
+### Changed
+
+- Added outside click support for closing `Menu`. Outside clicks will now call the `onClose` handler function. ([#548](https://github.com/equinor/design-system/issues/548))
+- Added `data` property to `Icon` component to easily compose icon to be rendered. ([#584](https://github.com/equinor/design-system/issues/584))
+
+```jsx
+import { save } from '@equinor/eds-icons';
+
+// EDS icon
+<Icon data={save} />
+
+// Custom icon
+<Icon data={{
+  prefix: 'custom',
+  height: '24',
+  width: '24',
+  svgPathData: 'M12 16.067l4.947 3.6-1.894-5.814L20 10.334h-6.067l-1.933-6-1.933 6H4l4.947 3.52-1.894 5.814 4.947-3.6z',
+}}>
+```
+
 ## [0.6.1] - 2020-09-04
 
 ### Fixed 🐛

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added outside click support for closing `Menu`. Outside clicks will now call the `onClose` handler function. ([#548](https://github.com/equinor/design-system/issues/548))
 - Added `data` property to `Icon` component to easily compose icon to be rendered. ([#584](https://github.com/equinor/design-system/issues/584))
-  - See `Icon` [README](./src/Icon/README.md) for more information
+  - See `Icon` [README](/libraries/core-react/src/Icon/README.md) for more information
 
 ## [0.6.1] - 2020-09-04
 

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -17,21 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added outside click support for closing `Menu`. Outside clicks will now call the `onClose` handler function. ([#548](https://github.com/equinor/design-system/issues/548))
 - Added `data` property to `Icon` component to easily compose icon to be rendered. ([#584](https://github.com/equinor/design-system/issues/584))
-
-```jsx
-import { save } from '@equinor/eds-icons';
-
-// EDS icon
-<Icon data={save} />
-
-// Custom icon
-<Icon data={{
-  prefix: 'custom',
-  height: '24',
-  width: '24',
-  svgPathData: 'M12 16.067l4.947 3.6-1.894-5.814L20 10.334h-6.067l-1.933-6-1.933 6H4l4.947 3.52-1.894 5.814 4.947-3.6z',
-}}>
-```
+  - See `Icon` [README](./src/Icon/README.md) for more information
 
 ## [0.6.1] - 2020-09-04
 

--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The React implementation of the Equinor Design System",
   "main": "dist/core-react.cjs.js",
   "module": "dist/core-react.es.js",

--- a/libraries/core-react/src/Icon/README.md
+++ b/libraries/core-react/src/Icon/README.md
@@ -5,18 +5,32 @@ React component for rendering SVG icons. The component is just an empty render c
 
 ## Usage
 
-The Icon component is intended to be used with the `@equinor/eds-icons` package.
+The Icon component is intended to be used with the `@equinor/eds-icons` package, but can also render any other svg data if provided through the `data` prop.
 
-```javascript
+Example of ways to use the `Icon` component.
+
+```jsx
 import { Icon } from '@equinor/eds-core-react'
 import { save } from '@equinor/eds-icons'
 
+// Way 1
 // Add to library (this needs only be done once)
 Icon.add({ save })
-
-// Renders "save" icon
+// Renders "save" icon only
 <Icon name="save" />
 
+// Way 2
+// EDS icon
+<Icon data={save} />
+
+// Way 3
+// Custom icon
+<Icon data={{
+  prefix: 'custom',
+  height: '24',
+  width: '24',
+  svgPathData: 'M12 16.067l4.947 3.6-1.894-5.814L20 10.334h-6.067l-1.933-6-1.933 6H4l4.947 3.52-1.894 5.814 4.947-3.6z',
+}}>
 ``` 
 
 ### Accessibilty


### PR DESCRIPTION
## [0.6.2] - 2020-09-16

### Fixed 🐛

- Fixed `onClose` handler not being called when `MenuItem` was used inside `MenuSection` ([#546](https://github.com/equinor/design-system/issues/546))
- Fixed focus showing when clicking on `MenuItem` ([#544](https://github.com/equinor/design-system/issues/544))
- Fixed an issue where `Divider` did not stretch to full width ([#608](https://github.com/equinor/design-system/issues/608))
- Fixed `Head` styling when `Table` is set to `width: 100%` ([#610](https://github.com/equinor/design-system/issues/610))

### Changed

- Added outside click support for closing `Menu`. Outside clicks will now call the `onClose` handler function. ([#548](https://github.com/equinor/design-system/issues/548))
- Added `data` property to `Icon` component to easily compose icon to be rendered. ([#584](https://github.com/equinor/design-system/issues/584))
  - See `Icon` [README](https://github.com/equinor/design-system/tree/develop/libraries/core-react/src/Icon) for more information