### PR TITLE
Move application of header background to thead instead of Cell

### DIFF
--- a/apps/storybook-react/stories/Table.stories.jsx
+++ b/apps/storybook-react/stories/Table.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 import { Table, Typography } from '@equinor/eds-core-react'
 import './../style.css'
 
@@ -47,3 +48,62 @@ export const simpleTable = () => (
     </div>
   </div>
 )
+
+export const FixedTableHeader = () => {
+  const FixedContainer = styled.div`
+    width: 200px;
+    height: 200px;
+    overflow: auto;
+  `
+  const StickyHeader = styled(Head)`
+    top: 0;
+    display: block;
+    position: sticky;
+  `
+
+  const FullTable = styled(Table)`
+    width: 100%;
+    height: 100%;
+  `
+
+  return (
+    <FixedContainer>
+      <FullTable>
+        <StickyHeader>
+          <Row>
+            <Cell as="th">Header</Cell>
+          </Row>
+        </StickyHeader>
+        <Body>
+          <Row>
+            <Cell>Cell 1</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+          <Row>
+            <Cell>Cell</Cell>
+          </Row>
+        </Body>
+      </FullTable>
+    </FixedContainer>
+  )
+}

--- a/libraries/core-react/src/Table/Cell.jsx
+++ b/libraries/core-react/src/Table/Cell.jsx
@@ -1,40 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import tableTokens from '@equinor/eds-tokens/components/table/table.json'
+import styled, { css } from 'styled-components'
+import { getTokens } from './Table.tokens'
 import { typographyTemplate } from '../_common/templates'
-
-const { header, cell } = tableTokens
-
-const variants = {
-  header: { text: header.text },
-  cell: {
-    text: cell.text,
-    numeric: cell.monospaced_numeric,
-    icon: cell.icon,
-    input: cell.input,
-  },
-}
-
-const getTokens = (as, variant) => {
-  switch (as) {
-    case 'th':
-      return {
-        ...variants.header[variant],
-        borders: {
-          thead: variants.header[variant].borders,
-          tbody: variants.cell[variant].borders,
-        },
-        background: {
-          thead: variants.header[variant].background,
-          tbody: variants.cell[variant].background,
-        },
-      }
-    case 'td':
-    default:
-      return variants.cell[variant]
-  }
-}
 
 const borderTemplate = (borders) =>
   Object.keys(borders).reduce((acc, val) => {
@@ -46,30 +14,22 @@ const Base = ({ tokens, as }) => {
   const { background, height, text, spacings, borders } = tokens
   const { typography } = text
   const bordersAndBackground =
-    as === 'th'
-      ? `
-        thead & {
-          ${borderTemplate(borders.thead)}
-          background: ${background.thead};
-        }
+    as !== 'th'
+      ? css`
+          ${borderTemplate(borders)}
+          background: ${background};
+        `
+      : ''
 
-        tbody & {
-          ${borderTemplate(borders.tbody)}
-          background: ${background.tbody};
-        }`
-      : `
-        ${borderTemplate(borders)}
-        background: ${background}`
+  const base = css`
+    min-height: ${height};
+    height: ${height};
 
-  const base = `
-  min-height: ${height};
-  height: ${height};
+    padding-left: ${spacings.left};
+    padding-right: ${spacings.right};
 
-  padding-left: ${spacings.left};
-  padding-right: ${spacings.right};
-
-  ${bordersAndBackground}
-  ${typographyTemplate(typography)}
+    ${bordersAndBackground}
+    ${typographyTemplate(typography)}
   `
   return base
 }

--- a/libraries/core-react/src/Table/Head.jsx
+++ b/libraries/core-react/src/Table/Head.jsx
@@ -1,9 +1,28 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
+import { getTokens } from './Table.tokens'
 
-export const Head = ({ children, ...props }) => (
-  <thead {...props}>{children}</thead>
-)
+const borderTemplate = (borders) =>
+  Object.keys(borders).reduce((acc, val) => {
+    const { color, width } = borders[val]
+    return `${acc} border-${val}: ${width} solid ${color}; \n`
+  }, '')
+
+const StyledTableHead = styled.thead`
+  ${({ token: { borders, background } }) => css`
+      ${borderTemplate(borders)}
+      background: ${background};`}
+`
+
+export const Head = ({ children, ...props }) => {
+  const token = getTokens('th', 'text')
+  return (
+    <StyledTableHead token={token} {...props}>
+      {children}
+    </StyledTableHead>
+  )
+}
 
 Head.propTypes = {
   /** @ignore */

--- a/libraries/core-react/src/Table/Table.tokens.js
+++ b/libraries/core-react/src/Table/Table.tokens.js
@@ -1,0 +1,33 @@
+import tableTokens from '@equinor/eds-tokens/components/table/table.json'
+
+const { header, cell } = tableTokens
+
+const variants = {
+  header: { text: header.text },
+  cell: {
+    text: cell.text,
+    numeric: cell.monospaced_numeric,
+    icon: cell.icon,
+    input: cell.input,
+  },
+}
+
+export const getTokens = (as, variant) => {
+  switch (as) {
+    case 'th':
+      return {
+        ...variants.header[variant],
+        // borders: {
+        //   thead: variants.header[variant].borders,
+        //   tbody: variants.cell[variant].borders,
+        // },
+        // background: {
+        //   thead: variants.header[variant].background,
+        //   tbody: variants.cell[variant].background,
+        // },
+      }
+    case 'td':
+    default:
+      return variants.cell[variant]
+  }
+}

--- a/libraries/core-react/src/Table/Table.tokens.js
+++ b/libraries/core-react/src/Table/Table.tokens.js
@@ -15,17 +15,7 @@ const variants = {
 export const getTokens = (as, variant) => {
   switch (as) {
     case 'th':
-      return {
-        ...variants.header[variant],
-        // borders: {
-        //   thead: variants.header[variant].borders,
-        //   tbody: variants.cell[variant].borders,
-        // },
-        // background: {
-        //   thead: variants.header[variant].background,
-        //   tbody: variants.cell[variant].background,
-        // },
-      }
+      return variants.header[variant]
     case 'td':
     default:
       return variants.cell[variant]


### PR DESCRIPTION
* Header background is applied to `Head` instead of `Cell` when as is `th`
  * Will now feel more native when `thead` is stretched to fit table width
* Created `Table.tokens` file and moved relevant code there
* Simplified token extraction from`table` token
* Added example with fixed header in stories

resolves #610  