### PR TITLE
Typescript config tweaks

### DIFF
--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -56,7 +56,6 @@
     "@types/styled-components": "^5.1.2",
     "@types/testing-library__jest-dom": "^5.9.2",
     "babel-plugin-react-docgen": "^4.1.0",
-    "babel-plugin-react-docgen-typescript": "^1.4.2",
     "babel-plugin-styled-components": "^1.10.7",
     "jest": "^26.0.1",
     "jest-styled-components": "^6.3.4",
@@ -66,9 +65,8 @@
     "react-dom": "^16.13.1",
     "rollup": "^2.15.0",
     "rollup-plugin-polyfill": "^3.0.0",
-    "ts-jest": "^26.3.0",
-    "rollup-plugin-typescript2": "^0.27.2",
     "styled-components": "4.4.1",
+    "ts-jest": "^26.3.0",
     "tslib": "^2.0.1",
     "typescript": "^4.0.2"
   },

--- a/libraries/core-react/pnpm-lock.yaml
+++ b/libraries/core-react/pnpm-lock.yaml
@@ -24,7 +24,6 @@ devDependencies:
   '@types/styled-components': 5.1.2
   '@types/testing-library__jest-dom': 5.9.2
   babel-plugin-react-docgen: 4.1.0
-  babel-plugin-react-docgen-typescript: 1.4.2_6e5b3a67faae6c4866d9a003ec605c7e
   babel-plugin-styled-components: 1.10.7_styled-components@4.4.1
   jest: 26.0.1
   jest-styled-components: 6.3.4_styled-components@4.4.1
@@ -2038,16 +2037,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-+AuoehOrjt9irZL7DOt2+4ZaTM6dlu1s5TTS46JBa0/qem4dy7VNW3tMb96qeEqcIh20LD73TVNtmVEeymTG7w==
-  /babel-plugin-react-docgen-typescript/1.4.2_6e5b3a67faae6c4866d9a003ec605c7e:
-    dependencies:
-      '@babel/core': 7.10.2
-      react-docgen-typescript: 1.20.3_typescript@4.0.2
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-      typescript: '*'
-    resolution:
-      integrity: sha512-PwXKu84cCMF9k1X4AlfU47V/1JR1wWJ5MDuaCb0gixnJwBWUM+wBYXWHy84Qjcn2FilR4WRy58srOKU2oiwmMw==
   /babel-plugin-react-docgen/4.1.0:
     dependencies:
       lodash: 4.17.15
@@ -4734,14 +4723,6 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-  /react-docgen-typescript/1.20.3_typescript@4.0.2:
-    dependencies:
-      typescript: 4.0.2
-    dev: true
-    peerDependencies:
-      typescript: '>= 3.x'
-    resolution:
-      integrity: sha512-ISdbO2O5BbD62trroxGmcQXlkFzARRL8ylK0tdnzllGuxcMu3IbnPOFOY/dOfRl8K4LVG9U8yulEVwpyGxGNYA==
   /react-docgen/5.3.0:
     dependencies:
       '@babel/core': 7.10.2
@@ -5927,7 +5908,6 @@ specifiers:
   '@types/styled-components': ^5.1.2
   '@types/testing-library__jest-dom': ^5.9.2
   babel-plugin-react-docgen: ^4.1.0
-  babel-plugin-react-docgen-typescript: ^1.4.2
   babel-plugin-styled-components: ^1.10.7
   focus-visible: ^5.1.0
   jest: ^26.0.1

--- a/libraries/core-react/rollup.config.js
+++ b/libraries/core-react/rollup.config.js
@@ -36,19 +36,7 @@ export default [
         babelHelpers: 'bundled',
         presets: ['@babel/preset-env', '@babel/preset-react'],
         extensions,
-        plugins: [
-          'babel-plugin-styled-components',
-          ...(buildForStorybook
-            ? [
-                [
-                  'babel-plugin-react-docgen-typescript',
-                  {
-                    skipPropsWithName: ['ref', 'key', 'className'],
-                  },
-                ],
-              ]
-            : []),
-        ],
+        plugins: ['babel-plugin-styled-components'],
       }),
       commonjs(),
       polyfill(['focus-visible']),

--- a/libraries/core-react/tsconfig.json
+++ b/libraries/core-react/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["./src"],
+  "include": ["./src/**/*.ts*"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     /* do we really understand the implications of these settings? 🙄 */
-    "target": "es5",
+    "target": "ES2015",
     "module": "esnext",
-    "lib": ["dom", "es2015"],
+    "lib": ["dom", "ES2015"],
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "sourceMap": false,
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
* Updated `base.tsconfig.json` with `skipLibCheck` as [recommended](https://www.npmjs.com/package/@tsconfig/recommended)
* Removed `babel-plugin-react-docgen-typescript` as `Icon` typescript variant ran into [this bug](https://github.com/strothj/babel-plugin-react-docgen-typescript/pull/21) which has not been approved yet. Does not seem to be [maintained](https://github.com/strothj/babel-plugin-react-docgen-typescript/issues/18) anymore either

Issue for finding alternative #622 
