### PR TITLE
Added typescript declarations to core-react

### DIFF
--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -5,6 +5,7 @@
   "main": "dist/core-react.cjs.js",
   "module": "dist/core-react.es.js",
   "browser": "dist/core-react.umd.js",
+  "types": "dist/types/index.d.ts",
   "license": "AGPL-3.0-or-later",
   "author": {
     "name": "EDS Core Team",
@@ -46,7 +47,6 @@
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^8.0.1",
-    "@rollup/plugin-typescript": "^5.0.2",
     "@testing-library/jest-dom": "^5.9.0",
     "@testing-library/react": "^10.2.1",
     "@testing-library/user-event": "^10.3.2",
@@ -65,6 +65,7 @@
     "react-dom": "^16.13.1",
     "rollup": "^2.15.0",
     "rollup-plugin-polyfill": "^3.0.0",
+    "rollup-plugin-typescript2": "^0.27.2",
     "styled-components": "4.4.1",
     "ts-jest": "^26.3.0",
     "tslib": "^2.0.1",

--- a/libraries/core-react/pnpm-lock.yaml
+++ b/libraries/core-react/pnpm-lock.yaml
@@ -14,7 +14,6 @@ devDependencies:
   '@rollup/plugin-commonjs': 13.0.0_rollup@2.15.0
   '@rollup/plugin-json': 4.1.0_rollup@2.15.0
   '@rollup/plugin-node-resolve': 8.0.1_rollup@2.15.0
-  '@rollup/plugin-typescript': 5.0.2_0a1a0f524a9d27ad422e76168b31793b
   '@testing-library/jest-dom': 5.9.0
   '@testing-library/react': 10.2.1_react-dom@16.13.1+react@16.13.1
   '@testing-library/user-event': 10.4.1
@@ -33,6 +32,7 @@ devDependencies:
   react-dom: 16.13.1_react@16.13.1
   rollup: 2.15.0
   rollup-plugin-polyfill: 3.0.0
+  rollup-plugin-typescript2: 0.27.2_rollup@2.15.0+typescript@4.0.2
   styled-components: 4.4.1_4f54128445bc6f13bd713dcb3d91e98e
   ts-jest: 26.3.0_jest@26.0.1+typescript@4.0.2
   tslib: 2.0.1
@@ -1518,22 +1518,6 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-KIeAmueDDaYMqMBnUngLVVZhURwxA12nq/YB6nGm5/JpVyOMwI1fCVU3oL/dAnnLBG7oiPXntO5LHOiMrfNXCA==
-  /@rollup/plugin-typescript/5.0.2_0a1a0f524a9d27ad422e76168b31793b:
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.15.0
-      resolve: 1.17.0
-      rollup: 2.15.0
-      tslib: 2.0.1
-      typescript: 4.0.2
-    dev: true
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      rollup: ^2.14.0
-      tslib: '*'
-      typescript: '>=3.4.0'
-    resolution:
-      integrity: sha512-CkS028Itwjqm1uLbFVfpJgtVtnNvZ+og/m6UlNRR5wOOnNTWPcVQzOu5xGdEX+WWJxdvWIqUq2uR/RBt2ZipWg==
   /@rollup/pluginutils/3.1.0_rollup@2.15.0:
     dependencies:
       '@types/estree': 0.0.39
@@ -2876,6 +2860,16 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  /find-cache-dir/3.3.1:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
   /find-up/2.1.0:
     dependencies:
       locate-path: 2.0.0
@@ -2925,6 +2919,16 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
+  /fs-extra/8.1.0:
+    dependencies:
+      graceful-fs: 4.2.4
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+    dev: true
+    engines:
+      node: '>=6 <7 || >=8'
+    resolution:
+      integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   /fs-readdir-recursive/1.1.0:
     dev: true
     resolution:
@@ -4018,6 +4022,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  /jsonfile/4.0.0:
+    dev: true
+    optionalDependencies:
+      graceful-fs: 4.2.4
+    resolution:
+      integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsprim/1.4.1:
     dependencies:
       assert-plus: 1.0.0
@@ -5007,6 +5017,21 @@ packages:
     dev: true
     resolution:
       integrity: sha512-LfJ1OR/wJrJdNDVNrdhVm7CgENfaNoQlFYMaQ0vlQH3zO+BMVrBMWDX9k6HVcr9gHsKbthrkiBzWRfFU9fr0hQ==
+  /rollup-plugin-typescript2/0.27.2_rollup@2.15.0+typescript@4.0.2:
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.15.0
+      find-cache-dir: 3.3.1
+      fs-extra: 8.1.0
+      resolve: 1.17.0
+      rollup: 2.15.0
+      tslib: 2.0.1
+      typescript: 4.0.2
+    dev: true
+    peerDependencies:
+      rollup: '>=1.26.3'
+      typescript: '>=2.4.0'
+    resolution:
+      integrity: sha512-zarMH2F8oT/NO6p20gl/jkts+WxyzOlhOIUwUU/EDx5e6ewdDPS/flwLj5XFuijUCr64bZwqKuRVwCPdXXYefQ==
   /rollup/2.15.0:
     dev: true
     engines:
@@ -5655,6 +5680,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
+  /universalify/0.1.2:
+    dev: true
+    engines:
+      node: '>= 4.0.0'
+    resolution:
+      integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
   /unset-value/1.0.0:
     dependencies:
       has-value: 0.3.1
@@ -5897,7 +5928,6 @@ specifiers:
   '@rollup/plugin-commonjs': ^13.0.0
   '@rollup/plugin-json': ^4.1.0
   '@rollup/plugin-node-resolve': ^8.0.1
-  '@rollup/plugin-typescript': ^5.0.2
   '@testing-library/jest-dom': ^5.9.0
   '@testing-library/react': ^10.2.1
   '@testing-library/react-hooks': ^3.3.0
@@ -5919,6 +5949,7 @@ specifiers:
   react-dom: ^16.13.1
   rollup: ^2.15.0
   rollup-plugin-polyfill: ^3.0.0
+  rollup-plugin-typescript2: ^0.27.2
   styled-components: 4.4.1
   ts-jest: ^26.3.0
   tslib: ^2.0.1

--- a/libraries/core-react/rollup.config.js
+++ b/libraries/core-react/rollup.config.js
@@ -4,7 +4,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import babel from '@rollup/plugin-babel'
 import polyfill from 'rollup-plugin-polyfill'
-import typescript from '@rollup/plugin-typescript'
+import typescript from 'rollup-plugin-typescript2'
 
 import pkg from './package.json'
 
@@ -17,11 +17,10 @@ const globals = {
   'styled-components': 'styled',
 }
 
-const buildForStorybook = process.env.STORYBOOK
 const extensions = ['.jsx', '.js', '.tsx', '.ts']
 export default [
   {
-    input: './src/index.js',
+    input: './src/index.ts',
     external: peerDeps,
     watch: {
       clearScreen: true,
@@ -30,7 +29,7 @@ export default [
     plugins: [
       json(),
       resolve({ extensions }),
-      typescript(),
+      typescript({ useTsconfigDeclarationDir: true }),
       babel({
         exclude: 'node_modules/**',
         babelHelpers: 'bundled',
@@ -50,7 +49,10 @@ export default [
         sourcemap: true,
         globals,
       },
-      ...(buildForStorybook ? [] : [{ file: pkg.main, format: 'cjs' }]),
+      {
+        file: pkg.main,
+        format: 'cjs',
+      },
     ],
   },
 ]

--- a/libraries/core-react/src/Menu/Menu.context.jsx
+++ b/libraries/core-react/src/Menu/Menu.context.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { useState, useContext } from 'react'
 import PropTypes from 'prop-types'
 

--- a/libraries/core-react/src/Menu/Menu.jsx
+++ b/libraries/core-react/src/Menu/Menu.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'

--- a/libraries/core-react/src/Menu/Menu.test.jsx
+++ b/libraries/core-react/src/Menu/Menu.test.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint-disable no-undef */
 import React from 'react'
 import { render, cleanup, screen, fireEvent } from './test-utils'

--- a/libraries/core-react/src/Menu/MenuItem.jsx
+++ b/libraries/core-react/src/Menu/MenuItem.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'

--- a/libraries/core-react/src/Menu/MenuList.jsx
+++ b/libraries/core-react/src/Menu/MenuList.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'

--- a/libraries/core-react/src/Menu/MenuSection.jsx
+++ b/libraries/core-react/src/Menu/MenuSection.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'

--- a/libraries/core-react/src/Menu/index.jsx
+++ b/libraries/core-react/src/Menu/index.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from 'react'
 import { Menu as BaseMenu } from './Menu'
 import { MenuItem } from './MenuItem'

--- a/libraries/core-react/src/Paper/Paper.jsx
+++ b/libraries/core-react/src/Paper/Paper.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'

--- a/libraries/core-react/src/index.ts
+++ b/libraries/core-react/src/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/prefer-default-export */
-// @ts-nocheck
 export { Button } from './Button'
 export { Typography } from './Typography'
 export { Table } from './Table'

--- a/libraries/core-react/tsconfig.json
+++ b/libraries/core-react/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "outDir": "./dist"
+  },
   "include": ["./src/**/*.ts*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
* Turns out the official `@rollup/plugin-typescript` plugin still has some [issues...](https://github.com/rollup/plugins/issues?q=is%3Aissue+is%3Aopen+typescript).
* Switching to `rollup-plugin-typescript2` works 👍
* Added missing `ts-no-checks` for now since we had to change `index.js` file to `.ts` for declarations to work
* Declarations are saved under `dist/types` as they are not bundled into one file and thus follow the same folder structure as is under `/src` but as type files

![image](https://user-images.githubusercontent.com/1070981/94001169-6d5eb100-fd98-11ea-8de9-38a168bc7e4c.png)


resolves #624 