### PR TITLE
🐛 fix spacing bugs on CardMedia

### DIFF
--- a/libraries/core-react/src/Banner/BannerActions.jsx
+++ b/libraries/core-react/src/Banner/BannerActions.jsx
@@ -15,9 +15,9 @@ const StyledBannerActions = styled.div`
     }}
 `
 
-export const BannerActions = ({ children, placement, className }) => {
+export const BannerActions = ({ children, placement, className, ...props }) => {
   return (
-    <StyledBannerActions placement={placement} className={className}>
+    <StyledBannerActions {...props} placement={placement} className={className}>
       {children}
     </StyledBannerActions>
   )

--- a/libraries/core-react/src/Card/CardMedia.jsx
+++ b/libraries/core-react/src/Card/CardMedia.jsx
@@ -17,6 +17,7 @@ const StyledCardMedia = styled.div`
           > * {
             width: calc(100% + ${spacing} + ${spacing});
             margin-left: -${spacing};
+            margin-right: -${spacing};
           }
 
           &:first-child {

--- a/libraries/core-react/src/Card/CardMedia.jsx
+++ b/libraries/core-react/src/Card/CardMedia.jsx
@@ -7,9 +7,6 @@ import { card as tokens } from './Card.tokens'
 const StyledCardMedia = styled.div`
   display: flex;
   width: 100%;
-  img {
-    margin-left: -16px;
-  }
   &:last-child {
     margin-bottom: 8px;
     /* Last child to have 24px total spacing to bottom */


### PR DESCRIPTION
Fixes #603 - missing spacing on left side of middle variant

Also fixes the full-width variant where spacing was applied on the right side of the media