### PR TITLE
fix link to edit page on github in storefront

### DIFF
--- a/apps/storefront/src/components/EditPageOnGithub.jsx
+++ b/apps/storefront/src/components/EditPageOnGithub.jsx
@@ -1,25 +1,35 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { useThemeUI } from 'theme-ui'
+import { Icon } from '@equinor/eds-core-react'
+import { edit_text } from '@equinor/eds-icons'
+import styled from 'styled-components'
+
+Icon.add({ edit_text })
+
+const Link = styled.a`
+  display: flex;
+  align-items: center;
+  margin-top: 3rem;
+  color: ${(props) => props.color || '#007079'};
+
+  & > svg {
+    margin-right: 8px;
+  }
+`
 
 export const EditPageOnGithub = ({ slug }) => {
   const context = useThemeUI()
   const { theme } = context
 
   return (
-    <a
+    <Link
+      color={theme.colors.primary}
       href={`https://github.com/equinor/design-system/blob/develop/apps/storefront/${slug}`}
-      style={{
-        display: 'block',
-        marginTop: '3rem',
-        color: theme.colors.primary,
-      }}
     >
-      <span role="img" aria-label="Pencil">
-        ✏️
-      </span>{' '}
+      <Icon name="edit_text" size={16} />
       Edit this page on GitHub
-    </a>
+    </Link>
   )
 }
 

--- a/apps/storefront/src/components/EditPageOnGithub.jsx
+++ b/apps/storefront/src/components/EditPageOnGithub.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 
 Icon.add({ edit_text })
 
-const Link = styled.a`
+const ExternalLink = styled.a`
   display: flex;
   align-items: center;
   margin-top: 3rem;
@@ -23,13 +23,13 @@ export const EditPageOnGithub = ({ slug }) => {
   const { theme } = context
 
   return (
-    <Link
+    <ExternalLink
       color={theme.colors.primary}
       href={`https://github.com/equinor/design-system/blob/develop/apps/storefront/${slug}`}
     >
       <Icon name="edit_text" size={16} />
       Edit this page on GitHub
-    </Link>
+    </ExternalLink>
   )
 }
 

--- a/apps/storefront/src/components/EditPageOnGithub.jsx
+++ b/apps/storefront/src/components/EditPageOnGithub.jsx
@@ -8,9 +8,7 @@ export const EditPageOnGithub = ({ slug }) => {
 
   return (
     <a
-      href={`https://github.com/equinor/design-system/tree/documentation/apps/storefront/src/content/${
-        slug === '/' ? `index` : slug
-      }.mdx`}
+      href={`https://github.com/equinor/design-system/blob/develop/apps/storefront/${slug}`}
       style={{
         display: 'block',
         marginTop: '3rem',

--- a/apps/storefront/src/gatsby-theme-docz/components/MainContainer/index.js
+++ b/apps/storefront/src/gatsby-theme-docz/components/MainContainer/index.js
@@ -117,7 +117,7 @@ export const MainContainer = ({ children, doc, ...rest }) => {
     route,
     mode = 'draft',
     type = 'contentPage',
-    slug,
+    filepath,
   } = doc.value
 
   const docs = useDocs()
@@ -223,7 +223,7 @@ export const MainContainer = ({ children, doc, ...rest }) => {
               <Content>
                 {children}
 
-                <EditPageOnGithub slug={slug} />
+                <EditPageOnGithub slug={filepath} />
               </Content>
             </Wrapper>
           </>


### PR DESCRIPTION
Resolves #620 

In addition to fixing the dead links, I also took the liberty of refactoring the `EditPageOnGithub` component to use the EDS icon and converted the inline styling to styled-components.