### PR TITLE
fix: Accordion can't handle null value as child

### DIFF
--- a/libraries/core-react/src/Accordion/Accordion.jsx
+++ b/libraries/core-react/src/Accordion/Accordion.jsx
@@ -9,6 +9,8 @@ const Accordion = forwardRef(function Accordion(
   const accordionId = useMemo(() => createId('accordion-'), [])
 
   const AccordionItems = React.Children.map(children, (child, index) => {
+    if (!child) return null
+
     return React.cloneElement(child, {
       accordionId,
       index,


### PR DESCRIPTION
Adds a guard clause to the rendering of AccordionItems to handle `null`, `undefined`, `false` values passed as Accordion children

Resolves #688 