### PR TITLE
Change .. imports to direct

### DIFF
--- a/libraries/core-react/src/Banner/Banner.test.jsx
+++ b/libraries/core-react/src/Banner/Banner.test.jsx
@@ -6,7 +6,7 @@ import 'jest-styled-components'
 import styled from 'styled-components'
 import { add } from '@equinor/eds-icons'
 import { Banner } from '.'
-import { Icon } from '..'
+import { Icon } from '../Icon'
 import { banner as tokens } from './Banner.tokens'
 
 const { BannerMessage, BannerIcon, BannerActions } = Banner

--- a/libraries/core-react/src/Progress/Circular/CircularProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Circular/CircularProgress.test.tsx
@@ -4,7 +4,7 @@ import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import styled from 'styled-components'
-import { CircularProgress } from '..'
+import { CircularProgress } from './CircularProgress'
 
 const StyledProgress = styled(CircularProgress)`
   position: absolute;

--- a/libraries/core-react/src/Progress/Dots/DotProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Dots/DotProgress.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import styled from 'styled-components'
 import { progress as tokens } from '../Progress.tokens'
-import { DotProgress } from '..'
+import { DotProgress } from './DotProgress'
 
 const StyledProgress = styled(DotProgress)`
   position: absolute;

--- a/libraries/core-react/src/Progress/Linear/LinearProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Linear/LinearProgress.test.tsx
@@ -4,7 +4,7 @@ import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import styled from 'styled-components'
-import { LinearProgress } from '..'
+import { LinearProgress } from './LinearProgress'
 
 const StyledProgress = styled(LinearProgress)`
   position: absolute;

--- a/libraries/core-react/src/Progress/Star/StarProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Star/StarProgress.test.tsx
@@ -4,7 +4,7 @@ import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import styled from 'styled-components'
-import { StarProgress } from '..'
+import { StarProgress } from './StarProgress'
 
 const StyledProgress = styled(StarProgress)`
   position: absolute;


### PR DESCRIPTION
partially fixes #708 

Changed in files that are not touched yet.

Follow has `..` imports which needs to be fixed in respective PRs.
* `Card.test.jsx` in #699 
* `Popover.test`, `PopoverItem` & `PopoverTitle` in #695 
* `TableOfContents.jsx` in #689 