### PR TITLE
Made AccordionItem toggleable through "isExpanded"

### DIFF
--- a/libraries/core-react/src/Accordion/AccordionItem.tsx
+++ b/libraries/core-react/src/Accordion/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState, ReactElement } from 'react'
+import React, { forwardRef, useState, useEffect, ReactElement } from 'react'
 import type { AccordionProps } from './Accordion.types'
 
 type Props = {
@@ -51,6 +51,10 @@ const AccordionItem = forwardRef<HTMLDivElement, Props>(function AccordionItem(
           headerId,
         })
   })
+
+  useEffect(() => {
+    setExpanded(isExpanded)
+  }, [isExpanded])
 
   return (
     <div {...props} ref={ref}>


### PR DESCRIPTION
Related to this issue: https://github.com/equinor/design-system/issues/677

This change lets users change the AccordionItem expanded state from outside the component, by programatically changing the `isExpanded`-prop.

----

Made a new PR for typescript branch. 