### PR TITLE
🎨 Improve story for Divider

### DIFF
--- a/apps/storybook-react/stories/Divider.stories.tsx
+++ b/apps/storybook-react/stories/Divider.stories.tsx
@@ -1,5 +1,9 @@
-import React from 'react'
-import styled from 'styled-components'
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import React, { FunctionComponent, HTMLProps } from 'react'
+import styled, { StyledFunction, ThemedStyledFunction } from 'styled-components'
+
 import { Divider, DividerProps } from '@equinor/eds-core-react'
 import { Story, Meta } from '@storybook/react/types-6-0'
 
@@ -22,9 +26,7 @@ export default {
   },
 } as Meta
 
-type WrapperProps = React.HTMLAttributes<HTMLDivElement>
-
-const Wrapper = styled.div<WrapperProps>`
+const Wrapper = styled.div`
   padding: 32px;
   background-color: #999;
 `

--- a/apps/storybook-react/stories/Divider.stories.tsx
+++ b/apps/storybook-react/stories/Divider.stories.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import React, { FunctionComponent, HTMLProps } from 'react'
-import styled, { StyledFunction, ThemedStyledFunction } from 'styled-components'
+import React from 'react'
+import styled from 'styled-components'
 
 import { Divider, DividerProps } from '@equinor/eds-core-react'
 import { Story, Meta } from '@storybook/react/types-6-0'

--- a/apps/storybook-react/stories/Divider.stories.tsx
+++ b/apps/storybook-react/stories/Divider.stories.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import React from 'react'
 import styled from 'styled-components'
-
 import { Divider, DividerProps } from '@equinor/eds-core-react'
 import { Story, Meta } from '@storybook/react/types-6-0'
 

--- a/libraries/core-react/src/Divider/Divider.tsx
+++ b/libraries/core-react/src/Divider/Divider.tsx
@@ -26,16 +26,17 @@ export type DividerProps = {
   className?: string
 }
 
-export const Divider = forwardRef<HTMLHRElement, DividerProps>(
-  ({ color = 'medium', variant = 'medium', className = '' }, ref) => {
-    const styleProps = {
-      backgroundColor: tokens.color[color],
-      marginTop: tokens[variant].spacings.top,
-      marginBottom: tokens[variant].spacings.bottom,
-      dividerHeight: tokens.height,
-    }
-    return <StyledDivider {...styleProps} className={className} ref={ref} />
-  },
-)
+export const Divider = forwardRef<HTMLHRElement, DividerProps>(function Divider(
+  { color = 'medium', variant = 'medium', className = '' },
+  ref,
+) {
+  const styleProps = {
+    backgroundColor: tokens.color[color],
+    marginTop: tokens[variant].spacings.top,
+    marginBottom: tokens[variant].spacings.bottom,
+    dividerHeight: tokens.height,
+  }
+  return <StyledDivider {...styleProps} className={className} ref={ref} />
+})
 
-Divider.displayName = 'Divider'
+// Divider.displayName = 'Divider'

--- a/libraries/core-react/src/Divider/index.ts
+++ b/libraries/core-react/src/Divider/index.ts
@@ -1,1 +1,1 @@
-export { Divider, DividerProps } from './Divider'
+export * from './Divider'


### PR DESCRIPTION
- The Divider component now uses a named function instead of an arrow function
- The component and it’s type is re-exported as `*`, which gets rid of the error message that type cannot be found

I’ve added some Eslint exceptions to the story, but these issues are something we have to discuss

Part of #735 