### PR TITLE
🔧 Lint stories

### DIFF
--- a/apps/storybook-react/stories/.eslintrc.yaml
+++ b/apps/storybook-react/stories/.eslintrc.yaml
@@ -1,0 +1,4 @@
+root: true
+extends: ../../../.eslintrc.js
+rules:
+  import/no-default-export: "off"


### PR DESCRIPTION
Extends the eslintconfig from root, but turns off the default exports error since storybook relies on default exports in the stories.