### PR TITLE
🔧 Update React imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,9 @@
+const pkg = require('./libraries/core-react/package.json')
+
+const {
+  devDependencies: { react: reactVersion },
+} = pkg
+
 module.exports = {
   root: true,
   extends: [
@@ -25,7 +31,7 @@ module.exports = {
   },
   settings: {
     react: {
-      version: 'detect',
+      version: reactVersion,
     },
   },
   globals: {

--- a/apps/figma-broker/pnpm-lock.yaml
+++ b/apps/figma-broker/pnpm-lock.yaml
@@ -10,7 +10,7 @@ dependencies:
   prettier: 2.0.5
   ramda: 0.27.0
   svgo: 1.3.2
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@koa/router/9.0.1:
     dependencies:

--- a/apps/storefront/pnpm-lock.yaml
+++ b/apps/storefront/pnpm-lock.yaml
@@ -7,9 +7,9 @@ dependencies:
   '@mikaelkristiansson/domready': 1.0.10
   '@reach/router': 1.3.4_react-dom@16.13.1+react@16.13.1
   babel-plugin-styled-components: 1.11.1_styled-components@5.1.1
-  docz: 2.3.1_c95255344fcbf6b4c2c4015e2d9e0f3f
+  docz: 2.3.1_react-dom@16.13.1+react@16.13.1
   focus-visible: 5.1.0
-  gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+  gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
   gatsby-image: 2.4.13
   gatsby-link: 2.4.12_3914268316c542370cbb046de235e031
   gatsby-plugin-algolia-docsearch: 1.0.5_gatsby@2.24.2
@@ -38,11 +38,11 @@ dependencies:
   react-helmet: 6.1.0_react@16.13.1
   remark-emoji: 2.1.0
   shallow-compare: 1.2.2
-  styled-components: 5.1.1_479e60ee9c1aa71dc1eb81036e3619dc
+  styled-components: 5.1.1_react-dom@16.13.1+react@16.13.1
 devDependencies:
   prettier: 2.0.5
   stylelint-config-recommended: 3.0.0
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@ardatan/aggregate-error/0.0.1:
     dev: false
@@ -1345,7 +1345,7 @@ packages:
       prop-types: 15.7.2
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
-      styled-components: 5.1.1_479e60ee9c1aa71dc1eb81036e3619dc
+      styled-components: 5.1.1_react-dom@16.13.1+react@16.13.1
     dev: false
     engines:
       node: '>=10.0.0'
@@ -1956,7 +1956,7 @@ packages:
       error-stack-parser: 2.0.6
       string-width: 2.1.1
       strip-ansi: 3.0.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
@@ -3147,7 +3147,7 @@ packages:
       mkdirp: 0.5.5
       pify: 4.0.1
       schema-utils: 2.7.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     engines:
       node: '>= 6.9'
@@ -3220,7 +3220,7 @@ packages:
       integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
   /babel-plugin-remove-graphql-queries/2.9.13_gatsby@2.24.2:
     dependencies:
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
     dev: false
     engines:
       node: '>=10.13.0'
@@ -3234,7 +3234,7 @@ packages:
       '@babel/helper-module-imports': 7.10.4
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.19
-      styled-components: 5.1.1_479e60ee9c1aa71dc1eb81036e3619dc
+      styled-components: 5.1.1_react-dom@16.13.1+react@16.13.1
     dev: false
     peerDependencies:
       styled-components: '>= 2'
@@ -3246,7 +3246,7 @@ packages:
       '@babel/helper-module-imports': 7.12.5
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.20
-      styled-components: 5.1.1_479e60ee9c1aa71dc1eb81036e3619dc
+      styled-components: 5.1.1_react-dom@16.13.1+react@16.13.1
     dev: false
     peerDependencies:
       styled-components: '>= 2'
@@ -4879,7 +4879,7 @@ packages:
       postcss-modules-values: 1.3.0
       postcss-value-parser: 3.3.1
       source-list-map: 2.0.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     engines:
       node: '>= 6.9.0 <7.0.0 || >= 8.9.0'
@@ -5584,7 +5584,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MDQ/GNnR6yc6gkGI6vrTWUwSxapNFh021JW9AW9eQIBu2E8560fggKBot8o/E9NuJt/h2bencoKnk8RH063aCg==
-  /docz/2.3.1_c95255344fcbf6b4c2c4015e2d9e0f3f:
+  /docz/2.3.1_react-dom@16.13.1+react@16.13.1:
     dependencies:
       '@emotion/core': 10.0.28_react@16.13.1
       '@mdx-js/react': 1.6.6_react@16.13.1
@@ -5592,7 +5592,7 @@ packages:
       capitalize: 2.0.3
       docz-core: 2.3.0
       fast-deep-equal: 2.0.1
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       gatsby-plugin-eslint: 2.0.8_gatsby@2.24.2
       gatsby-plugin-typescript: 2.4.14_gatsby@2.24.2
       gatsby-theme-docz: 2.3.1_c95255344fcbf6b4c2c4015e2d9e0f3f
@@ -5609,7 +5609,6 @@ packages:
     dev: false
     hasBin: true
     peerDependencies:
-      docz: '*'
       react: ^16.8.0
       react-dom: ^16.8.0
     resolution:
@@ -6039,7 +6038,7 @@ packages:
       object-assign: 4.1.1
       object-hash: 1.3.1
       rimraf: 2.7.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     peerDependencies:
       eslint: '>=1.6.0 <7.0.0'
@@ -6730,7 +6729,7 @@ packages:
     dependencies:
       loader-utils: 1.4.0
       schema-utils: 0.4.7
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     engines:
       node: '>= 4.3 < 5.0.0 || >= 5.10'
@@ -7206,7 +7205,7 @@ packages:
   /gatsby-plugin-algolia-docsearch/1.0.5_gatsby@2.24.2:
     dependencies:
       '@babel/runtime': 7.10.4
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
     dev: false
     peerDependencies:
       gatsby: ^2.0.0
@@ -7215,7 +7214,7 @@ packages:
   /gatsby-plugin-alias-imports/1.0.5_gatsby@2.24.2:
     dependencies:
       '@babel/runtime': 7.10.4
-      gatsby: 2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc
+      gatsby: 2.24.2_7ad1e1a5bb97bbc75ca12d1d39096bfd
     dev: false
     peerDependencies:
       gatsby: '>2.0.0'
@@ -7224,7 +7223,7 @@ packages:
   /gatsby-plugin-compile-es6-packages/2.1.0_gatsby@2.24.2:
     dependencies:
       '@babel/runtime': 7.10.4
-      gatsby: 2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc
+      gatsby: 2.24.2_7ad1e1a5bb97bbc75ca12d1d39096bfd
       regex-escape: 3.4.9
     dev: false
     peerDependencies:
@@ -7236,7 +7235,7 @@ packages:
       '@babel/runtime': 7.10.4
       '@emotion/babel-preset-css-prop': 10.0.27
       '@emotion/core': 10.0.28_react@16.13.1
-      gatsby: 2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc
+      gatsby: 2.24.2_7ad1e1a5bb97bbc75ca12d1d39096bfd
     dev: false
     engines:
       node: '>=10.13.0'
@@ -7248,7 +7247,7 @@ packages:
       integrity: sha512-OQrNgq3Te+bjra/sNo2PwOm24dPVr8MsjWf3X/3ciPf4bkf+Ey0jzJ36JnIIUIzZvpbyBHAr6eNzSOWnE2X2zA==
   /gatsby-plugin-eslint/2.0.8_gatsby@2.24.2:
     dependencies:
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
     dev: false
     peerDependencies:
       eslint: ^6.6.0
@@ -7259,7 +7258,7 @@ packages:
   /gatsby-plugin-load-script/1.1.0_gatsby@2.24.2:
     dependencies:
       '@babel/runtime': 7.10.4
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
     dev: false
     peerDependencies:
       gatsby: ^2.20.12
@@ -7268,7 +7267,7 @@ packages:
   /gatsby-plugin-manifest/2.4.18_gatsby@2.24.2:
     dependencies:
       '@babel/runtime': 7.10.4
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       gatsby-core-utils: 1.3.12
       semver: 5.7.1
       sharp: 0.25.4
@@ -7372,7 +7371,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.10.4
       cheerio: 1.0.0-rc.3
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       gatsby-core-utils: 1.3.12
       glob: 7.1.6
       idb-keyval: 3.2.0
@@ -7390,7 +7389,7 @@ packages:
       '@babel/runtime': 7.10.4
       bluebird: 3.7.2
       fs-exists-cached: 1.0.0
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       gatsby-page-utils: 0.2.17
       glob: 7.1.6
       lodash: 4.17.19
@@ -7404,7 +7403,7 @@ packages:
       integrity: sha512-mIIotda+tR59tb3gk5qW3CUVSsdA608hchuX/+bKUCyuqyqZKjPffOdGUgy92Aa+mmIKgJTiGDUnIJoVsHSdtg==
   /gatsby-plugin-react-helmet-async/1.0.16_0d3de3853106fe1b308c9747ca1b1415:
     dependencies:
-      gatsby: 2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc
+      gatsby: 2.24.2_7ad1e1a5bb97bbc75ca12d1d39096bfd
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
       react-helmet-async: 1.0.6_react-dom@16.13.1+react@16.13.1
@@ -7419,7 +7418,7 @@ packages:
   /gatsby-plugin-react-helmet/3.3.10_gatsby@2.24.2+react-helmet@6.1.0:
     dependencies:
       '@babel/runtime': 7.10.4
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       react-helmet: 6.1.0_react@16.13.1
     dev: false
     engines:
@@ -7431,7 +7430,7 @@ packages:
       integrity: sha512-AcXYwmS3r298JWs6iQ3OLNxIe8L8i5a2iSdLr/SDMpHqumYm7q/vB9kCX0et5wM7DIuZ7aPXDrdi5yDCAvU5lg==
   /gatsby-plugin-root-import/2.0.5_gatsby@2.24.2:
     dependencies:
-      gatsby: 2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc
+      gatsby: 2.24.2_7ad1e1a5bb97bbc75ca12d1d39096bfd
     dev: false
     peerDependencies:
       gatsby: '>=1'
@@ -7443,7 +7442,7 @@ packages:
       async: 2.6.3
       bluebird: 3.7.2
       fs-extra: 8.1.0
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       gatsby-core-utils: 1.3.12
       got: 8.3.2
       imagemin: 6.1.0
@@ -7469,8 +7468,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.10.4
       babel-plugin-styled-components: 1.11.1_styled-components@5.1.1
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
-      styled-components: 5.1.1_479e60ee9c1aa71dc1eb81036e3619dc
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
+      styled-components: 5.1.1_react-dom@16.13.1+react@16.13.1
     dev: false
     engines:
       node: '>=10.13.0'
@@ -7588,7 +7587,7 @@ packages:
       chokidar: 3.4.0
       file-type: 12.4.2
       fs-extra: 8.1.0
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       gatsby-core-utils: 1.3.12
       got: 9.6.0
       md5-file: 3.2.3
@@ -7635,10 +7634,10 @@ packages:
       '@theme-ui/typography': 0.2.46
       babel-plugin-export-metadata: 2.3.0
       copy-text-to-clipboard: 2.2.0
-      docz: 2.3.1_c95255344fcbf6b4c2c4015e2d9e0f3f
+      docz: 2.3.1_react-dom@16.13.1+react@16.13.1
       emotion-theming: 10.0.27_c989b1aa057905c7a8b69bf973f55a19
       fs-extra: 8.1.0
-      gatsby: 2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc
+      gatsby: 2.24.2_7ad1e1a5bb97bbc75ca12d1d39096bfd
       gatsby-plugin-alias-imports: 1.0.5_gatsby@2.24.2
       gatsby-plugin-compile-es6-packages: 2.1.0_gatsby@2.24.2
       gatsby-plugin-emotion: 4.3.10_cdf84ffd3567639bd6470dc52b87109d
@@ -7678,7 +7677,7 @@ packages:
       '@babel/runtime': 7.10.4
       bluebird: 3.7.2
       fs-extra: 8.1.0
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       gatsby-plugin-sharp: 2.6.19_gatsby@2.24.2
       potrace: 2.1.6
       probe-image-size: 4.1.1
@@ -7695,7 +7694,7 @@ packages:
   /gatsby-transformer-yaml/2.4.10_gatsby@2.24.2:
     dependencies:
       '@babel/runtime': 7.10.4
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
+      gatsby: 2.24.2_react-dom@16.13.1+react@16.13.1
       js-yaml: 3.14.0
       lodash: 4.17.19
       unist-util-select: 1.5.0
@@ -7706,7 +7705,163 @@ packages:
       gatsby: ^2.0.15
     resolution:
       integrity: sha512-jQwtyIn0pvT1GfmdxKUKgdJwgK/z8aVVN7wFeHuskhDwWzxCghB88ybyhS7gOF0ttyKNYjQIpwgwt9PnL+AJBQ==
-  /gatsby/2.24.2_87c673b4c99150bcbaa42956bba55e13:
+  /gatsby/2.24.2_7ad1e1a5bb97bbc75ca12d1d39096bfd:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/core': 7.10.4
+      '@babel/parser': 7.10.4
+      '@babel/runtime': 7.10.4
+      '@babel/traverse': 7.10.4
+      '@hapi/joi': 15.1.1
+      '@mikaelkristiansson/domready': 1.0.10
+      '@pieh/friendly-errors-webpack-plugin': 1.7.0-chalk-2_webpack@4.43.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.3.3_d8528028579e0129932d17e99387126e
+      '@reach/router': 1.3.4_react-dom@16.13.1+react@16.13.1
+      '@types/http-proxy': 1.17.4
+      '@typescript-eslint/eslint-plugin': 2.34.0_5a17f289f30f975b48207d0526ec4dc8
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.5.3
+      address: 1.1.2
+      autoprefixer: 9.8.5
+      axios: 0.19.2
+      babel-core: 7.0.0-bridge.0_@babel+core@7.10.4
+      babel-eslint: 10.1.0_eslint@6.8.0
+      babel-loader: 8.1.0_0cfd9791b7d0e032fda143e7498c778b
+      babel-plugin-add-module-exports: 0.3.3
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-remove-graphql-queries: 2.9.13_gatsby@2.24.2
+      babel-preset-gatsby: 0.5.2_@babel+core@7.10.4+core-js@3.6.5
+      better-opn: 1.0.0
+      better-queue: 3.8.10
+      bluebird: 3.7.2
+      browserslist: 4.13.0
+      cache-manager: 2.11.1
+      cache-manager-fs-hash: 0.0.9
+      chalk: 2.4.2
+      chokidar: 3.4.0
+      common-tags: 1.8.0
+      compression: 1.7.4
+      convert-hrtime: 3.0.0
+      copyfiles: 2.3.0
+      core-js: 3.6.5
+      cors: 2.8.5
+      css-loader: 1.0.1_webpack@4.43.0
+      date-fns: 2.14.0
+      debug: 3.2.6
+      del: 5.1.0
+      detect-port: 1.3.0
+      devcert: 1.1.2
+      dotenv: 8.2.0
+      eslint: 6.8.0
+      eslint-config-react-app: 5.2.1_fbff7b7320d19b77d0de995a556595df
+      eslint-loader: 2.2.1_eslint@6.8.0+webpack@4.43.0
+      eslint-plugin-flowtype: 3.13.0_eslint@6.8.0
+      eslint-plugin-graphql: 3.1.1_graphql@14.7.0
+      eslint-plugin-import: 2.22.0_eslint@6.8.0
+      eslint-plugin-jsx-a11y: 6.3.1_eslint@6.8.0
+      eslint-plugin-react: 7.20.3_eslint@6.8.0
+      eslint-plugin-react-hooks: 1.7.0_eslint@6.8.0
+      event-source-polyfill: 1.0.15
+      express: 4.17.1
+      express-graphql: 0.9.0_graphql@14.7.0
+      fast-levenshtein: 2.0.6
+      file-loader: 1.1.11_webpack@4.43.0
+      fs-exists-cached: 1.0.0
+      fs-extra: 8.1.0
+      gatsby-cli: 2.12.60
+      gatsby-core-utils: 1.3.12
+      gatsby-graphiql-explorer: 0.4.11
+      gatsby-legacy-polyfills: 0.0.2
+      gatsby-link: 2.4.12_3914268316c542370cbb046de235e031
+      gatsby-plugin-page-creator: 2.3.17_gatsby@2.24.2
+      gatsby-plugin-typescript: 2.4.14_gatsby@2.24.2
+      gatsby-react-router-scroll: 3.0.11_3914268316c542370cbb046de235e031
+      gatsby-telemetry: 1.3.19
+      glob: 7.1.6
+      got: 8.3.2
+      graphql: 14.7.0
+      graphql-compose: 6.3.8_graphql@14.7.0
+      graphql-playground-middleware-express: 1.7.18_express@4.17.1
+      hasha: 5.2.0
+      http-proxy: 1.18.1
+      invariant: 2.2.4
+      is-relative: 1.0.0
+      is-relative-url: 3.0.0
+      is-wsl: 2.2.0
+      jest-worker: 24.9.0
+      json-loader: 0.5.7
+      json-stringify-safe: 5.0.1
+      latest-version: 5.1.0
+      lodash: 4.17.19
+      md5-file: 3.2.3
+      meant: 1.0.1
+      micromatch: 3.1.10
+      mime: 2.4.6
+      mini-css-extract-plugin: 0.8.2_webpack@4.43.0
+      mitt: 1.2.0
+      mkdirp: 0.5.5
+      moment: 2.27.0
+      name-all-modules-plugin: 1.0.1
+      normalize-path: 2.1.1
+      null-loader: 3.0.0_webpack@4.43.0
+      opentracing: 0.14.4
+      optimize-css-assets-webpack-plugin: 5.0.3_webpack@4.43.0
+      p-defer: 3.0.0
+      parseurl: 1.3.3
+      physical-cpu-count: 2.0.0
+      pnp-webpack-plugin: 1.6.4_typescript@3.5.3
+      postcss-flexbugs-fixes: 4.2.1
+      postcss-loader: 3.0.0
+      prompts: 2.3.2
+      prop-types: 15.7.2
+      query-string: 6.13.1
+      raw-loader: 0.5.1
+      react: 16.13.1
+      react-dev-utils: 4.2.3
+      react-dom: 16.13.1_react@16.13.1
+      react-error-overlay: 3.0.0
+      react-hot-loader: 4.12.21_react-dom@16.13.1+react@16.13.1
+      react-refresh: 0.7.2
+      redux: 4.0.5
+      redux-thunk: 2.3.0
+      semver: 5.7.1
+      shallow-compare: 1.2.2
+      signal-exit: 3.0.3
+      slugify: 1.4.4
+      socket.io: 2.3.0
+      socket.io-client: 2.3.0
+      st: 2.0.0
+      stack-trace: 0.0.10
+      string-similarity: 1.2.2
+      style-loader: 0.23.1
+      terser-webpack-plugin: 1.4.4_webpack@4.43.0
+      tmp: 0.2.1
+      true-case-path: 2.2.1
+      type-of: 2.0.1
+      url-loader: 1.1.2_webpack@4.43.0
+      util.promisify: 1.0.1
+      uuid: 3.4.0
+      v8-compile-cache: 1.1.2
+      webpack: 4.43.0
+      webpack-dev-middleware: 3.7.2_webpack@4.43.0
+      webpack-dev-server: 3.11.0_webpack@4.43.0
+      webpack-hot-middleware: 2.25.0
+      webpack-merge: 4.2.2
+      webpack-stats-plugin: 0.3.2
+      webpack-virtual-modules: 0.2.2
+      xstate: 4.11.0
+      yaml-loader: 0.6.0
+    dev: false
+    engines:
+      node: '>=10.13.0'
+    hasBin: true
+    peerDependencies:
+      react: ^16.4.2
+      react-dom: ^16.4.2
+      typescript: '*'
+    requiresBuild: true
+    resolution:
+      integrity: sha512-2zhCJZBPRJiUGbFRnCogMY3liBoFdb3+cCmIpp5b4BzGUEm+t+QZPSW34xkV5IE1WNywuIMtpZF6G8xTbuepbA==
+  /gatsby/2.24.2_react-dom@16.13.1+react@16.13.1:
     dependencies:
       '@babel/code-frame': 7.10.4
       '@babel/core': 7.10.4
@@ -7768,7 +7923,6 @@ packages:
       file-loader: 1.1.11_webpack@4.43.0
       fs-exists-cached: 1.0.0
       fs-extra: 8.1.0
-      gatsby: 2.24.2_87c673b4c99150bcbaa42956bba55e13
       gatsby-cli: 2.12.60
       gatsby-core-utils: 1.3.12
       gatsby-graphiql-explorer: 0.4.11
@@ -7843,7 +7997,7 @@ packages:
       util.promisify: 1.0.1
       uuid: 3.4.0
       v8-compile-cache: 1.1.2
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
       webpack-dev-middleware: 3.7.2_webpack@4.43.0
       webpack-dev-server: 3.11.0_webpack@4.43.0
       webpack-hot-middleware: 2.25.0
@@ -7857,168 +8011,8 @@ packages:
       node: '>=10.13.0'
     hasBin: true
     peerDependencies:
-      gatsby: '*'
       react: ^16.4.2
       react-dom: ^16.4.2
-    requiresBuild: true
-    resolution:
-      integrity: sha512-2zhCJZBPRJiUGbFRnCogMY3liBoFdb3+cCmIpp5b4BzGUEm+t+QZPSW34xkV5IE1WNywuIMtpZF6G8xTbuepbA==
-  /gatsby/2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc:
-    dependencies:
-      '@babel/code-frame': 7.10.4
-      '@babel/core': 7.10.4
-      '@babel/parser': 7.10.4
-      '@babel/runtime': 7.10.4
-      '@babel/traverse': 7.10.4
-      '@hapi/joi': 15.1.1
-      '@mikaelkristiansson/domready': 1.0.10
-      '@pieh/friendly-errors-webpack-plugin': 1.7.0-chalk-2_webpack@4.43.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.3.3_d8528028579e0129932d17e99387126e
-      '@reach/router': 1.3.4_react-dom@16.13.1+react@16.13.1
-      '@types/http-proxy': 1.17.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_5a17f289f30f975b48207d0526ec4dc8
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.5.3
-      address: 1.1.2
-      autoprefixer: 9.8.5
-      axios: 0.19.2
-      babel-core: 7.0.0-bridge.0_@babel+core@7.10.4
-      babel-eslint: 10.1.0_eslint@6.8.0
-      babel-loader: 8.1.0_0cfd9791b7d0e032fda143e7498c778b
-      babel-plugin-add-module-exports: 0.3.3
-      babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 2.9.13_gatsby@2.24.2
-      babel-preset-gatsby: 0.5.2_@babel+core@7.10.4+core-js@3.6.5
-      better-opn: 1.0.0
-      better-queue: 3.8.10
-      bluebird: 3.7.2
-      browserslist: 4.13.0
-      cache-manager: 2.11.1
-      cache-manager-fs-hash: 0.0.9
-      chalk: 2.4.2
-      chokidar: 3.4.0
-      common-tags: 1.8.0
-      compression: 1.7.4
-      convert-hrtime: 3.0.0
-      copyfiles: 2.3.0
-      core-js: 3.6.5
-      cors: 2.8.5
-      css-loader: 1.0.1_webpack@4.43.0
-      date-fns: 2.14.0
-      debug: 3.2.6
-      del: 5.1.0
-      detect-port: 1.3.0
-      devcert: 1.1.2
-      dotenv: 8.2.0
-      eslint: 6.8.0
-      eslint-config-react-app: 5.2.1_fbff7b7320d19b77d0de995a556595df
-      eslint-loader: 2.2.1_eslint@6.8.0+webpack@4.43.0
-      eslint-plugin-flowtype: 3.13.0_eslint@6.8.0
-      eslint-plugin-graphql: 3.1.1_graphql@14.7.0
-      eslint-plugin-import: 2.22.0_eslint@6.8.0
-      eslint-plugin-jsx-a11y: 6.3.1_eslint@6.8.0
-      eslint-plugin-react: 7.20.3_eslint@6.8.0
-      eslint-plugin-react-hooks: 1.7.0_eslint@6.8.0
-      event-source-polyfill: 1.0.15
-      express: 4.17.1
-      express-graphql: 0.9.0_graphql@14.7.0
-      fast-levenshtein: 2.0.6
-      file-loader: 1.1.11_webpack@4.43.0
-      fs-exists-cached: 1.0.0
-      fs-extra: 8.1.0
-      gatsby: 2.24.2_d48f8ebf7c6f206e49bdb45b3ebb87cc
-      gatsby-cli: 2.12.60
-      gatsby-core-utils: 1.3.12
-      gatsby-graphiql-explorer: 0.4.11
-      gatsby-legacy-polyfills: 0.0.2
-      gatsby-link: 2.4.12_3914268316c542370cbb046de235e031
-      gatsby-plugin-page-creator: 2.3.17_gatsby@2.24.2
-      gatsby-plugin-typescript: 2.4.14_gatsby@2.24.2
-      gatsby-react-router-scroll: 3.0.11_3914268316c542370cbb046de235e031
-      gatsby-telemetry: 1.3.19
-      glob: 7.1.6
-      got: 8.3.2
-      graphql: 14.7.0
-      graphql-compose: 6.3.8_graphql@14.7.0
-      graphql-playground-middleware-express: 1.7.18_express@4.17.1
-      hasha: 5.2.0
-      http-proxy: 1.18.1
-      invariant: 2.2.4
-      is-relative: 1.0.0
-      is-relative-url: 3.0.0
-      is-wsl: 2.2.0
-      jest-worker: 24.9.0
-      json-loader: 0.5.7
-      json-stringify-safe: 5.0.1
-      latest-version: 5.1.0
-      lodash: 4.17.19
-      md5-file: 3.2.3
-      meant: 1.0.1
-      micromatch: 3.1.10
-      mime: 2.4.6
-      mini-css-extract-plugin: 0.8.2_webpack@4.43.0
-      mitt: 1.2.0
-      mkdirp: 0.5.5
-      moment: 2.27.0
-      name-all-modules-plugin: 1.0.1
-      normalize-path: 2.1.1
-      null-loader: 3.0.0_webpack@4.43.0
-      opentracing: 0.14.4
-      optimize-css-assets-webpack-plugin: 5.0.3_webpack@4.43.0
-      p-defer: 3.0.0
-      parseurl: 1.3.3
-      physical-cpu-count: 2.0.0
-      pnp-webpack-plugin: 1.6.4_typescript@3.5.3
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 3.0.0
-      prompts: 2.3.2
-      prop-types: 15.7.2
-      query-string: 6.13.1
-      raw-loader: 0.5.1
-      react: 16.13.1
-      react-dev-utils: 4.2.3
-      react-dom: 16.13.1_react@16.13.1
-      react-error-overlay: 3.0.0
-      react-hot-loader: 4.12.21_react-dom@16.13.1+react@16.13.1
-      react-refresh: 0.7.2
-      redux: 4.0.5
-      redux-thunk: 2.3.0
-      semver: 5.7.1
-      shallow-compare: 1.2.2
-      signal-exit: 3.0.3
-      slugify: 1.4.4
-      socket.io: 2.3.0
-      socket.io-client: 2.3.0
-      st: 2.0.0
-      stack-trace: 0.0.10
-      string-similarity: 1.2.2
-      style-loader: 0.23.1
-      terser-webpack-plugin: 1.4.4_webpack@4.43.0
-      tmp: 0.2.1
-      true-case-path: 2.2.1
-      type-of: 2.0.1
-      typescript: 3.5.3
-      url-loader: 1.1.2_webpack@4.43.0
-      util.promisify: 1.0.1
-      uuid: 3.4.0
-      v8-compile-cache: 1.1.2
-      webpack: 4.43.0_webpack@4.43.0
-      webpack-dev-middleware: 3.7.2_webpack@4.43.0
-      webpack-dev-server: 3.11.0_webpack@4.43.0
-      webpack-hot-middleware: 2.25.0
-      webpack-merge: 4.2.2
-      webpack-stats-plugin: 0.3.2
-      webpack-virtual-modules: 0.2.2
-      xstate: 4.11.0
-      yaml-loader: 0.6.0
-    dev: false
-    engines:
-      node: '>=10.13.0'
-    hasBin: true
-    peerDependencies:
-      gatsby: '*'
-      react: ^16.4.2
-      react-dom: ^16.4.2
-      typescript: '*'
     requiresBuild: true
     resolution:
       integrity: sha512-2zhCJZBPRJiUGbFRnCogMY3liBoFdb3+cCmIpp5b4BzGUEm+t+QZPSW34xkV5IE1WNywuIMtpZF6G8xTbuepbA==
@@ -10954,7 +10948,7 @@ packages:
       loader-utils: 1.4.0
       normalize-url: 1.9.1
       schema-utils: 1.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -11425,7 +11419,7 @@ packages:
     dependencies:
       loader-utils: 1.4.0
       schema-utils: 1.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     engines:
       node: '>= 8.9.0'
@@ -11648,7 +11642,7 @@ packages:
     dependencies:
       cssnano: 4.1.10
       last-call-webpack-plugin: 3.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     peerDependencies:
       webpack: ^4.0.0
@@ -15327,7 +15321,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
-  /styled-components/5.1.1_479e60ee9c1aa71dc1eb81036e3619dc:
+  /styled-components/5.1.1_react-dom@16.13.1+react@16.13.1:
     dependencies:
       '@babel/helper-module-imports': 7.10.4
       '@babel/traverse': 7.10.4
@@ -15346,7 +15340,6 @@ packages:
       react: '>= 16.8.0'
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
-      styled-components: '*'
     resolution:
       integrity: sha512-1ps8ZAYu2Husx+Vz8D+MvXwEwvMwFv+hqqUwhNlDN5ybg6A+3xyW1ECrAgywhvXapNfXiz79jJyU0x22z0FFTg==
   /stylehacks/4.0.3:
@@ -15571,7 +15564,7 @@ packages:
       serialize-javascript: 3.1.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -16341,7 +16334,7 @@ packages:
       loader-utils: 1.4.0
       mime: 2.4.6
       schema-utils: 1.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
     dev: false
     engines:
       node: '>= 6.9.0'
@@ -16600,7 +16593,7 @@ packages:
       mime: 2.4.6
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
       webpack-log: 2.0.0
     dev: false
     engines:
@@ -16640,7 +16633,7 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 6.1.0
       url: 0.11.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.43.0
       webpack-dev-middleware: 3.7.2_webpack@4.43.0
       webpack-log: 2.0.0
       ws: 6.2.1
@@ -16707,7 +16700,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
-  /webpack/4.43.0_webpack@4.43.0:
+  /webpack/4.43.0:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -16736,8 +16729,6 @@ packages:
     engines:
       node: '>=6.11.5'
     hasBin: true
-    peerDependencies:
-      webpack: '*'
     resolution:
       integrity: sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
   /websocket-driver/0.6.5:

--- a/apps/storybook-html/pnpm-lock.yaml
+++ b/apps/storybook-html/pnpm-lock.yaml
@@ -9,7 +9,7 @@ devDependencies:
   '@storybook/addon-storysource': 5.2.6_react-dom@16.12.0+react@16.12.0
   '@storybook/html': 5.2.6_857a459f32e08451cc6a8fb9b43751b7
   babel-loader: 8.0.6_@babel+core@7.7.2
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.5.5:
     dependencies:
@@ -1163,7 +1163,7 @@ packages:
       unfetch: 4.1.0
       url-loader: 2.2.0_file-loader@3.0.1+webpack@4.41.2
       util-deprecate: 1.0.2
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
       webpack-dev-middleware: 3.7.2_webpack@4.41.2
       webpack-hot-middleware: 2.25.0
     dev: true
@@ -1488,6 +1488,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+  /abbrev/1.1.1:
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
   /accepts/1.3.7:
     dependencies:
       mime-types: 2.1.25
@@ -2644,7 +2649,7 @@ packages:
   /corejs-upgrade-webpack-plugin/2.2.0:
     dependencies:
       resolve-from: 5.0.0
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
     dev: true
     resolution:
       integrity: sha512-J0QMp9GNoiw91Kj/dkIQFZeiCXgXoja/Wlht1SPybxerBWh4NCmb0pOgCv61lrlQZETwvVVfAFAA3IqoEO9aqQ==
@@ -2773,7 +2778,7 @@ packages:
       postcss-modules-values: 3.0.0
       postcss-value-parser: 4.0.2
       schema-utils: 2.5.0
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
     dev: true
     engines:
       node: '>= 8.9.0'
@@ -2833,6 +2838,13 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  /deep-extend/0.6.0:
+    dev: true
+    engines:
+      node: '>=4.0.0'
+    optional: true
+    resolution:
+      integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
   /deep-object-diff/1.1.0:
     dev: true
     resolution:
@@ -2896,6 +2908,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+  /detect-libc/1.0.3:
+    dev: true
+    engines:
+      node: '>=0.10'
+    hasBin: true
+    optional: true
+    resolution:
+      integrity: sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
   /detect-port-alt/1.1.6:
     dependencies:
       address: 1.1.2
@@ -3004,7 +3024,7 @@ packages:
   /dotenv-webpack/1.7.0_webpack@4.41.2:
     dependencies:
       dotenv-defaults: 1.0.2
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
     dev: true
     peerDependencies:
       webpack: ^1 || ^2 || ^3 || ^4
@@ -3454,7 +3474,7 @@ packages:
     dependencies:
       loader-utils: 1.2.3
       schema-utils: 1.0.0
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
     dev: true
     engines:
       node: '>= 6.9.0'
@@ -3636,6 +3656,13 @@ packages:
       node: '>=6 <7 || >=8'
     resolution:
       integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  /fs-minipass/1.2.7:
+    dependencies:
+      minipass: 2.9.0
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
   /fs-write-stream-atomic/1.0.10:
     dependencies:
       graceful-fs: 4.2.3
@@ -3654,11 +3681,14 @@ packages:
       - node-pre-gyp
     dependencies:
       nan: 2.14.0
+      node-pre-gyp: 0.12.0
     deprecated: 'One of your dependencies needs to upgrade to fsevents v2: 1) Proper nodejs v10+ support 2) No more fetching binaries from AWS, smaller package size'
     dev: true
     engines:
       node: '>=4.0'
     optional: true
+    os:
+      - darwin
     requiresBuild: true
     resolution:
       integrity: sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
@@ -3986,7 +4016,7 @@ packages:
       pretty-error: 2.1.1
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
     dev: true
     engines:
       node: '>=6.9'
@@ -4061,6 +4091,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-xg7taebY/bazEEofy8ocGS3FtQE=
+  /ignore-walk/3.0.3:
+    dependencies:
+      minimatch: 3.0.4
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
   /ignore/3.3.10:
     dev: true
     resolution:
@@ -4886,6 +4923,21 @@ packages:
     dev: true
     resolution:
       integrity: sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  /minipass/2.9.0:
+    dependencies:
+      safe-buffer: 5.2.0
+      yallist: 3.1.1
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  /minizlib/1.3.3:
+    dependencies:
+      minipass: 2.9.0
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   /mississippi/3.0.0:
     dependencies:
       concat-stream: 1.6.2
@@ -4969,6 +5021,18 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  /needle/2.5.2:
+    dependencies:
+      debug: 3.2.6
+      iconv-lite: 0.4.24
+      sax: 1.2.4
+    dev: true
+    engines:
+      node: '>= 4.4.x'
+    hasBin: true
+    optional: true
+    resolution:
+      integrity: sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==
   /negotiator/0.6.2:
     dev: true
     engines:
@@ -5030,12 +5094,38 @@ packages:
     dev: true
     resolution:
       integrity: sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
+  /node-pre-gyp/0.12.0:
+    dependencies:
+      detect-libc: 1.0.3
+      mkdirp: 0.5.1
+      needle: 2.5.2
+      nopt: 4.0.3
+      npm-packlist: 1.4.8
+      npmlog: 4.1.2
+      rc: 1.2.8
+      rimraf: 2.7.1
+      semver: 5.7.1
+      tar: 4.4.13
+    dev: true
+    hasBin: true
+    optional: true
+    resolution:
+      integrity: sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
   /node-releases/1.1.40:
     dependencies:
       semver: 6.3.0
     dev: true
     resolution:
       integrity: sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==
+  /nopt/4.0.3:
+    dependencies:
+      abbrev: 1.1.1
+      osenv: 0.1.5
+    dev: true
+    hasBin: true
+    optional: true
+    resolution:
+      integrity: sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
   /normalize-path/2.1.1:
     dependencies:
       remove-trailing-separator: 1.1.0
@@ -5056,6 +5146,27 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+  /npm-bundled/1.1.1:
+    dependencies:
+      npm-normalize-package-bin: 1.0.1
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  /npm-normalize-package-bin/1.0.1:
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+  /npm-packlist/1.4.8:
+    dependencies:
+      ignore-walk: 3.0.3
+      npm-bundled: 1.1.1
+      npm-normalize-package-bin: 1.0.1
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
   /npm-run-path/2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -5223,12 +5334,27 @@ packages:
     dev: true
     resolution:
       integrity: sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
+  /os-homedir/1.0.2:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    optional: true
+    resolution:
+      integrity: sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
   /os-tmpdir/1.0.2:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+  /osenv/0.1.5:
+    dependencies:
+      os-homedir: 1.0.2
+      os-tmpdir: 1.0.2
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
   /p-finally/1.0.0:
     dev: true
     engines:
@@ -5793,7 +5919,7 @@ packages:
     dependencies:
       loader-utils: 1.2.3
       schema-utils: 1.0.0
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
     dev: true
     engines:
       node: '>= 6.9.0'
@@ -5801,6 +5927,17 @@ packages:
       webpack: ^4.3.0
     resolution:
       integrity: sha512-kZnO5MoIyrojfrPWqrhFNLZemIAX8edMOCp++yC5RKxzFB3m92DqKNhKlU6+FvpOhWtvyh3jOaD7J6/9tpdIKg==
+  /rc/1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.5
+      minimist: 1.2.0
+      strip-json-comments: 2.0.1
+    dev: true
+    hasBin: true
+    optional: true
+    resolution:
+      integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
   /react-clientside-effect/1.2.2_react@16.12.0:
     dependencies:
       '@babel/runtime': 7.7.2
@@ -6370,6 +6507,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+  /sax/1.2.4:
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
   /scheduler/0.18.0:
     dependencies:
       loose-envify: 1.4.0
@@ -6827,6 +6969,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+  /strip-json-comments/2.0.1:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    optional: true
+    resolution:
+      integrity: sha1-PFMZQukIwml8DsNEhYwobHygpgo=
   /style-loader/0.23.1:
     dependencies:
       loader-utils: 1.2.3
@@ -6879,6 +7028,21 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
+  /tar/4.4.13:
+    dependencies:
+      chownr: 1.1.3
+      fs-minipass: 1.2.7
+      minipass: 2.9.0
+      minizlib: 1.3.3
+      mkdirp: 0.5.1
+      safe-buffer: 5.2.0
+      yallist: 3.1.1
+    dev: true
+    engines:
+      node: '>=4.5'
+    optional: true
+    resolution:
+      integrity: sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
   /telejson/3.1.0:
     dependencies:
       '@types/is-function': 1.0.0
@@ -6909,7 +7073,7 @@ packages:
       serialize-javascript: 1.9.1
       source-map: 0.6.1
       terser: 4.4.0
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -7189,13 +7353,16 @@ packages:
       loader-utils: 1.2.3
       mime: 2.4.4
       schema-utils: 2.5.0
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
     dev: true
     engines:
       node: '>= 8.9.0'
     peerDependencies:
       file-loader: '*'
       webpack: ^4.0.0
+    peerDependenciesMeta:
+      file-loader:
+        optional: true
     resolution:
       integrity: sha512-G8nk3np8ZAnwhHXas1JxJEwJyQdqFXAKJehfgZ/XrC48volFBRtO+FIKtF2u0Ma3bw+4vnDVjHPAQYlF9p2vsw==
   /url-parse/1.4.7:
@@ -7292,7 +7459,7 @@ packages:
       mime: 2.4.4
       mkdirp: 0.5.1
       range-parser: 1.2.1
-      webpack: 4.41.2_webpack@4.41.2
+      webpack: 4.41.2
       webpack-log: 2.0.0
     dev: true
     engines:
@@ -7326,7 +7493,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  /webpack/4.41.2_webpack@4.41.2:
+  /webpack/4.41.2:
     dependencies:
       '@webassemblyjs/ast': 1.8.5
       '@webassemblyjs/helper-module-context': 1.8.5
@@ -7355,8 +7522,6 @@ packages:
     engines:
       node: '>=6.11.5'
     hasBin: true
-    peerDependencies:
-      webpack: '*'
     resolution:
       integrity: sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==
   /websocket-driver/0.7.3:

--- a/apps/storybook-react/pnpm-lock.yaml
+++ b/apps/storybook-react/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
   babel-runtime: 6.26.0
   react-dom: 16.13.1_react@16.13.1
   react-hook-form: 5.7.2_react@16.13.1
-  styled-components: 5.1.1_9a4a3b3ed34a772b68db523825332f5f
+  styled-components: 5.1.1_988f4f9157fb8e0dba6a9870bbd1cb60
 devDependencies:
   '@babel/core': 7.10.2
   '@babel/plugin-transform-react-jsx': 7.10.1_@babel+core@7.10.2
@@ -26,7 +26,7 @@ devDependencies:
   babel-loader: 8.1.0_@babel+core@7.10.2
   react: 16.13.1
   react-is: 16.13.1
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.10.1:
     dependencies:
@@ -3570,32 +3570,6 @@ packages:
       global: 4.4.0
     resolution:
       integrity: sha512-IY/p0f9XxfHZWVkjeIYOwF6xuonjgmZ9mYPy7Ks47zzDFrUe0/g5cqfBJBUj1YOqlANbF6XCO8YiKXjkE70olw==
-  /@storybook/components/6.0.27:
-    dependencies:
-      '@storybook/client-logger': 6.0.27
-      '@storybook/csf': 0.0.1
-      '@storybook/theming': 6.0.27_react-dom@16.14.0+react@16.14.0
-      '@types/overlayscrollbars': 1.12.0
-      '@types/react-color': 3.0.4
-      '@types/react-syntax-highlighter': 11.0.4
-      core-js: 3.6.5
-      fast-deep-equal: 3.1.3
-      global: 4.4.0
-      lodash: 4.17.20
-      markdown-to-jsx: 6.11.4_react@16.14.0
-      memoizerific: 1.11.3
-      overlayscrollbars: 1.13.0
-      polished: 3.6.7
-      popper.js: 1.16.1
-      react: 16.14.0
-      react-color: 2.18.1_react@16.14.0
-      react-dom: 16.14.0_react@16.14.0
-      react-popper-tooltip: 2.11.1_react-dom@16.14.0+react@16.14.0
-      react-syntax-highlighter: 12.2.1_react@16.14.0
-      react-textarea-autosize: 8.2.0_react@16.14.0
-      ts-dedent: 1.2.0
-    resolution:
-      integrity: sha512-CnWgr/jgo7/XU+s7jhpNYevUivEsJccMRxuyOI+Ry8ndnoheifT4fp4+O5OaOeC08hStlPyad85LdTbOKigt7g==
   /@storybook/components/6.0.27_@types+react@16.9.54:
     dependencies:
       '@storybook/client-logger': 6.0.27
@@ -3666,7 +3640,7 @@ packages:
       '@storybook/router': 6.0.27_react-dom@16.13.1+react@16.13.1
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.0.27_react-dom@16.13.1+react@16.13.1
-      '@storybook/ui': 6.0.27
+      '@storybook/ui': 6.0.27_@types+react@16.9.54
       '@types/glob-base': 0.3.0
       '@types/micromatch': 4.0.1
       '@types/node-fetch': 2.5.7
@@ -3727,7 +3701,7 @@ packages:
       unfetch: 4.2.0
       url-loader: 4.1.1_file-loader@6.1.1+webpack@4.44.1
       util-deprecate: 1.0.2
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-dev-middleware: 3.7.2_webpack@4.44.1
       webpack-hot-middleware: 2.25.0
       webpack-virtual-modules: 0.2.2
@@ -3782,7 +3756,7 @@ packages:
       react-dom: 16.13.1_react@16.13.1
       regenerator-runtime: 0.13.7
       ts-dedent: 1.1.1
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     dev: false
     engines:
       node: '>=8.0.0'
@@ -3931,14 +3905,14 @@ packages:
       react-dom: '*'
     resolution:
       integrity: sha512-6jm7tJuGUZzSftRQce776fS9/Pt5OAypmaTOj035z3RWswoQ1pj8olXVnSNxSt6jyYoWrJru8kiCl7w78q0rPg==
-  /@storybook/ui/6.0.27:
+  /@storybook/ui/6.0.27_@types+react@16.9.54:
     dependencies:
       '@emotion/core': 10.0.35_react@16.14.0
       '@storybook/addons': 6.0.27_react-dom@16.14.0+react@16.14.0
       '@storybook/api': 6.0.27_react-dom@16.14.0
       '@storybook/channels': 6.0.27
       '@storybook/client-logger': 6.0.27
-      '@storybook/components': 6.0.27
+      '@storybook/components': 6.0.27_@types+react@16.9.54
       '@storybook/core-events': 6.0.27
       '@storybook/router': 6.0.27_react-dom@16.14.0+react@16.14.0
       '@storybook/semver': 7.3.2
@@ -3964,6 +3938,8 @@ packages:
       regenerator-runtime: 0.13.7
       resolve-from: 5.0.0
       store2: 2.12.0
+    peerDependencies:
+      '@types/react': '*'
     resolution:
       integrity: sha512-hxTeoe3QTSJ4P9EI8Kc8hroxem5OXEYq77zKq8XxgtOKhVzhQVaA+c4p/t6Z68+yK693CCp07+6QvGo++EQEHw==
   /@svgr/babel-plugin-add-jsx-attribute/5.4.0:
@@ -4428,7 +4404,7 @@ packages:
       chalk: 2.4.2
       strip-ansi: 4.0.0
       text-table: 0.2.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-log: 1.2.0
     dev: false
     engines:
@@ -4842,7 +4818,7 @@ packages:
       mkdirp: 0.5.5
       pify: 4.0.1
       schema-utils: 2.7.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     engines:
       node: '>= 6.9'
     peerDependencies:
@@ -5016,7 +4992,7 @@ packages:
       '@babel/helper-module-imports': 7.10.1
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.15
-      styled-components: 5.1.1_9a4a3b3ed34a772b68db523825332f5f
+      styled-components: 5.1.1_988f4f9157fb8e0dba6a9870bbd1cb60
     dev: false
     peerDependencies:
       styled-components: '>= 2'
@@ -5944,7 +5920,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.1
       semver: 6.3.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     engines:
       node: '>= 8.9.0'
     peerDependencies:
@@ -6262,7 +6238,7 @@ packages:
   /dotenv-webpack/1.8.0_webpack@4.44.1:
     dependencies:
       dotenv-defaults: 1.1.1
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     peerDependencies:
       webpack: ^1 || ^2 || ^3 || ^4
     resolution:
@@ -6769,7 +6745,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 3.0.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     engines:
       node: '>= 10.13.0'
     peerDependencies:
@@ -7399,7 +7375,7 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     engines:
       node: '>=6.9'
     peerDependencies:
@@ -9517,7 +9493,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 3.0.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     engines:
       node: '>= 10.13.0'
     peerDependencies:
@@ -9832,16 +9808,6 @@ packages:
       use-latest: 1.1.0_7a81abeb4682dcd740958f1c62af662f
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0
-    resolution:
-      integrity: sha512-grajUlVbkx6VdtSxCgzloUIphIZF5bKr21OYMceWPKkniy7H0mRAT/AXPrRtObAe+zUePnNlBwUc4ivVjUGIjw==
-  /react-textarea-autosize/8.2.0_react@16.14.0:
-    dependencies:
-      '@babel/runtime': 7.12.1
-      react: 16.14.0
-      use-composed-ref: 1.0.0_react@16.14.0
-      use-latest: 1.1.0_react@16.14.0
-    peerDependencies:
       react: ^16.8.0
     resolution:
       integrity: sha512-grajUlVbkx6VdtSxCgzloUIphIZF5bKr21OYMceWPKkniy7H0mRAT/AXPrRtObAe+zUePnNlBwUc4ivVjUGIjw==
@@ -10729,7 +10695,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 2.7.1
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     engines:
       node: '>= 8.9.0'
     peerDependencies:
@@ -10742,7 +10708,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
-  /styled-components/5.1.1_9a4a3b3ed34a772b68db523825332f5f:
+  /styled-components/5.1.1_988f4f9157fb8e0dba6a9870bbd1cb60:
     dependencies:
       '@babel/helper-module-imports': 7.10.1
       '@babel/traverse': 7.10.1
@@ -10762,7 +10728,6 @@ packages:
       react: '>= 16.8.0'
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
-      styled-components: '*'
     requiresBuild: true
     resolution:
       integrity: sha512-1ps8ZAYu2Husx+Vz8D+MvXwEwvMwFv+hqqUwhNlDN5ybg6A+3xyW1ECrAgywhvXapNfXiz79jJyU0x22z0FFTg==
@@ -10876,7 +10841,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     engines:
@@ -10895,7 +10860,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-sources: 1.4.3
     engines:
       node: '>= 10.13.0'
@@ -11289,7 +11254,7 @@ packages:
       loader-utils: 2.0.0
       mime-types: 2.1.27
       schema-utils: 3.0.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     engines:
       node: '>= 10.13.0'
     peerDependencies:
@@ -11326,34 +11291,11 @@ packages:
         optional: true
     resolution:
       integrity: sha512-JMwJ7Vd86NwAt1jH7q+OIozZSIxA4ND0fx6AsOe2q1H8ooBUp5aN6DvVCqZiIaYU6JaMRJGyR0FO7EBCIsb/Rg==
-  /use-isomorphic-layout-effect/1.0.0_react@16.14.0:
-    dependencies:
-      react: 16.14.0
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    resolution:
-      integrity: sha512-JMwJ7Vd86NwAt1jH7q+OIozZSIxA4ND0fx6AsOe2q1H8ooBUp5aN6DvVCqZiIaYU6JaMRJGyR0FO7EBCIsb/Rg==
   /use-latest/1.1.0_7a81abeb4682dcd740958f1c62af662f:
     dependencies:
       '@types/react': 16.9.54
       react: 16.14.0
       use-isomorphic-layout-effect: 1.0.0_7a81abeb4682dcd740958f1c62af662f
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    resolution:
-      integrity: sha512-gF04d0ZMV3AMB8Q7HtfkAWe+oq1tFXP6dZKwBHQF5nVXtGsh2oAYeeqma5ZzxtlpOcW8Ro/tLcfmEodjDeqtuw==
-  /use-latest/1.1.0_react@16.14.0:
-    dependencies:
-      react: 16.14.0
-      use-isomorphic-layout-effect: 1.0.0_react@16.14.0
     peerDependencies:
       '@types/react': '*'
       react: ^16.8.0
@@ -11479,7 +11421,7 @@ packages:
       mime: 2.4.6
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-log: 2.0.0
     engines:
       node: '>= 6'
@@ -11525,7 +11467,7 @@ packages:
       debug: 3.2.6
     resolution:
       integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
-  /webpack/4.44.1_webpack@4.44.1:
+  /webpack/4.44.1:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -11549,13 +11491,11 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.44.1
       watchpack: 1.7.4
-      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
     engines:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
-      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/libraries/core-react/README.md
+++ b/libraries/core-react/README.md
@@ -62,7 +62,7 @@ npm install @equinor/eds-core-react styled-components
 ## Usage
 
 ```jsx
-import React from 'react'
+import * as React from 'react'
 import { render } from 'react-dom'
 import { Button, Typography } from '@equinor/eds-core-react'
 

--- a/libraries/core-react/pnpm-lock.yaml
+++ b/libraries/core-react/pnpm-lock.yaml
@@ -32,11 +32,11 @@ devDependencies:
   react-dom: 16.13.1_react@16.13.1
   rollup: 2.15.0
   rollup-plugin-typescript2: 0.27.2_rollup@2.15.0+typescript@4.0.2
-  styled-components: 4.4.1_4f54128445bc6f13bd713dcb3d91e98e
+  styled-components: 4.4.1_react-dom@16.13.1+react@16.13.1
   ts-jest: 26.3.0_jest@26.0.1+typescript@4.0.2
   tslib: 2.0.1
   typescript: 4.0.2
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/cli/7.10.1_@babel+core@7.10.2:
     dependencies:
@@ -1303,7 +1303,7 @@ packages:
       jest-haste-map: 26.0.1
       jest-message-util: 26.0.1
       jest-regex-util: 26.0.0
-      jest-resolve: 26.0.1_jest-resolve@26.0.1
+      jest-resolve: 26.0.1
       jest-resolve-dependencies: 26.0.1
       jest-runner: 26.0.1
       jest-runtime: 26.0.1
@@ -1371,7 +1371,7 @@ packages:
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
       jest-haste-map: 26.0.1
-      jest-resolve: 26.0.1_jest-resolve@26.0.1
+      jest-resolve: 26.0.1
       jest-util: 26.0.1
       jest-worker: 26.0.0
       slash: 3.0.0
@@ -2024,7 +2024,7 @@ packages:
       '@babel/helper-module-imports': 7.10.1
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.15
-      styled-components: 4.4.1_4f54128445bc6f13bd713dcb3d91e98e
+      styled-components: 4.4.1_react-dom@16.13.1+react@16.13.1
     dev: true
     peerDependencies:
       styled-components: '>= 2'
@@ -3503,7 +3503,7 @@ packages:
       jest-get-type: 26.0.0
       jest-jasmine2: 26.0.1
       jest-regex-util: 26.0.0
-      jest-resolve: 26.0.1_jest-resolve@26.0.1
+      jest-resolve: 26.0.1
       jest-util: 26.0.1
       jest-validate: 26.0.1
       micromatch: 4.0.2
@@ -3693,7 +3693,7 @@ packages:
       integrity: sha512-MpYTBqycuPYSY6xKJognV7Ja46/TeRbAZept987Zp+tuJvMN0YBWyyhG9mXyYQaU3SBI0TUlSaO5L3p49agw7Q==
   /jest-pnp-resolver/1.2.1_jest-resolve@26.0.1:
     dependencies:
-      jest-resolve: 26.0.1_jest-resolve@26.0.1
+      jest-resolve: 26.0.1
     dev: true
     engines:
       node: '>=6'
@@ -3720,7 +3720,7 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-9d5/RS/ft0vB/qy7jct/qAhzJsr6fRQJyGAFigK3XD4hf9kIbEH5gks4t4Z7kyMRhowU6HWm/o8ILqhaHdSqLw==
-  /jest-resolve/26.0.1_jest-resolve@26.0.1:
+  /jest-resolve/26.0.1:
     dependencies:
       '@jest/types': 26.0.1
       chalk: 4.0.0
@@ -3733,8 +3733,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    peerDependencies:
-      jest-resolve: '*'
     resolution:
       integrity: sha512-6jWxk0IKZkPIVTvq6s72RH735P8f9eCJW3IM5CX/SJFeKq1p2cZx0U49wf/SdMlhaB/anann5J2nCJj6HrbezQ==
   /jest-runner/26.0.1:
@@ -3752,7 +3750,7 @@ packages:
       jest-jasmine2: 26.0.1
       jest-leak-detector: 26.0.1
       jest-message-util: 26.0.1
-      jest-resolve: 26.0.1_jest-resolve@26.0.1
+      jest-resolve: 26.0.1
       jest-runtime: 26.0.1
       jest-util: 26.0.1
       jest-worker: 26.0.0
@@ -3784,7 +3782,7 @@ packages:
       jest-message-util: 26.0.1
       jest-mock: 26.0.1
       jest-regex-util: 26.0.0
-      jest-resolve: 26.0.1_jest-resolve@26.0.1
+      jest-resolve: 26.0.1
       jest-snapshot: 26.0.1
       jest-util: 26.0.1
       jest-validate: 26.0.1
@@ -3817,7 +3815,7 @@ packages:
       jest-get-type: 26.0.0
       jest-matcher-utils: 26.0.1
       jest-message-util: 26.0.1
-      jest-resolve: 26.0.1_jest-resolve@26.0.1
+      jest-resolve: 26.0.1
       make-dir: 3.1.0
       natural-compare: 1.4.0
       pretty-format: 26.0.1
@@ -3830,7 +3828,7 @@ packages:
   /jest-styled-components/6.3.4_styled-components@4.4.1:
     dependencies:
       css: 2.2.4
-      styled-components: 4.4.1_4f54128445bc6f13bd713dcb3d91e98e
+      styled-components: 4.4.1_react-dom@16.13.1+react@16.13.1
     dev: true
     peerDependencies:
       styled-components: ^2 || ^3 || ^4
@@ -5332,7 +5330,7 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
-  /styled-components/4.4.1_4f54128445bc6f13bd713dcb3d91e98e:
+  /styled-components/4.4.1_react-dom@16.13.1+react@16.13.1:
     dependencies:
       '@babel/helper-module-imports': 7.10.1
       '@babel/traverse': 7.10.1
@@ -5353,7 +5351,6 @@ packages:
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
-      styled-components: '*'
     requiresBuild: true
     resolution:
       integrity: sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==

--- a/libraries/core-react/src/Accordion/Accordion.test.tsx
+++ b/libraries/core-react/src/Accordion/Accordion.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Accordion/Accordion.tsx
+++ b/libraries/core-react/src/Accordion/Accordion.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useMemo, ReactElement, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, useMemo, ReactElement, HTMLAttributes } from 'react'
 import createId from 'lodash/uniqueId'
 import type { AccordionProps } from './Accordion.types'
 

--- a/libraries/core-react/src/Accordion/AccordionHeader.tsx
+++ b/libraries/core-react/src/Accordion/AccordionHeader.tsx
@@ -1,9 +1,5 @@
-import React, {
-  forwardRef,
-  HTMLAttributes,
-  isValidElement,
-  ReactElement,
-} from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes, isValidElement, ReactElement } from 'react'
 import styled from 'styled-components'
 import type { CSSObject } from 'styled-components'
 // eslint-disable-next-line camelcase

--- a/libraries/core-react/src/Accordion/AccordionHeaderTitle.tsx
+++ b/libraries/core-react/src/Accordion/AccordionHeaderTitle.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { accordion as tokens } from './Accordion.tokens'
 

--- a/libraries/core-react/src/Accordion/AccordionItem.tsx
+++ b/libraries/core-react/src/Accordion/AccordionItem.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   useState,
   useEffect,

--- a/libraries/core-react/src/Accordion/AccordionPanel.tsx
+++ b/libraries/core-react/src/Accordion/AccordionPanel.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { accordion as tokens } from './Accordion.tokens'
 

--- a/libraries/core-react/src/Avatar/Avatar.test.tsx
+++ b/libraries/core-react/src/Avatar/Avatar.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Avatar/Avatar.tsx
+++ b/libraries/core-react/src/Avatar/Avatar.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { avatar as tokens } from './Avatar.tokens'
 

--- a/libraries/core-react/src/Banner/Banner.test.tsx
+++ b/libraries/core-react/src/Banner/Banner.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Banner/Banner.tsx
+++ b/libraries/core-react/src/Banner/Banner.tsx
@@ -1,4 +1,5 @@
-import React, { FC, HTMLAttributes, ReactNode } from 'react'
+import * as React from 'react'
+import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import { banner as tokens } from './Banner.tokens'
 import { Divider } from '../Divider'

--- a/libraries/core-react/src/Banner/BannerActions.tsx
+++ b/libraries/core-react/src/Banner/BannerActions.tsx
@@ -1,4 +1,5 @@
-import React, { FC, HTMLAttributes, ReactNode } from 'react'
+import * as React from 'react'
+import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import { banner as tokens } from './Banner.tokens'
 

--- a/libraries/core-react/src/Banner/BannerIcon.tsx
+++ b/libraries/core-react/src/Banner/BannerIcon.tsx
@@ -1,4 +1,5 @@
-import React, { FC, HTMLAttributes, ReactNode } from 'react'
+import * as React from 'react'
+import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import { banner as tokens } from './Banner.tokens'
 import { Icon } from '../Icon'

--- a/libraries/core-react/src/Banner/BannerMessage.tsx
+++ b/libraries/core-react/src/Banner/BannerMessage.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react'
+import * as React from 'react'
+import { FC } from 'react'
 import styled from 'styled-components'
 import { Typography } from '../Typography'
 import { TypographyProps } from '../Typography/Typography'

--- a/libraries/core-react/src/Breadcrumbs/Breadcrumb.tsx
+++ b/libraries/core-react/src/Breadcrumbs/Breadcrumb.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { Typography } from '../Typography'
 import { Tooltip } from '../Tooltip'

--- a/libraries/core-react/src/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/libraries/core-react/src/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/libraries/core-react/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   useState,
   Fragment,

--- a/libraries/core-react/src/Button/Button.test.tsx
+++ b/libraries/core-react/src/Button/Button.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Button/Button.tsx
+++ b/libraries/core-react/src/Button/Button.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, ElementType, ButtonHTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, ElementType, ButtonHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { button, Button as ButtonType, ButtonGroups } from './Button.tokens'
 import { typographyTemplate } from '../_common/templates'

--- a/libraries/core-react/src/Card/Card.test.tsx
+++ b/libraries/core-react/src/Card/Card.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Card/Card.tsx
+++ b/libraries/core-react/src/Card/Card.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { card as tokens } from './Card.tokens'
 import { spacingsTemplate } from '../_common/templates'

--- a/libraries/core-react/src/Card/CardActions.tsx
+++ b/libraries/core-react/src/Card/CardActions.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { Typography } from '../Typography'
 

--- a/libraries/core-react/src/Card/CardHeader.tsx
+++ b/libraries/core-react/src/Card/CardHeader.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 import { card as tokens } from './Card.tokens'

--- a/libraries/core-react/src/Card/CardHeaderTitle.tsx
+++ b/libraries/core-react/src/Card/CardHeaderTitle.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 export type CardHeaderTitleProps = HTMLAttributes<HTMLDivElement>

--- a/libraries/core-react/src/Card/CardMedia.tsx
+++ b/libraries/core-react/src/Card/CardMedia.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 
 import { card as tokens } from './Card.tokens'

--- a/libraries/core-react/src/Chip/Chip.test.tsx
+++ b/libraries/core-react/src/Chip/Chip.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Chip/Chip.tsx
+++ b/libraries/core-react/src/Chip/Chip.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { Icon } from './Icon'
 import { chip as tokens } from './Chip.tokens'

--- a/libraries/core-react/src/Dialog/Actions.tsx
+++ b/libraries/core-react/src/Dialog/Actions.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react'
+import * as React from 'react'
+import { forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 import { dialog as tokens } from './Dialog.tokens'
 

--- a/libraries/core-react/src/Dialog/CustomContent.tsx
+++ b/libraries/core-react/src/Dialog/CustomContent.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, Fragment, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, Fragment, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { Divider } from '../Divider'
 import { typographyTemplate } from '../_common/templates'

--- a/libraries/core-react/src/Dialog/Dialog.tsx
+++ b/libraries/core-react/src/Dialog/Dialog.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react'
+import * as React from 'react'
+import { forwardRef } from 'react'
 import styled from 'styled-components'
 import { typographyTemplate } from '../_common/templates'
 import { dialog as tokens } from './Dialog.tokens'

--- a/libraries/core-react/src/Dialog/Title.tsx
+++ b/libraries/core-react/src/Dialog/Title.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, Fragment } from 'react'
+import * as React from 'react'
+import { forwardRef, Fragment } from 'react'
 import styled, { css } from 'styled-components'
 import { Divider } from '../Divider'
 import { typographyTemplate } from '../_common/templates'

--- a/libraries/core-react/src/Divider/Divider.test.tsx
+++ b/libraries/core-react/src/Divider/Divider.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Divider/Divider.tsx
+++ b/libraries/core-react/src/Divider/Divider.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { divider as tokens } from './Divider.tokens'
 

--- a/libraries/core-react/src/Icon/Icon.test.tsx
+++ b/libraries/core-react/src/Icon/Icon.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Icon/Icon.tsx
+++ b/libraries/core-react/src/Icon/Icon.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, Ref, SVGProps } from 'react'
+import * as React from 'react'
+import { forwardRef, Ref, SVGProps } from 'react'
 import styled from 'styled-components'
 import { get } from './library'
 import type { IconData } from '@equinor/eds-icons'

--- a/libraries/core-react/src/List/List.test.tsx
+++ b/libraries/core-react/src/List/List.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/List/List.tsx
+++ b/libraries/core-react/src/List/List.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes, ElementType } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes, ElementType } from 'react'
 import styled, { css } from 'styled-components'
 import { list as tokens } from './List.tokens'
 import { typographyTemplate } from '../_common/templates'

--- a/libraries/core-react/src/List/ListItem.tsx
+++ b/libraries/core-react/src/List/ListItem.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react'
+import * as React from 'react'
+import { forwardRef } from 'react'
 
 export type ListItemProps = React.HTMLAttributes<HTMLLIElement>
 

--- a/libraries/core-react/src/Menu/Menu.context.tsx
+++ b/libraries/core-react/src/Menu/Menu.context.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useContext, ReactNode, MouseEvent } from 'react'
+import * as React from 'react'
+import { useState, useContext, ReactNode, MouseEvent } from 'react'
 
 export type State = {
   focusedIndex: number

--- a/libraries/core-react/src/Menu/Menu.test.tsx
+++ b/libraries/core-react/src/Menu/Menu.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen, fireEvent } from './test-utils'
 import '@testing-library/jest-dom'
 import '@testing-library/jest-dom/extend-expect'

--- a/libraries/core-react/src/Menu/Menu.tsx
+++ b/libraries/core-react/src/Menu/Menu.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, ReactNode, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { useEffect, useRef, ReactNode, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { useMenu } from './Menu.context'
 import { Paper } from '../Paper'

--- a/libraries/core-react/src/Menu/MenuItem.tsx
+++ b/libraries/core-react/src/Menu/MenuItem.tsx
@@ -1,4 +1,5 @@
-import React, { MouseEvent } from 'react'
+import * as React from 'react'
+import { MouseEvent } from 'react'
 import styled, { css } from 'styled-components'
 import { menu as tokens } from './Menu.tokens'
 import { templates, useCombinedRefs } from '../_common'

--- a/libraries/core-react/src/Menu/MenuList.tsx
+++ b/libraries/core-react/src/Menu/MenuList.tsx
@@ -1,9 +1,5 @@
-import React, {
-  useEffect,
-  ReactElement,
-  ReactNode,
-  isValidElement,
-} from 'react'
+import * as React from 'react'
+import { useEffect, ReactElement, ReactNode, isValidElement } from 'react'
 import styled from 'styled-components'
 import { useMenu } from './Menu.context'
 import type { FocusTarget } from './Menu.types'

--- a/libraries/core-react/src/Menu/MenuSection.tsx
+++ b/libraries/core-react/src/Menu/MenuSection.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react'
+import * as React from 'react'
+import { ReactNode } from 'react'
 import styled from 'styled-components'
 import { menu as tokens } from './Menu.tokens'
 import { templates } from '../_common'

--- a/libraries/core-react/src/Menu/index.tsx
+++ b/libraries/core-react/src/Menu/index.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react'
+import * as React from 'react'
+import { FC } from 'react'
 import { Menu as BaseMenu, MenuProps } from './Menu'
 import { MenuItem } from './MenuItem'
 import { MenuSection } from './MenuSection'

--- a/libraries/core-react/src/Menu/test-utils.tsx
+++ b/libraries/core-react/src/Menu/test-utils.tsx
@@ -1,4 +1,5 @@
-import React, { ElementType, ReactElement, ReactNode } from 'react'
+import * as React from 'react'
+import { ElementType, ReactElement, ReactNode } from 'react'
 import { render, RenderOptions, RenderResult } from '@testing-library/react'
 
 const AllTheProviders = ({ children }: { children: ReactNode }) => {

--- a/libraries/core-react/src/Pagination/Pagination.test.tsx
+++ b/libraries/core-react/src/Pagination/Pagination.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Pagination/Pagination.tsx
+++ b/libraries/core-react/src/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   useState,
   MouseEvent,
@@ -200,10 +201,10 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
       <FlexContainer>
         <Text>
           {currentItemFirst !== currentItemLast
-            ? `${currentItemFirst} 
-              ${' - '} 
+            ? `${currentItemFirst}
+              ${' - '}
               ${currentItemLast}
-              ${' of '} 
+              ${' of '}
               ${totalItems}
               ${' items'}`
             : `${currentItemFirst} ${' of '} ${totalItems} ${' items'}`}

--- a/libraries/core-react/src/Pagination/PaginationItem.tsx
+++ b/libraries/core-react/src/Pagination/PaginationItem.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, MouseEvent, KeyboardEvent } from 'react'
+import * as React from 'react'
+import { forwardRef, MouseEvent, KeyboardEvent } from 'react'
 import { Button } from '../Button'
 import { pagination as tokens } from './Pagination.tokens'
 

--- a/libraries/core-react/src/Paper/Paper.tsx
+++ b/libraries/core-react/src/Paper/Paper.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react'
+import * as React from 'react'
+import { forwardRef } from 'react'
 import styled from 'styled-components'
 import { paper as tokens, ElevationTypes } from './Paper.tokens'
 

--- a/libraries/core-react/src/Popover/Popover.test.tsx
+++ b/libraries/core-react/src/Popover/Popover.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import PropTypes from 'prop-types'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'

--- a/libraries/core-react/src/Popover/Popover.tsx
+++ b/libraries/core-react/src/Popover/Popover.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   useRef,
   HTMLAttributes,

--- a/libraries/core-react/src/Popover/PopoverAnchor.tsx
+++ b/libraries/core-react/src/Popover/PopoverAnchor.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 
 type Props = HTMLAttributes<HTMLDivElement>
 

--- a/libraries/core-react/src/Popover/PopoverContent.tsx
+++ b/libraries/core-react/src/Popover/PopoverContent.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 const ContentWrapper = styled.div`

--- a/libraries/core-react/src/Popover/PopoverItem.tsx
+++ b/libraries/core-react/src/Popover/PopoverItem.tsx
@@ -1,11 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import React, {
-  useEffect,
-  useRef,
-  forwardRef,
-  HTMLAttributes,
-  SVGProps,
-} from 'react'
+import * as React from 'react'
+import { useEffect, useRef, forwardRef, HTMLAttributes, SVGProps } from 'react'
 import styled, { css } from 'styled-components'
 import { Icon } from '../Icon'
 import { Card } from '../Card'

--- a/libraries/core-react/src/Popover/PopoverTitle.tsx
+++ b/libraries/core-react/src/Popover/PopoverTitle.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { Divider } from '../Divider'
 import { typographyTemplate } from '../_common/templates'

--- a/libraries/core-react/src/Progress/Circular/CircularProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Circular/CircularProgress.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Progress/Circular/CircularProgress.tsx
+++ b/libraries/core-react/src/Progress/Circular/CircularProgress.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import CSS from 'csstype'
 import styled, { css, keyframes } from 'styled-components'
 import { progress as tokens } from '../Progress.tokens'

--- a/libraries/core-react/src/Progress/Dots/DotProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Dots/DotProgress.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Progress/Dots/DotProgress.tsx
+++ b/libraries/core-react/src/Progress/Dots/DotProgress.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, Ref, SVGProps } from 'react'
+import * as React from 'react'
+import { forwardRef, Ref, SVGProps } from 'react'
 import styled, { keyframes } from 'styled-components'
 import { progress as tokens } from '../Progress.tokens'
 

--- a/libraries/core-react/src/Progress/Linear/LinearProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Linear/LinearProgress.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Progress/Linear/LinearProgress.tsx
+++ b/libraries/core-react/src/Progress/Linear/LinearProgress.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import { progress as tokens } from '../Progress.tokens'
 import CSS from 'csstype'

--- a/libraries/core-react/src/Progress/Star/StarProgress.test.tsx
+++ b/libraries/core-react/src/Progress/Star/StarProgress.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Progress/Star/StarProgress.tsx
+++ b/libraries/core-react/src/Progress/Star/StarProgress.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, SVGProps, Ref } from 'react'
+import * as React from 'react'
+import { forwardRef, SVGProps, Ref } from 'react'
 import styled, { keyframes, css } from 'styled-components'
 import { progress as tokens } from '../Progress.tokens'
 

--- a/libraries/core-react/src/Scrim/Scrim.test.tsx
+++ b/libraries/core-react/src/Scrim/Scrim.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
-import React, { useState } from 'react'
+import * as React from 'react'
+import { useState } from 'react'
 import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Scrim/Scrim.tsx
+++ b/libraries/core-react/src/Scrim/Scrim.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useEffect, MouseEvent, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, useEffect, MouseEvent, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { scrim as tokens } from './Scrim.tokens'
 

--- a/libraries/core-react/src/Search/Search.test.tsx
+++ b/libraries/core-react/src/Search/Search.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Search/Search.tsx
+++ b/libraries/core-react/src/Search/Search.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   useState,
   useRef,
   useEffect,

--- a/libraries/core-react/src/SelectionControls/Checkbox/Checkbox.test.tsx
+++ b/libraries/core-react/src/SelectionControls/Checkbox/Checkbox.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 
-import React, { useState } from 'react'
+import * as React from 'react'
+import { useState } from 'react'
 import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/SelectionControls/Checkbox/Checkbox.tsx
+++ b/libraries/core-react/src/SelectionControls/Checkbox/Checkbox.tsx
@@ -1,5 +1,6 @@
 /* eslint camelcase: "off" */
-import React, { forwardRef, Ref, InputHTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, Ref, InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import {
   checkbox,

--- a/libraries/core-react/src/SelectionControls/Radio/Radio.test.tsx
+++ b/libraries/core-react/src/SelectionControls/Radio/Radio.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'

--- a/libraries/core-react/src/SelectionControls/Radio/Radio.tsx
+++ b/libraries/core-react/src/SelectionControls/Radio/Radio.tsx
@@ -1,5 +1,6 @@
 /* eslint camelcase: "off" */
-import React, { forwardRef, Ref, InputHTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, Ref, InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import {
   radio_button_selected, // eslint-disable-line camelcase

--- a/libraries/core-react/src/SelectionControls/Switch/Input.tsx
+++ b/libraries/core-react/src/SelectionControls/Switch/Input.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, InputHTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { switchControl as tokens } from './Switch.tokens'
 import type { Size } from './Switch.types'

--- a/libraries/core-react/src/SelectionControls/Switch/InputWrapper.tsx
+++ b/libraries/core-react/src/SelectionControls/Switch/InputWrapper.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react'
+import * as React from 'react'
+import { ReactNode } from 'react'
 import styled from 'styled-components'
 import { switchControl as tokens } from './Switch.tokens'
 import type { Size } from './Switch.types'

--- a/libraries/core-react/src/SelectionControls/Switch/Switch.test.tsx
+++ b/libraries/core-react/src/SelectionControls/Switch/Switch.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/SelectionControls/Switch/Switch.tsx
+++ b/libraries/core-react/src/SelectionControls/Switch/Switch.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, Ref, InputHTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, Ref, InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { SwitchSmall } from './SwitchSmall'
 import { SwitchDefault } from './SwitchDefault'

--- a/libraries/core-react/src/SelectionControls/Switch/SwitchDefault.tsx
+++ b/libraries/core-react/src/SelectionControls/Switch/SwitchDefault.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react'
+import * as React from 'react'
+import { forwardRef } from 'react'
 import styled from 'styled-components'
 import { switchControl as tokens } from './Switch.tokens'
 import { InputWrapper } from './InputWrapper'

--- a/libraries/core-react/src/SelectionControls/Switch/SwitchSmall.tsx
+++ b/libraries/core-react/src/SelectionControls/Switch/SwitchSmall.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react'
+import * as React from 'react'
+import { forwardRef } from 'react'
 import styled from 'styled-components'
 import { switchControl as tokens } from './Switch.tokens'
 import { InputWrapper } from './InputWrapper'

--- a/libraries/core-react/src/SideSheet/SideSheet.test.tsx
+++ b/libraries/core-react/src/SideSheet/SideSheet.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/SideSheet/SideSheet.tsx
+++ b/libraries/core-react/src/SideSheet/SideSheet.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { clear } from '@equinor/eds-icons'
 import { spacingsTemplate } from '../_common/templates'

--- a/libraries/core-react/src/Slider/MinMax.tsx
+++ b/libraries/core-react/src/Slider/MinMax.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes, ReactNode } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import { typographyTemplate } from '../_common/templates'
 import { slider as tokens } from './Slider.tokens'

--- a/libraries/core-react/src/Slider/Output.tsx
+++ b/libraries/core-react/src/Slider/Output.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, OutputHTMLAttributes, ReactNode } from 'react'
+import * as React from 'react'
+import { forwardRef, OutputHTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import { typographyTemplate } from '../_common/templates'
 import { slider as tokens } from './Slider.tokens'

--- a/libraries/core-react/src/Slider/Slider.test.tsx
+++ b/libraries/core-react/src/Slider/Slider.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Slider } from './Slider'

--- a/libraries/core-react/src/Slider/Slider.tsx
+++ b/libraries/core-react/src/Slider/Slider.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   useState,
   useRef,

--- a/libraries/core-react/src/Slider/SliderInput.tsx
+++ b/libraries/core-react/src/Slider/SliderInput.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, InputHTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, InputHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { slider as tokens } from './Slider.tokens'
 

--- a/libraries/core-react/src/Snackbar/Snackbar.test.tsx
+++ b/libraries/core-react/src/Snackbar/Snackbar.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import {
   render,
   cleanup,

--- a/libraries/core-react/src/Snackbar/Snackbar.tsx
+++ b/libraries/core-react/src/Snackbar/Snackbar.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, HTMLAttributes, FC } from 'react'
+import * as React from 'react'
+import { useState, useEffect, HTMLAttributes, FC } from 'react'
 import styled from 'styled-components'
 import { snackbar as tokens } from './Snackbar.tokens'
 import { typographyTemplate } from '../_common/templates'

--- a/libraries/core-react/src/Snackbar/SnackbarAction.tsx
+++ b/libraries/core-react/src/Snackbar/SnackbarAction.tsx
@@ -1,4 +1,5 @@
-import React, { Children, ReactNode } from 'react'
+import * as React from 'react'
+import { Children, ReactNode } from 'react'
 import styled from 'styled-components'
 import { snackbar as tokens } from './Snackbar.tokens'
 

--- a/libraries/core-react/src/Table/Body.tsx
+++ b/libraries/core-react/src/Table/Body.tsx
@@ -1,4 +1,5 @@
-import React, { HTMLAttributes } from 'react'
+import * as React from 'react'
+import { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 const TableBase = styled.tbody``

--- a/libraries/core-react/src/Table/Cell.tsx
+++ b/libraries/core-react/src/Table/Cell.tsx
@@ -1,4 +1,5 @@
-import React, { TdHTMLAttributes } from 'react'
+import * as React from 'react'
+import { TdHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import type { Border } from '@equinor/eds-tokens'
 import { getTokens, TableCell } from './Table.tokens'

--- a/libraries/core-react/src/Table/Head.tsx
+++ b/libraries/core-react/src/Table/Head.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent } from 'react'
+import * as React from 'react'
+import { FunctionComponent } from 'react'
 import styled, { css } from 'styled-components'
 import { getTokens, TableCell } from './Table.tokens'
 import type { Border } from '@equinor/eds-tokens'

--- a/libraries/core-react/src/Table/Row.tsx
+++ b/libraries/core-react/src/Table/Row.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent } from 'react'
+import * as React from 'react'
+import { FunctionComponent } from 'react'
 import styled from 'styled-components'
 
 const TableBase = styled.tr``

--- a/libraries/core-react/src/Table/Table.tsx
+++ b/libraries/core-react/src/Table/Table.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { FunctionComponent, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 const TableBase = styled.table`

--- a/libraries/core-react/src/TableOfContents/LinkItem.tsx
+++ b/libraries/core-react/src/TableOfContents/LinkItem.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { tableOfContents as tokens } from './TableOfContents.tokens'
 

--- a/libraries/core-react/src/TableOfContents/TableOfContents.test.tsx
+++ b/libraries/core-react/src/TableOfContents/TableOfContents.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/TableOfContents/TableOfContents.tsx
+++ b/libraries/core-react/src/TableOfContents/TableOfContents.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { List } from '../List'
 import { Typography } from '../Typography'

--- a/libraries/core-react/src/Tabs/Tab.tsx
+++ b/libraries/core-react/src/Tabs/Tab.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, ButtonHTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, ButtonHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { tab as tokens } from './Tabs.tokens'
 

--- a/libraries/core-react/src/Tabs/TabList.tsx
+++ b/libraries/core-react/src/Tabs/TabList.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   useContext,
   useRef,

--- a/libraries/core-react/src/Tabs/TabPanel.tsx
+++ b/libraries/core-react/src/Tabs/TabPanel.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { tabPanel as tokens } from './Tabs.tokens'
 

--- a/libraries/core-react/src/Tabs/TabPanels.tsx
+++ b/libraries/core-react/src/Tabs/TabPanels.tsx
@@ -1,9 +1,5 @@
-import React, {
-  forwardRef,
-  ReactElement,
-  useContext,
-  HTMLAttributes,
-} from 'react'
+import * as React from 'react'
+import { forwardRef, ReactElement, useContext, HTMLAttributes } from 'react'
 import { TabsContext } from './Tabs.context'
 
 type TabPanelsProps = HTMLAttributes<HTMLDivElement>

--- a/libraries/core-react/src/Tabs/Tabs.test.tsx
+++ b/libraries/core-react/src/Tabs/Tabs.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
-import React, { useRef, useEffect, useState, Fragment } from 'react'
+import * as React from 'react'
+import { useRef, useEffect, useState, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'

--- a/libraries/core-react/src/Tabs/Tabs.tsx
+++ b/libraries/core-react/src/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useMemo, useState, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, useMemo, useState, HTMLAttributes } from 'react'
 import createId from 'lodash/uniqueId'
 import { TabsProvider } from './Tabs.context'
 import { Variants } from './Tabs.types'

--- a/libraries/core-react/src/TextField/HelperText/HelperText.tsx
+++ b/libraries/core-react/src/TextField/HelperText/HelperText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react'
+import * as React from 'react'
+import { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 import { typographyTemplate } from '../../_common/templates'
 import {

--- a/libraries/core-react/src/TextField/Icon/Icon.tsx
+++ b/libraries/core-react/src/TextField/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { useTextField } from '../context'
 

--- a/libraries/core-react/src/TextField/Input/Input.tsx
+++ b/libraries/core-react/src/TextField/Input/Input.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, ElementType, InputHTMLAttributes } from 'react'
+import * as React from 'react'
+import { ReactNode, ElementType, InputHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { InputVariantProps, input as tokens } from './Input.tokens'
 import { typographyTemplate, spacingsTemplate } from '../../_common/templates'

--- a/libraries/core-react/src/TextField/Label/Label.tsx
+++ b/libraries/core-react/src/TextField/Label/Label.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled from 'styled-components'
 import { typographyTemplate } from '../../_common/templates'
 import { label as tokens } from './Label.tokens'

--- a/libraries/core-react/src/TextField/TextField.test.tsx
+++ b/libraries/core-react/src/TextField/TextField.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, fireEvent } from '@testing-library/react'
 import 'jest-styled-components'
 import styled from 'styled-components'

--- a/libraries/core-react/src/TextField/TextField.tsx
+++ b/libraries/core-react/src/TextField/TextField.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, InputHTMLAttributes } from 'react'
+import * as React from 'react'
+import { ReactNode, InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { Input } from './Input'
 import { Label } from './Label'

--- a/libraries/core-react/src/TextField/context.tsx
+++ b/libraries/core-react/src/TextField/context.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useContext, ReactNode } from 'react'
+import * as React from 'react'
+import { useState, useContext, ReactNode } from 'react'
 
 export const propsFor = {
   variants: ['error', 'warning', 'success', 'default'],

--- a/libraries/core-react/src/Tooltip/Tooltip.test.tsx
+++ b/libraries/core-react/src/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Tooltip/Tooltip.tsx
+++ b/libraries/core-react/src/Tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   useState,
   HTMLAttributes,

--- a/libraries/core-react/src/TopBar/Actions.tsx
+++ b/libraries/core-react/src/TopBar/Actions.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 type ActionsProps = HTMLAttributes<HTMLDivElement>

--- a/libraries/core-react/src/TopBar/CustomContent.tsx
+++ b/libraries/core-react/src/TopBar/CustomContent.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 type CustomContentProps = HTMLAttributes<HTMLDivElement>

--- a/libraries/core-react/src/TopBar/Header.tsx
+++ b/libraries/core-react/src/TopBar/Header.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { typographyTemplate } from '../_common/templates'
 

--- a/libraries/core-react/src/TopBar/TopBar.test.tsx
+++ b/libraries/core-react/src/TopBar/TopBar.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/TopBar/TopBar.tsx
+++ b/libraries/core-react/src/TopBar/TopBar.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import * as React from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { spacingsTemplate, typographyTemplate } from '../_common/templates'
 import { topbar as tokens } from './TopBar.tokens'

--- a/libraries/core-react/src/Typography/Typography.test.tsx
+++ b/libraries/core-react/src/Typography/Typography.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import React from 'react'
+import * as React from 'react'
 import { render, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'

--- a/libraries/core-react/src/Typography/Typography.tsx
+++ b/libraries/core-react/src/Typography/Typography.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react'
+import {
   forwardRef,
   ElementType,
   HTMLAttributes,

--- a/libraries/core/pnpm-lock.yaml
+++ b/libraries/core/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 devDependencies:
   prettier: 1.17.1
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /prettier/1.17.1:
     dev: true

--- a/libraries/icons/pnpm-lock.yaml
+++ b/libraries/icons/pnpm-lock.yaml
@@ -3,7 +3,7 @@ devDependencies:
   rollup: 2.15.0
   rollup-plugin-typescript2: 0.27.2_rollup@2.15.0+typescript@4.0.2
   typescript: 4.0.2
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@rollup/plugin-node-resolve/8.0.1_rollup@2.15.0:
     dependencies:

--- a/libraries/tokens/pnpm-lock.yaml
+++ b/libraries/tokens/pnpm-lock.yaml
@@ -3,7 +3,7 @@ devDependencies:
   rollup: 2.15.0
   rollup-plugin-typescript2: 0.27.2_rollup@2.15.0+typescript@4.0.2
   typescript: 4.0.2
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@rollup/plugin-node-resolve/8.0.1_rollup@2.15.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ devDependencies:
   eslint-plugin-testing-library: 1.5.0_eslint@7.11.0
   prettier: 2.0.5
   typescript: 4.0.2
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.10.4:
     dependencies:


### PR DESCRIPTION
This pr started out as an attempt to remove `allowSyntheticDefaultImports` and `esModuleInterop` from the config – but we already consume modules ourselves which require us to keep these settings. 

For example, if we remove these, we have to change the lodash/uniqueId import to `import createId = require('lodash/uniqueId')` – which then results in eslint errors because `eslint-plugin-import` does not yet support this syntax. 

See https://github.com/benmosher/eslint-plugin-import/issues/1244 for details. 

However, since the React imports are all now on separate lines, it will be easier for us to remove these once we upgrade to React 17, so I propose we still merge this pr as it is.

I also updated all the lock-files, allthough strictly not part of this issue.

resolves #826 