### PR TITLE
eds-core-react dependencies 

### DIFF
--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.3",
   "description": "The React implementation of the Equinor Design System",
   "main": "src/index.ts",
   "publishConfig": {
@@ -50,15 +50,20 @@
     "@rollup/plugin-node-resolve": "^8.0.1",
     "@testing-library/jest-dom": "^5.9.0",
     "@testing-library/react": "^10.2.1",
+    "@testing-library/react-hooks": "^3.3.0",
     "@testing-library/user-event": "^10.3.2",
     "@types/jest": "^26.0.10",
+    "@types/lodash": "^4.14.162",
     "@types/react": "^16.9.47",
     "@types/react-dom": "^16.9.8",
     "@types/styled-components": "^5.1.2",
     "@types/testing-library__jest-dom": "^5.9.2",
     "babel-plugin-styled-components": "^1.10.7",
+    "csstype": "^3.0.3",
+    "focus-visible": "^5.2.0",
     "jest": "^26.0.1",
     "jest-styled-components": "^6.3.4",
+    "lodash": "^4.17.19",
     "prettier": "^2.0.5",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
@@ -72,18 +77,13 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": ">=16.8.6",
+    "react-dom": ">=16.8.6",
     "styled-components": "^4.2.0"
   },
   "dependencies": {
     "@equinor/eds-icons": "0.5.0-beta.1",
-    "@equinor/eds-tokens": "0.5.1-beta.1",
-    "@testing-library/react-hooks": "^3.3.0",
-    "@types/lodash": "^4.14.162",
-    "csstype": "^3.0.3",
-    "focus-visible": "^5.2.0",
-    "lodash": "^4.17.19"
+    "@equinor/eds-tokens": "0.5.1-beta.1"
   },
   "engines": {
     "pnpm": ">=4",

--- a/libraries/core-react/pnpm-lock.yaml
+++ b/libraries/core-react/pnpm-lock.yaml
@@ -1,11 +1,6 @@
 dependencies:
   '@equinor/eds-icons': 0.5.0-beta.1
   '@equinor/eds-tokens': 0.5.1-beta.1
-  '@testing-library/react-hooks': 3.3.0_react@16.13.1
-  '@types/lodash': 4.14.162
-  csstype: 3.0.3
-  focus-visible: 5.2.0
-  lodash: 4.17.19
 devDependencies:
   '@babel/cli': 7.10.1_@babel+core@7.10.2
   '@babel/core': 7.10.2
@@ -17,15 +12,20 @@ devDependencies:
   '@rollup/plugin-node-resolve': 8.0.1_rollup@2.15.0
   '@testing-library/jest-dom': 5.9.0
   '@testing-library/react': 10.2.1_react-dom@16.13.1+react@16.13.1
+  '@testing-library/react-hooks': 3.3.0_react@16.13.1
   '@testing-library/user-event': 10.4.1
   '@types/jest': 26.0.10
+  '@types/lodash': 4.14.162
   '@types/react': 16.9.47
   '@types/react-dom': 16.9.8
   '@types/styled-components': 5.1.2
   '@types/testing-library__jest-dom': 5.9.2
   babel-plugin-styled-components: 1.10.7_styled-components@4.4.1
+  csstype: 3.0.3
+  focus-visible: 5.2.0
   jest: 26.0.1
   jest-styled-components: 6.3.4_styled-components@4.4.1
+  lodash: 4.17.19
   prettier: 2.0.5
   prop-types: 15.7.2
   react: 16.13.1
@@ -1159,6 +1159,7 @@ packages:
   /@babel/runtime/7.10.2:
     dependencies:
       regenerator-runtime: 0.13.5
+    dev: true
     resolution:
       integrity: sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
   /@babel/template/7.10.1:
@@ -1596,7 +1597,7 @@ packages:
       '@babel/runtime': 7.10.2
       '@types/testing-library__react-hooks': 3.2.0
       react: 16.13.1
-    dev: false
+    dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-test-renderer: '>=16.9.0'
@@ -1723,7 +1724,7 @@ packages:
     resolution:
       integrity: sha512-i2m0oyh8w/Lum7wWK/YOZJakYF8Mx08UaKA1CtbmFeDquVhAEdA7znacsVSf2hJ1OQ/OfVMGN90pw/AtzF8s/Q==
   /@types/lodash/4.14.162:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==
   /@types/node/14.0.11:
@@ -1743,6 +1744,7 @@ packages:
     resolution:
       integrity: sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
   /@types/prop-types/15.7.3:
+    dev: true
     resolution:
       integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
   /@types/react-dom/16.9.8:
@@ -1760,14 +1762,14 @@ packages:
   /@types/react-test-renderer/16.9.2:
     dependencies:
       '@types/react': 16.9.35
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==
   /@types/react/16.9.35:
     dependencies:
       '@types/prop-types': 15.7.3
       csstype: 2.6.10
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==
   /@types/react/16.9.47:
@@ -1812,7 +1814,7 @@ packages:
     dependencies:
       '@types/react': 16.9.35
       '@types/react-test-renderer': 16.9.2
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-dE8iMTuR5lzB+MqnxlzORlXzXyCL0EKfzH0w/lau20OpkHD37EaWjZDz0iNG8b71iEtxT4XKGmSKAGVEqk46mw==
   /@types/yargs-parser/15.0.0:
@@ -2488,10 +2490,11 @@ packages:
     resolution:
       integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   /csstype/2.6.10:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
   /csstype/3.0.3:
+    dev: true
     resolution:
       integrity: sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
   /dashdash/1.14.1:
@@ -2878,7 +2881,7 @@ packages:
     resolution:
       integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   /focus-visible/5.2.0:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
   /for-in/1.0.2:
@@ -4118,6 +4121,7 @@ packages:
     resolution:
       integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
   /lodash/4.17.19:
+    dev: true
     resolution:
       integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
   /lodash/4.17.20:
@@ -4806,6 +4810,7 @@ packages:
     resolution:
       integrity: sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
   /regenerator-runtime/0.13.5:
+    dev: true
     resolution:
       integrity: sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
   /regenerator-transform/0.14.4:


### PR DESCRIPTION
Moved correct dependencies to `dev` and change `react` to be a minimum instead of up to minor releases.

This was done due to problems with resolving react versions and leaking dependencies used for development to consumers. 

![image](https://user-images.githubusercontent.com/1070981/98805504-f482e980-2417-11eb-83e0-c93e45ff14da.png)


So in short the following packages was installed for any user installing `eds-core-react`.... 🙈
  *  @testing-library/react-hooks
  * @types/lodash
   * csstype
   * focus-visible
   * lodash