### PR TITLE
Simplify dependencies and package type

### DIFF
--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -82,8 +82,8 @@
     "styled-components": ">=4.2"
   },
   "dependencies": {
-    "@equinor/eds-icons": "0.5.0-beta.1",
-    "@equinor/eds-tokens": "0.5.1-beta.1"
+    "@equinor/eds-icons": "0.5.0-beta.2",
+    "@equinor/eds-tokens": "0.5.1-beta.2"
   },
   "engines": {
     "pnpm": ">=4",

--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "description": "The React implementation of the Equinor Design System",
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/core-react.cjs.js",
-    "module": "dist/core-react.es.js",
+    "module": "dist/core-react.esm.js",
     "browser": "dist/core-react.umd.js"
   },
   "types": "dist/types/index.d.ts",
@@ -76,10 +76,10 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.7.2",
-    "react": ">=16.8.6",
-    "react-dom": ">=16.8.6",
-    "styled-components": "^4.2.0"
+    "prop-types": ">=15.7.2",
+    "react": ">=16.8",
+    "react-dom": ">=16.8",
+    "styled-components": ">=4.2"
   },
   "dependencies": {
     "@equinor/eds-icons": "0.5.0-beta.1",

--- a/libraries/core-react/pnpm-lock.yaml
+++ b/libraries/core-react/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 dependencies:
-  '@equinor/eds-icons': 0.5.0-beta.1
-  '@equinor/eds-tokens': 0.5.1-beta.1
+  '@equinor/eds-icons': 0.5.0-beta.2
+  '@equinor/eds-tokens': 0.5.1-beta.2
 devDependencies:
   '@babel/cli': 7.10.1_@babel+core@7.10.2
   '@babel/core': 7.10.2
@@ -1258,20 +1258,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
-  /@equinor/eds-icons/0.5.0-beta.1:
+  /@equinor/eds-icons/0.5.0-beta.2:
     dev: false
     engines:
       node: '>=10.0.0'
       pnpm: '>=4'
     resolution:
-      integrity: sha512-IjveWnsKXjVvM3Fp0Y1x3FWm1BPtkDf69YhztRJY8jraP6kZ8o+tdkVdXAyUyd2ELwdgvSTTQuvVaUberAz9hw==
-  /@equinor/eds-tokens/0.5.1-beta.1:
+      integrity: sha512-sD574J11TMS/HhiNupDCASFFE++l5uywLc9zGcE5QAI4kXED4aC2KOWN9nnoshK5KKTyax8wkA2JDsNa7UPJeQ==
+  /@equinor/eds-tokens/0.5.1-beta.2:
     dev: false
     engines:
       node: '>=10.0.0'
       pnpm: '>=4'
     resolution:
-      integrity: sha512-62zlIoepdd1NqS8dizH5ESbKjI9Y+Hz/oovo9Q5XgoupIzKGw14DkOCNnlcJ4rs6o7MPO3OKUPNH4RnIGcqPFg==
+      integrity: sha512-54KCtyCKEu7srnbDO6D7mFONoT4bQ0tPjuvOHMSR+Bk+yg0+gGrwyt8C1s0C0NqTFDarTbu6d6VzWRGwKSkUeA==
   /@istanbuljs/load-nyc-config/1.1.0:
     dependencies:
       camelcase: 5.3.1
@@ -5873,8 +5873,8 @@ specifiers:
   '@babel/preset-env': ^7.10.2
   '@babel/preset-react': ^7.10.1
   '@babel/preset-typescript': ^7.10.4
-  '@equinor/eds-icons': 0.5.0-beta.1
-  '@equinor/eds-tokens': 0.5.1-beta.1
+  '@equinor/eds-icons': 0.5.0-beta.2
+  '@equinor/eds-tokens': 0.5.1-beta.2
   '@rollup/plugin-babel': ^5.0.3
   '@rollup/plugin-commonjs': ^13.0.0
   '@rollup/plugin-node-resolve': ^8.0.1

--- a/libraries/icons/package.json
+++ b/libraries/icons/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.5.0-beta.1",
+  "version": "0.5.0-beta.2",
   "description": "Icons from the Equinor Design System",
-  "type": "module",
-  "main": "dist/icons.esm.js",
+  "main": "dist/icons.cjs.js",
   "module": "dist/icons.esm.js",
   "browser": "dist/icons.umd.js",
   "types": "dist/types/index.d.ts",

--- a/libraries/icons/rollup.config.js
+++ b/libraries/icons/rollup.config.js
@@ -15,7 +15,7 @@ export default [
       {
         file: pkg.module,
         name: pkg.name,
-        format: 'esm',
+        format: 'es',
         exports: 'named',
       },
       {

--- a/libraries/tokens/commonjs/package.json
+++ b/libraries/tokens/commonjs/package.json
@@ -1,4 +1,4 @@
 {
   "type": "commonjs",
-  "main": "../dist/tokens.cjs"
+  "main": "../dist/tokens.cjs.js"
 }

--- a/libraries/tokens/package.json
+++ b/libraries/tokens/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@equinor/eds-tokens",
-  "version": "0.5.1-beta.1",
+  "version": "0.5.1-beta.2",
   "description": "Design tokens for the Equinor Design System",
-  "main": "dist/tokens.esm.js",
+  "main": "dist/tokens.cjs.js",
   "module": "dist/tokens.esm.js",
   "browser": "dist/tokens.umd.js",
   "types": "dist/types/index.d.ts",
-  "type": "module",
   "license": "MIT",
   "author": {
     "name": "EDS Core Team",

--- a/libraries/tokens/rollup.config.js
+++ b/libraries/tokens/rollup.config.js
@@ -15,7 +15,7 @@ export default [
       {
         file: pkg.module,
         name: pkg.name,
-        format: 'esm',
+        format: 'es',
         exports: 'named',
       },
       {


### PR DESCRIPTION
* `tokens` and `icons` have `cjs` bundle as main now.
* Removed `type` flag on `icons` & `tokens` as this flag is meant for consuming applications as[ i've understood](https://nodejs.org/docs/latest-v15.x/api/esm.html#esm_enabling). Meaning if you make a new application and set `type="module"` in `package.json`, it will then load the bundle under `"module"` in our library.
* Set all peer-deps to have a min.version approach