### PR TITLE
1️⃣  TS beta test fixes  

### DIFF
--- a/apps/storybook-react/pnpm-lock.yaml
+++ b/apps/storybook-react/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
   babel-runtime: 6.26.0
   react-dom: 16.13.1_react@16.13.1
   react-hook-form: 5.7.2_react@16.13.1
-  styled-components: 5.1.1_988f4f9157fb8e0dba6a9870bbd1cb60
+  styled-components: 5.1.1_9a4a3b3ed34a772b68db523825332f5f
 devDependencies:
   '@babel/core': 7.10.2
   '@babel/plugin-transform-react-jsx': 7.10.1_@babel+core@7.10.2
@@ -26,7 +26,7 @@ devDependencies:
   babel-loader: 8.1.0_@babel+core@7.10.2
   react: 16.13.1
   react-is: 16.13.1
-lockfileVersion: 5.2
+lockfileVersion: 5.1
 packages:
   /@babel/code-frame/7.10.1:
     dependencies:
@@ -71,7 +71,6 @@ packages:
       resolve: 1.17.0
       semver: 5.7.1
       source-map: 0.5.7
-    dev: true
     engines:
       node: '>=6.9.0'
     resolution:
@@ -386,7 +385,6 @@ packages:
   /@babel/helper-member-expression-to-functions/7.10.1:
     dependencies:
       '@babel/types': 7.10.2
-    dev: true
     resolution:
       integrity: sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==
   /@babel/helper-member-expression-to-functions/7.11.0:
@@ -423,7 +421,6 @@ packages:
       '@babel/template': 7.10.1
       '@babel/types': 7.10.2
       lodash: 4.17.15
-    dev: true
     resolution:
       integrity: sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==
   /@babel/helper-module-transforms/7.11.0:
@@ -453,7 +450,6 @@ packages:
   /@babel/helper-optimise-call-expression/7.10.1:
     dependencies:
       '@babel/types': 7.10.2
-    dev: true
     resolution:
       integrity: sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==
   /@babel/helper-optimise-call-expression/7.10.4:
@@ -494,7 +490,6 @@ packages:
       '@babel/helper-optimise-call-expression': 7.10.1
       '@babel/traverse': 7.10.1
       '@babel/types': 7.10.2
-    dev: true
     resolution:
       integrity: sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==
   /@babel/helper-replace-supers/7.10.4:
@@ -517,7 +512,6 @@ packages:
     dependencies:
       '@babel/template': 7.10.1
       '@babel/types': 7.10.2
-    dev: true
     resolution:
       integrity: sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==
   /@babel/helper-simple-access/7.10.4:
@@ -581,7 +575,6 @@ packages:
       '@babel/template': 7.10.1
       '@babel/traverse': 7.10.1
       '@babel/types': 7.10.2
-    dev: true
     resolution:
       integrity: sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==
   /@babel/helpers/7.10.4:
@@ -3701,7 +3694,7 @@ packages:
       unfetch: 4.2.0
       url-loader: 4.1.1_file-loader@6.1.1+webpack@4.44.1
       util-deprecate: 1.0.2
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
       webpack-dev-middleware: 3.7.2_webpack@4.44.1
       webpack-hot-middleware: 2.25.0
       webpack-virtual-modules: 0.2.2
@@ -3756,7 +3749,7 @@ packages:
       react-dom: 16.13.1_react@16.13.1
       regenerator-runtime: 0.13.7
       ts-dedent: 1.1.1
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: false
     engines:
       node: '>=8.0.0'
@@ -4222,7 +4215,6 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.3
       csstype: 3.0.4
-    dev: true
     resolution:
       integrity: sha512-GhawhYraQZpGFO2hVMArjPrYbnA/6+DS8SubK8IPhhVClmKqANihsRenOm5E0mvqK0m/BKoqVktA1O1+Xvlz9w==
   /@types/reactcss/1.2.3:
@@ -4404,7 +4396,7 @@ packages:
       chalk: 2.4.2
       strip-ansi: 4.0.0
       text-table: 0.2.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
       webpack-log: 1.2.0
     dev: false
     engines:
@@ -4488,9 +4480,7 @@ packages:
       symbol.prototype.description: 1.0.2
     resolution:
       integrity: sha512-wJNXPH66U2xjgo1Zwyjf9EydvJ2Si94+vSdk6EERcBfB2VZkeltpqIats0cqIZMLCXP3zcyaUKGYQeIBT6XjsQ==
-  /ajv-errors/1.0.1_ajv@6.12.4:
-    dependencies:
-      ajv: 6.12.4
+  /ajv-errors/1.0.1:
     peerDependencies:
       ajv: '>=5.0.0'
     resolution:
@@ -4502,6 +4492,11 @@ packages:
       ajv: ^6.9.1
     resolution:
       integrity: sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
+  /ajv-keywords/3.5.2:
+    peerDependencies:
+      ajv: ^6.9.1
+    resolution:
+      integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
   /ajv-keywords/3.5.2_ajv@6.12.4:
     dependencies:
       ajv: 6.12.4
@@ -4818,7 +4813,7 @@ packages:
       mkdirp: 0.5.5
       pify: 4.0.1
       schema-utils: 2.7.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     engines:
       node: '>= 6.9'
     peerDependencies:
@@ -4992,7 +4987,7 @@ packages:
       '@babel/helper-module-imports': 7.10.1
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.15
-      styled-components: 5.1.1_988f4f9157fb8e0dba6a9870bbd1cb60
+      styled-components: 5.1.1_9a4a3b3ed34a772b68db523825332f5f
     dev: false
     peerDependencies:
       styled-components: '>= 2'
@@ -5920,7 +5915,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.1
       semver: 6.3.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     engines:
       node: '>= 8.9.0'
     peerDependencies:
@@ -6238,7 +6233,7 @@ packages:
   /dotenv-webpack/1.8.0_webpack@4.44.1:
     dependencies:
       dotenv-defaults: 1.1.1
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     peerDependencies:
       webpack: ^1 || ^2 || ^3 || ^4
     resolution:
@@ -6745,7 +6740,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 3.0.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     engines:
       node: '>= 10.13.0'
     peerDependencies:
@@ -7375,7 +7370,7 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     engines:
       node: '>=6.9'
     peerDependencies:
@@ -9493,7 +9488,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 3.0.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     engines:
       node: '>= 10.13.0'
     peerDependencies:
@@ -9609,7 +9604,6 @@ packages:
       prop-types: 15.7.2
       react: 16.13.1
       scheduler: 0.19.1
-    dev: false
     peerDependencies:
       react: ^16.13.1
     resolution:
@@ -9803,6 +9797,7 @@ packages:
   /react-textarea-autosize/8.2.0_7a81abeb4682dcd740958f1c62af662f:
     dependencies:
       '@babel/runtime': 7.12.1
+      '@types/react': 16.9.54
       react: 16.14.0
       use-composed-ref: 1.0.0_react@16.14.0
       use-latest: 1.1.0_7a81abeb4682dcd740958f1c62af662f
@@ -9830,7 +9825,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
@@ -10228,8 +10222,8 @@ packages:
   /schema-utils/1.0.0:
     dependencies:
       ajv: 6.12.4
-      ajv-errors: 1.0.1_ajv@6.12.4
-      ajv-keywords: 3.5.2_ajv@6.12.4
+      ajv-errors: 1.0.1
+      ajv-keywords: 3.5.2
     engines:
       node: '>= 4'
     resolution:
@@ -10247,7 +10241,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.6
       ajv: 6.12.6
-      ajv-keywords: 3.5.2_ajv@6.12.6
+      ajv-keywords: 3.5.2
     engines:
       node: '>= 8.9.0'
     resolution:
@@ -10695,7 +10689,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 2.7.1
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     engines:
       node: '>= 8.9.0'
     peerDependencies:
@@ -10708,7 +10702,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
-  /styled-components/5.1.1_988f4f9157fb8e0dba6a9870bbd1cb60:
+  /styled-components/5.1.1_9a4a3b3ed34a772b68db523825332f5f:
     dependencies:
       '@babel/helper-module-imports': 7.10.1
       '@babel/traverse': 7.10.1
@@ -10728,6 +10722,7 @@ packages:
       react: '>= 16.8.0'
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
+      styled-components: '*'
     requiresBuild: true
     resolution:
       integrity: sha512-1ps8ZAYu2Husx+Vz8D+MvXwEwvMwFv+hqqUwhNlDN5ybg6A+3xyW1ECrAgywhvXapNfXiz79jJyU0x22z0FFTg==
@@ -10841,7 +10836,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     engines:
@@ -10860,7 +10855,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
     engines:
       node: '>= 10.13.0'
@@ -11254,7 +11249,7 @@ packages:
       loader-utils: 2.0.0
       mime-types: 2.1.27
       schema-utils: 3.0.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     engines:
       node: '>= 10.13.0'
     peerDependencies:
@@ -11421,7 +11416,7 @@ packages:
       mime: 2.4.6
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
       webpack-log: 2.0.0
     engines:
       node: '>= 6'
@@ -11467,7 +11462,7 @@ packages:
       debug: 3.2.6
     resolution:
       integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
-  /webpack/4.44.1:
+  /webpack/4.44.1_webpack@4.44.1:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -11491,11 +11486,13 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.44.1
       watchpack: 1.7.4
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
     engines:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
+      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/apps/storybook-react/stories/TextField.stories.tsx
+++ b/apps/storybook-react/stories/TextField.stories.tsx
@@ -49,6 +49,7 @@ export default {
     rows: {
       control: 'number',
       description: 'Rows when "multiline" is true',
+      default: 1,
     },
   },
 } as Meta

--- a/apps/storybook-react/stories/TextField.stories.tsx
+++ b/apps/storybook-react/stories/TextField.stories.tsx
@@ -45,6 +45,12 @@ const ICONS = {
 export default {
   title: 'Components/TextField',
   component: TextField,
+  argTypes: {
+    rows: {
+      control: 'number',
+      description: 'Rows when "multiline" is true',
+    },
+  },
 } as Meta
 
 export const Default: Story<TextFieldProps> = (args) => (

--- a/libraries/core-react/pnpm-lock.yaml
+++ b/libraries/core-react/pnpm-lock.yaml
@@ -32,11 +32,11 @@ devDependencies:
   rollup-plugin-delete: 2.0.0
   rollup-plugin-size-snapshot: 0.12.0_rollup@2.15.0
   rollup-plugin-typescript2: 0.27.2_rollup@2.15.0+typescript@4.0.2
-  styled-components: 4.4.1_react-dom@16.13.1+react@16.13.1
+  styled-components: 4.4.1_4f54128445bc6f13bd713dcb3d91e98e
   ts-jest: 26.3.0_jest@26.0.1+typescript@4.0.2
   tslib: 2.0.1
   typescript: 4.0.2
-lockfileVersion: 5.2
+lockfileVersion: 5.1
 packages:
   /@babel/cli/7.10.1_@babel+core@7.10.2:
     dependencies:
@@ -1318,7 +1318,7 @@ packages:
       jest-haste-map: 26.0.1
       jest-message-util: 26.0.1
       jest-regex-util: 26.0.0
-      jest-resolve: 26.0.1
+      jest-resolve: 26.0.1_jest-resolve@26.0.1
       jest-resolve-dependencies: 26.0.1
       jest-runner: 26.0.1
       jest-runtime: 26.0.1
@@ -1386,7 +1386,7 @@ packages:
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
       jest-haste-map: 26.0.1
-      jest-resolve: 26.0.1
+      jest-resolve: 26.0.1_jest-resolve@26.0.1
       jest-util: 26.0.1
       jest-worker: 26.0.0
       slash: 3.0.0
@@ -2324,7 +2324,7 @@ packages:
       '@babel/helper-module-imports': 7.10.1
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.15
-      styled-components: 4.4.1_react-dom@16.13.1+react@16.13.1
+      styled-components: 4.4.1_4f54128445bc6f13bd713dcb3d91e98e
     dev: true
     peerDependencies:
       styled-components: '>= 2'
@@ -4367,7 +4367,7 @@ packages:
       jest-get-type: 26.0.0
       jest-jasmine2: 26.0.1
       jest-regex-util: 26.0.0
-      jest-resolve: 26.0.1
+      jest-resolve: 26.0.1_jest-resolve@26.0.1
       jest-util: 26.0.1
       jest-validate: 26.0.1
       micromatch: 4.0.2
@@ -4574,7 +4574,7 @@ packages:
       integrity: sha512-MpYTBqycuPYSY6xKJognV7Ja46/TeRbAZept987Zp+tuJvMN0YBWyyhG9mXyYQaU3SBI0TUlSaO5L3p49agw7Q==
   /jest-pnp-resolver/1.2.1_jest-resolve@26.0.1:
     dependencies:
-      jest-resolve: 26.0.1
+      jest-resolve: 26.0.1_jest-resolve@26.0.1
     dev: true
     engines:
       node: '>=6'
@@ -4601,7 +4601,7 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-9d5/RS/ft0vB/qy7jct/qAhzJsr6fRQJyGAFigK3XD4hf9kIbEH5gks4t4Z7kyMRhowU6HWm/o8ILqhaHdSqLw==
-  /jest-resolve/26.0.1:
+  /jest-resolve/26.0.1_jest-resolve@26.0.1:
     dependencies:
       '@jest/types': 26.0.1
       chalk: 4.0.0
@@ -4614,6 +4614,8 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      jest-resolve: '*'
     resolution:
       integrity: sha512-6jWxk0IKZkPIVTvq6s72RH735P8f9eCJW3IM5CX/SJFeKq1p2cZx0U49wf/SdMlhaB/anann5J2nCJj6HrbezQ==
   /jest-runner/26.0.1:
@@ -4631,7 +4633,7 @@ packages:
       jest-jasmine2: 26.0.1
       jest-leak-detector: 26.0.1
       jest-message-util: 26.0.1
-      jest-resolve: 26.0.1
+      jest-resolve: 26.0.1_jest-resolve@26.0.1
       jest-runtime: 26.0.1
       jest-util: 26.0.1
       jest-worker: 26.0.0
@@ -4663,7 +4665,7 @@ packages:
       jest-message-util: 26.0.1
       jest-mock: 26.0.1
       jest-regex-util: 26.0.0
-      jest-resolve: 26.0.1
+      jest-resolve: 26.0.1_jest-resolve@26.0.1
       jest-snapshot: 26.0.1
       jest-util: 26.0.1
       jest-validate: 26.0.1
@@ -4696,7 +4698,7 @@ packages:
       jest-get-type: 26.0.0
       jest-matcher-utils: 26.0.1
       jest-message-util: 26.0.1
-      jest-resolve: 26.0.1
+      jest-resolve: 26.0.1_jest-resolve@26.0.1
       make-dir: 3.1.0
       natural-compare: 1.4.0
       pretty-format: 26.0.1
@@ -4709,7 +4711,7 @@ packages:
   /jest-styled-components/6.3.4_styled-components@4.4.1:
     dependencies:
       css: 2.2.4
-      styled-components: 4.4.1_react-dom@16.13.1+react@16.13.1
+      styled-components: 4.4.1_4f54128445bc6f13bd713dcb3d91e98e
     dev: true
     peerDependencies:
       styled-components: ^2 || ^3 || ^4
@@ -6201,7 +6203,7 @@ packages:
       memory-fs: 0.5.0
       rollup: 2.15.0
       terser: 4.8.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: true
     engines:
       node: '>=10'
@@ -6672,7 +6674,7 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
-  /styled-components/4.4.1_react-dom@16.13.1+react@16.13.1:
+  /styled-components/4.4.1_4f54128445bc6f13bd713dcb3d91e98e:
     dependencies:
       '@babel/helper-module-imports': 7.10.1
       '@babel/traverse': 7.10.1
@@ -6693,6 +6695,7 @@ packages:
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
+      styled-components: '*'
     requiresBuild: true
     resolution:
       integrity: sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
@@ -6769,7 +6772,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -7207,7 +7210,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  /webpack/4.44.2:
+  /webpack/4.44.2_webpack@4.44.2:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -7237,6 +7240,7 @@ packages:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
+      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ devDependencies:
   eslint-plugin-testing-library: 1.5.0_eslint@7.11.0
   prettier: 2.0.5
   typescript: 4.0.2
-lockfileVersion: 5.2
+lockfileVersion: 5.1
 packages:
   /@babel/code-frame/7.10.4:
     dependencies:


### PR DESCRIPTION
Solves #871 

Notes: 
- `rows` prop was always included in `InputHTMLAttributes` but I added it manually to the Story to have it documented. It's probably not intuitive for all users that these default attributes are included as well as the custom ones.
- Regarding the `errorMsg` prop, I don't find that it deprecated on Typescript migration. It was already labeled `helperText`. I didn't take more time to research this, but I guess they have used this prop before and now after TS support it's not allowed.
- `variant` prop in `Icon` has never been a case before either, so I guess the same happened as with the `errorMsg` mentioned above

So the only 'fix' here is adding rows prop to TextField story to document multiline input.
