### PR TITLE
📝 Added 'rows' to TextField prop table 

### DIFF
--- a/apps/storybook-react/stories/TextField.stories.tsx
+++ b/apps/storybook-react/stories/TextField.stories.tsx
@@ -45,6 +45,13 @@ const ICONS = {
 export default {
   title: 'Components/TextField',
   component: TextField,
+  argTypes: {
+    rows: {
+      control: 'number',
+      description: 'Rows when "multiline" is true',
+      default: 1,
+    },
+  },
 } as Meta
 
 export const Default: Story<TextFieldProps> = (args) => (


### PR DESCRIPTION
Solves #871

Notes:

- `rows` prop was always included in `InputHTMLAttributes` but I added it manually to the Story to have it documented. It's probably not intuitive for all users that these default attributes are included as well as the custom ones.

- Regarding the `errorMsg` prop, I don't find that it deprecated on Typescript migration. It was already labeled `helperText`. I didn't take more time to research this, but I guess they have used this prop before and now after TS support it's not allowed.

- `variant` prop in Icon has never been a case before either, so I guess the same happened as with the `errorMsg` mentioned above

So the only 'fix' here is adding rows prop to `TextField` story to document multiline input.