### PR TITLE
⬆️ Use @next in the Storefront

### DIFF
--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -8,29 +8,18 @@ COPY ./package.yaml ./
 COPY ./pnpm-workspaces.yaml ./
 COPY ./.npmrc ./
 
-# copy libraries
-WORKDIR /app/libraries
-COPY ./libraries/tokens ./tokens
-COPY ./libraries/core-react ./core-react
-COPY ./libraries/icons ./icons
-
 # copy storefront
 WORKDIR /app/apps
 COPY ./apps/storefront ./storefront
 
 # build storefront and dependencies
 WORKDIR /app
-RUN pnpm --filter ./libraries/tokens install && \
-  pnpm --filter ./libraries/tokens run build
 
-RUN pnpm --filter ./libraries/core-react install && \
-  pnpm --filter ./libraries/core-react run build:for-storybook
-
-RUN pnpm --filter ./apps/storefront install
+RUN pnpm m i
 
 # build storefront
 ARG GATSBY_STAGE
-RUN pnpm --filter ./apps/storefront run build
+RUN pnpm build:storefront
 RUN mv ./apps/storefront/public ./storefront
 
 # host

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -20,10 +20,9 @@ RUN pnpm m i
 # build storefront
 ARG GATSBY_STAGE
 RUN pnpm build:storefront
-RUN mv ./apps/storefront/public ./storefront
 
 # host
 FROM nginx:1.15.8-alpine
 WORKDIR /app
-COPY --from=builder ./app/storefront /app
+COPY --from=builder ./app/apps/storefront/public/ .
 COPY ./apps/storefront/nginx.conf /etc/nginx/conf.d/default.conf

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",
-    "@equinor/eds-core-react": "^0.6.2",
-    "@equinor/eds-icons": "^0.4.0",
-    "@equinor/eds-tokens": "^0.4.0",
+    "@equinor/eds-core-react": "^0.7.0-beta.4",
+    "@equinor/eds-icons": "^0.5.0-beta.2",
+    "@equinor/eds-tokens": "^0.5.1-beta.2",
     "@mdx-js/react": "^1.6.6",
     "@mikaelkristiansson/domready": "^1.0.10",
     "@reach/router": "^1.3.4",

--- a/apps/storefront/pnpm-lock.yaml
+++ b/apps/storefront/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 dependencies:
   '@emotion/core': 10.0.28_react@16.13.1
-  '@equinor/eds-core-react': 0.6.2_beaba6b0dd04a5acd327321cb21768d5
-  '@equinor/eds-icons': 0.4.0
-  '@equinor/eds-tokens': 0.4.0
+  '@equinor/eds-core-react': 0.7.0-beta.4_beaba6b0dd04a5acd327321cb21768d5
+  '@equinor/eds-icons': 0.5.0-beta.2
+  '@equinor/eds-tokens': 0.5.1-beta.2
   '@mdx-js/react': 1.6.6_react@16.13.1
   '@mikaelkristiansson/domready': 1.0.10
   '@reach/router': 1.3.4_react-dom@16.13.1+react@16.13.1
@@ -1335,13 +1335,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
-  /@equinor/eds-core-react/0.6.2_beaba6b0dd04a5acd327321cb21768d5:
+  /@equinor/eds-core-react/0.7.0-beta.4_beaba6b0dd04a5acd327321cb21768d5:
     dependencies:
-      '@equinor/eds-icons': 0.4.0
-      '@equinor/eds-tokens': 0.4.0
-      '@testing-library/react-hooks': 3.4.2_react@16.13.1
-      focus-visible: 5.1.0
-      lodash: 4.17.20
+      '@equinor/eds-icons': 0.5.0-beta.2
+      '@equinor/eds-tokens': 0.5.1-beta.2
       prop-types: 15.7.2
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
@@ -1351,26 +1348,26 @@ packages:
       node: '>=10.0.0'
       pnpm: '>=4'
     peerDependencies:
-      prop-types: ^15.7.2
-      react: ^16.8.6
-      react-dom: ^16.8.6
-      styled-components: ^4.2.0
+      prop-types: '>=15.7.2'
+      react: '>=16.8'
+      react-dom: '>=16.8'
+      styled-components: '>=4.2'
     resolution:
-      integrity: sha512-ZQnuevIa0czYyMN5nwLC7L3VjVvv2/LPnjqZbqxbM8gxUAEy+fM40BqC2V5n2s3UF0IvgKaJ4hb4iDlyv2Epug==
-  /@equinor/eds-icons/0.4.0:
+      integrity: sha512-DNUruRvNpS+1Iq7zRpMq4UBMpoh3fhL6+ofKAShAds0unDKGEYcoKHl4OJq3S5T7QV9d+yX+kVuin6e0B828JQ==
+  /@equinor/eds-icons/0.5.0-beta.2:
     dev: false
     engines:
       node: '>=10.0.0'
       pnpm: '>=4'
     resolution:
-      integrity: sha512-UNZqIZqxCBPIpkenwzFyP18oKtWSt8Y52TlQLSgVp5pNwKY2hVzRC60j5iCRenCT1vF8fr+LDXkDUOl4mE4HTw==
-  /@equinor/eds-tokens/0.4.0:
+      integrity: sha512-sD574J11TMS/HhiNupDCASFFE++l5uywLc9zGcE5QAI4kXED4aC2KOWN9nnoshK5KKTyax8wkA2JDsNa7UPJeQ==
+  /@equinor/eds-tokens/0.5.1-beta.2:
     dev: false
     engines:
       node: '>=10.0.0'
       pnpm: '>=4'
     resolution:
-      integrity: sha512-LEsIcAVNLkgkbjR9WSsMb8W5sAe/NWsQtqPtU7fd44l0Lda+v3FzWL7OOUnb4Da9FPARu/1ZGgad4WLBFcym6Q==
+      integrity: sha512-54KCtyCKEu7srnbDO6D7mFONoT4bQ0tPjuvOHMSR+Bk+yg0+gGrwyt8C1s0C0NqTFDarTbu6d6VzWRGwKSkUeA==
   /@graphql-tools/schema/6.0.12_graphql@14.7.0:
     dependencies:
       '@graphql-tools/utils': 6.0.12_graphql@14.7.0
@@ -2046,17 +2043,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
-  /@testing-library/react-hooks/3.4.2_react@16.13.1:
-    dependencies:
-      '@babel/runtime': 7.10.4
-      '@types/testing-library__react-hooks': 3.4.1
-      react: 16.13.1
-    dev: false
-    peerDependencies:
-      react: '>=16.9.0'
-      react-test-renderer: '>=16.9.0'
-    resolution:
-      integrity: sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==
   /@theme-ui/typography/0.2.46:
     dependencies:
       compass-vertical-rhythm: 1.4.5
@@ -2198,12 +2184,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-h0NbqXN/tJuBY/xggZSej1SKQEstbHO7J/omt1tYoFGmj3YXOodZKbbqD4mNDh7zvEGYd7YFrac1LTtAr3xsYQ==
-  /@types/react-test-renderer/16.9.3:
-    dependencies:
-      '@types/react': 16.9.43
-    dev: false
-    resolution:
-      integrity: sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
   /@types/react/16.9.43:
     dependencies:
       '@types/prop-types': 15.7.3
@@ -2218,12 +2198,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-8gBudvllD2A/c0CcEX/BivIDorHFt5UI5m46TsNj8DjWCCTTZT74kEe4g+QsY7P/B9WdO98d82zZgXO/RQzu2Q==
-  /@types/testing-library__react-hooks/3.4.1:
-    dependencies:
-      '@types/react-test-renderer': 16.9.3
-    dev: false
-    resolution:
-      integrity: sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
   /@types/tmp/0.0.33:
     dev: false
     resolution:
@@ -17234,9 +17208,9 @@ packages:
       integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==
 specifiers:
   '@emotion/core': ^10.0.28
-  '@equinor/eds-core-react': ^0.6.2
-  '@equinor/eds-icons': ^0.4.0
-  '@equinor/eds-tokens': ^0.4.0
+  '@equinor/eds-core-react': ^0.7.0-beta.4
+  '@equinor/eds-icons': ^0.5.0-beta.2
+  '@equinor/eds-tokens': ^0.5.1-beta.2
   '@mdx-js/react': ^1.6.6
   '@mikaelkristiansson/domready': ^1.0.10
   '@reach/router': ^1.3.4

--- a/package.yaml
+++ b/package.yaml
@@ -7,7 +7,8 @@ scripts:
   'lint:storybook': pnpm run lint ./apps/storybook-react/stories
   'lint:core-react': pnpm run lint ./libraries/core-react/src
   init: pnpm multi install --force && pnpm run build
-  build: pnpm --filter @equinor/eds-core-react run build
+  core-react: pnpm --filter @equinor/eds-core-react run dev
+  'test:core-react': pnpm --filter @equinor/eds-core-react run test
   'build:core-react': pnpm --filter @equinor/eds-core-react run build
   'bump:core-react': >-
     pnpm --filter @equinor/eds-core-react recursive exec -- pnpm version
@@ -15,17 +16,15 @@ scripts:
   'publish:core-react': >-
     pnpm --filter @equinor/eds-core-react recursive exec -- pnpm publish --tag
     alpha --access public
-  storybook-build: >-
+  storybook: pnpm --filter @equinor/eds-storybook-react run dev
+  'build:storybook': >-
     pnpm --filter @equinor/eds-core-react install && pnpm --filter
     @equinor/eds-core-react run build && pnpm --filter
     @equinor/eds-storybook-react install && pnpm --filter
     @equinor/eds-storybook-react run build
-  storybook: pnpm --filter @equinor/eds-storybook-react run dev
   storefront: pnpm --filter @equinor/eds-storefront run dev
-  'build:storefront': pnpm --filter @equinor/eds-core-react install
-  core-react: pnpm --filter @equinor/eds-core-react run dev
+  'build:storefront': pnpm --filter @equinor/eds-storefront run build
   figma-broker: pnpm --filter @equinor/eds-figma-broker run dev
-  test:core-react: pnpm --filter @equinor/eds-core-react run test
   test:watch:core-react: pnpm --filter @equinor/eds-core-react run test:watch
   demo: pnpm --filter ./apps/demo run dev
   dockerize-storybook: docker build -t eds/storybook-react -f apps/storybook-react/Dockerfile.dev .

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,7 @@ scripts:
     @equinor/eds-storybook-react run build
   storybook: pnpm --filter @equinor/eds-storybook-react run dev
   storefront: pnpm --filter @equinor/eds-storefront run dev
-  storefront-build: pnpm --filter @equinor/eds-core-react install
+  'build:storefront': pnpm --filter @equinor/eds-core-react install
   core-react: pnpm --filter @equinor/eds-core-react run dev
   figma-broker: pnpm --filter @equinor/eds-figma-broker run dev
   test:core-react: pnpm --filter @equinor/eds-core-react run test


### PR DESCRIPTION
- Installs dependencies from npm in Docker instead of hard linking internally
- Uses the @next release of the EDS components