### PR TITLE
Release eds-core-react@0.7.0

### DIFF
--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `z-index` values for correct layering of the components ([#872](https://github.com/equinor/design-system/issues/872))
 - Changed licence from GNU AGPL to MIT ([#852](https://github.com/equinor/design-system/issues/852))
 - Clean up use of spacings in `Card` ([#717](https://github.com/equinor/design-system/issues/717))
-- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>`/commonjs path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
+- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
 
 ### Housekeeping 🏠
 

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.3] - 2020-11-26
+## [0.7.0] - 2020-11-26
 
 ### Added ✨
 

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 📓
 
-- Updated line height for Cell Text (`Table`) tokens and text color for `Snackbar` ([#824](https://github.com/equinor/design-system/issues/824))
 - Updated `z-index` values for correct layering of the components ([#872](https://github.com/equinor/design-system/issues/872))
 - Changed licence from GNU AGPL to MIT ([#852](https://github.com/equinor/design-system/issues/852))
 - Clean up use of spacings in `Card` ([#717](https://github.com/equinor/design-system/issues/717))

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added ✨
 
-- Typescript support in all of the EDS libraries! 🎉 ([Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1))
+- Types, as part of the [Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1)
 - Created `NativeSelect` component ([#509](https://github.com/equinor/design-system/issues/509))
 - Added `Table` caption ([#621](https://github.com/equinor/design-system/issues/621))
 - Added `isExpanded` prop to be able to control `Accordion` externally ([#677](https://github.com/equinor/design-system/issues/677))
@@ -26,11 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `z-index` values for correct layering of the components ([#872](https://github.com/equinor/design-system/issues/872))
 - Changed licence from GNU AGPL to MIT ([#852](https://github.com/equinor/design-system/issues/852))
 - Clean up use of spacings in `Card` ([#717](https://github.com/equinor/design-system/issues/717))
+- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>`/commonjs path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
 
 ### Housekeeping 🏠
 
 - Removed unused dependencies ([#870](https://github.com/equinor/design-system/issues/870))
 - Bundle improvements ([#627](https://github.com/equinor/design-system/issues/627))
+- Cleaning and remodelling core-react for the future 💅 ([#887](https://github.com/equinor/design-system/issues/887))
+- Cleaned up leaking `devDependencies` ([#862](https://github.com/equinor/design-system/issues/862))
 
 ## [0.6.2] - 2020-09-16
 

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2020-11-26
+
+### Added ✨
+
+- Typescript support in all of the EDS libraries! 🎉 ([Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1))
+- Created `NativeSelect` component ([#509](https://github.com/equinor/design-system/issues/509))
+- Added `Table` caption ([#621](https://github.com/equinor/design-system/issues/621))
+- Added `isExpanded` prop to be able to control `Accordion` externally ([#677](https://github.com/equinor/design-system/issues/677))
+
+### Fixed 🐛
+
+- Added a guard clause to handle null values for `Accordion` children ([#688](https://github.com/equinor/design-system/issues/688))
+- Fixed `CardMedia` spacing bug ([#603](https://github.com/equinor/design-system/issues/603))
+- Added props spread to `BannerAction` ([#478](https://github.com/equinor/design-system/issues/478))
+- Fixed a console warning in `Pagination` ([#647](https://github.com/equinor/design-system/issues/647))
+
+### Changed 📓
+
+- Updated line height for Cell Text (`Table`) tokens and text color for `Snackbar` ([#824](https://github.com/equinor/design-system/issues/824))
+- Updated `z-index` values for correct layering of the components ([#872](https://github.com/equinor/design-system/issues/872))
+- Changed licence from GNU AGPL to MIT ([#852](https://github.com/equinor/design-system/issues/852))
+- Clean up use of spacings in `Card` ([#717](https://github.com/equinor/design-system/issues/717))
+
+### Housekeeping 🏠
+
+- Removed unused dependencies ([#870](https://github.com/equinor/design-system/issues/870))
+- Bundle improvements ([#627](https://github.com/equinor/design-system/issues/627))
+
 ## [0.6.2] - 2020-09-16
 
 ### Fixed 🐛

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -10,16 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added ✨
 
 - Types, as part of the [Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1)
-- Created `NativeSelect` component ([#509](https://github.com/equinor/design-system/issues/509))
-- Added `Table` caption ([#621](https://github.com/equinor/design-system/issues/621))
-- Added `isExpanded` prop to be able to control `Accordion` externally ([#677](https://github.com/equinor/design-system/issues/677))
+- `NativeSelect` component ([#509](https://github.com/equinor/design-system/issues/509))
+- `Table` caption ([#621](https://github.com/equinor/design-system/issues/621))
+- `isExpanded` prop to control `Accordion` externally ([#677](https://github.com/equinor/design-system/issues/677))
 
 ### Fixed 🐛
 
 - Added a guard clause to handle null values for `Accordion` children ([#688](https://github.com/equinor/design-system/issues/688))
-- Fixed `CardMedia` spacing bug ([#603](https://github.com/equinor/design-system/issues/603))
+- `CardMedia` spacing bug ([#603](https://github.com/equinor/design-system/issues/603))
 - Added props spread to `BannerAction` ([#478](https://github.com/equinor/design-system/issues/478))
-- Fixed a console warning in `Pagination` ([#647](https://github.com/equinor/design-system/issues/647))
+- `Pagination` bug ([#647](https://github.com/equinor/design-system/issues/647))
+- Bundle improvements ([#627](https://github.com/equinor/design-system/issues/627))
+- Cleaned up leaking `devDependencies` ([#862](https://github.com/equinor/design-system/issues/862))
 
 ### Changed 📓
 
@@ -27,13 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed licence from GNU AGPL to MIT ([#852](https://github.com/equinor/design-system/issues/852))
 - Clean up use of spacings in `Card` ([#717](https://github.com/equinor/design-system/issues/717))
 - Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
-
-### Housekeeping 🏠
-
 - Removed unused dependencies ([#870](https://github.com/equinor/design-system/issues/870))
-- Bundle improvements ([#627](https://github.com/equinor/design-system/issues/627))
 - Cleaning and remodelling core-react for the future 💅 ([#887](https://github.com/equinor/design-system/issues/887))
-- Cleaned up leaking `devDependencies` ([#862](https://github.com/equinor/design-system/issues/862))
 
 ## [0.6.2] - 2020-09-16
 

--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Pagination` bug ([#647](https://github.com/equinor/design-system/issues/647))
 - Bundle improvements ([#627](https://github.com/equinor/design-system/issues/627))
 - Cleaned up leaking `devDependencies` ([#862](https://github.com/equinor/design-system/issues/862))
+- Hide `Tooltip` when title is empty ([#920](https://github.com/equinor/design-system/issues/920))
 
 ### Changed 📓
 

--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0",
   "description": "The React implementation of the Equinor Design System",
   "main": "src/index.ts",
   "publishConfig": {


### PR DESCRIPTION
## [0.7.0] - 2020-11-26

### Added ✨

- Types, as part of the [Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1)
- `NativeSelect` component ([#509](https://github.com/equinor/design-system/issues/509))
- `Table` caption ([#621](https://github.com/equinor/design-system/issues/621))
- `isExpanded` prop to control `Accordion` externally ([#677](https://github.com/equinor/design-system/issues/677))

### Fixed 🐛

- Added a guard clause to handle null values for `Accordion` children ([#688](https://github.com/equinor/design-system/issues/688))
- `CardMedia` spacing bug ([#603](https://github.com/equinor/design-system/issues/603))
- Added props spread to `BannerAction` ([#478](https://github.com/equinor/design-system/issues/478))
- `Pagination` bug ([#647](https://github.com/equinor/design-system/issues/647))
- Bundle improvements ([#627](https://github.com/equinor/design-system/issues/627))
- Cleaned up leaking `devDependencies` ([#862](https://github.com/equinor/design-system/issues/862))
- Hide `Tooltip` when title is empty ([#920](https://github.com/equinor/design-system/issues/920))

### Changed 📓

- Updated `z-index` values for correct layering of the components ([#872](https://github.com/equinor/design-system/issues/872))
- Changed licence from GNU AGPL to MIT ([#852](https://github.com/equinor/design-system/issues/852))
- Clean up use of spacings in `Card` ([#717](https://github.com/equinor/design-system/issues/717))
- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
- Removed unused dependencies ([#870](https://github.com/equinor/design-system/issues/870))
- Cleaning and remodelling core-react for the future 💅 ([#887](https://github.com/equinor/design-system/issues/887))


Resolves #907 