### PR TITLE
Release eds-tokens@0.5.0

### DIFF
--- a/libraries/tokens/CHANGELOG.md
+++ b/libraries/tokens/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2020-11-26
+
+### Added
+
+- Typescript support in all of the EDS libraries ([Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1))
+
+### Changed
+
+- Updated line height for Cell Text (`Table`) tokens and text color for `Snackbar` [#824](https://github.com/equinor/design-system/issues/824)
+
 ## [0.4.0] - 2020-09-02
 
 ### Added

--- a/libraries/tokens/CHANGELOG.md
+++ b/libraries/tokens/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated line height for Cell Text (`Table`) tokens and text color for `Snackbar` [#824](https://github.com/equinor/design-system/issues/824)
+- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
 
 ## [0.4.0] - 2020-09-02
 

--- a/libraries/tokens/CHANGELOG.md
+++ b/libraries/tokens/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Typescript support in all of the EDS libraries ([Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1))
+- Types, as part of the ([Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1))
 
 ### Changed
 

--- a/libraries/tokens/package.json
+++ b/libraries/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-tokens",
-  "version": "0.5.1-beta.2",
+  "version": "0.5.0",
   "description": "Design tokens for the Equinor Design System",
   "main": "dist/tokens.cjs.js",
   "module": "dist/tokens.esm.js",


### PR DESCRIPTION
## [0.5.0] - 2020-11-26

### Added

- Types, as part of the [Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1)

### Changed

- Updated line height for Cell Text (`Table`) tokens and text color for `Snackbar` [#824](https://github.com/equinor/design-system/issues/824)
- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))

Resolves #908 