### PR TITLE
Release eds-icons@0.5.0

### DIFF
--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Types, as part of the [Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1)
 
+### Changed
+
+- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
+
 ## [0.4.0] - 2020-09-11
 
 ### Added

--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2020-11-26
+
+### Added
+
+- Types, as part of the [Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1)
+
 ## [0.4.0] - 2020-09-11
 
 ### Added

--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
+- Changed module types for better support with `cjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))
 
 ## [0.4.0] - 2020-09-11
 

--- a/libraries/icons/package.json
+++ b/libraries/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "description": "Icons from the Equinor Design System",
   "main": "dist/icons.cjs.js",
   "module": "dist/icons.esm.js",

--- a/libraries/icons/package.json
+++ b/libraries/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.5.0-beta.2",
+  "version": "0.6.0",
   "description": "Icons from the Equinor Design System",
   "main": "dist/icons.cjs.js",
   "module": "dist/icons.esm.js",


### PR DESCRIPTION
## [0.5.0] - 2020-11-26

### Added ✨ 

- Types, as part of the [Typescript Milestone](https://github.com/equinor/design-system/milestone/7?closed=1)

### Changed 📓 
- Changed module types for better support with `commonjs` and `esm`. Using the `<some-eds-npm-package>/commonjs` path on packages should no longer be needed and will be deprecated in the future ([#887](https://github.com/equinor/design-system/issues/887))

Resolves #909 