### PR TITLE
Release eds-tokens

### DIFF
--- a/libraries/tokens/CHANGELOG.md
+++ b/libraries/tokens/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2020-12-09
+
+### Changed
+
+- Removed component tokens in favour of the base tokens approach
+  - `Table`
+  - `Button`
+    - Danger
+    - Disabled
+    - Primary
+    - Secondary
+
 ## [0.5.2] - 2020-11-26
 
 ### Changed 📓

--- a/libraries/tokens/CHANGELOG.md
+++ b/libraries/tokens/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.3] - 2020-12-09
 
-### Changed
+### Removed
 
 - Removed component tokens in favour of the base tokens approach
-  - `Table`
-  - `Button`
+  - `Table` ([#830](https://github.com/equinor/design-system/issues/830))
+  - `Button` ([#831](https://github.com/equinor/design-system/issues/831))
     - Danger
     - Disabled
     - Primary

--- a/libraries/tokens/package.json
+++ b/libraries/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-tokens",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Design tokens for the Equinor Design System",
   "main": "dist/tokens.cjs.js",
   "module": "dist/tokens.esm.js",


### PR DESCRIPTION
Part of #965 

## [0.5.3] - 2020-12-09

### Changed

- Removed component tokens in favour of the base tokens approach
  - `Table`
  - `Button`
    - Danger
    - Disabled
    - Primary
    - Secondary