### PR TITLE
🐛 Stuck hover effects on touch devices

### DIFF
--- a/libraries/core-react/src/components/SelectionControls/Checkbox/Input.tsx
+++ b/libraries/core-react/src/components/SelectionControls/Checkbox/Input.tsx
@@ -69,9 +69,11 @@ const InputWrapper = styled.span<StyledInputWrapperProps>`
   display: inline-flex;
   border-radius: 50%;
   padding: ${enabled.padding};
-  &:hover {
-    background-color: ${({ disabled }) =>
-      disabled ? 'transparent' : color.hover};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ disabled }) =>
+        disabled ? 'transparent' : color.hover};
+    }
   }
 `
 export type InputProps = {

--- a/libraries/core-react/src/components/SelectionControls/Radio/Radio.tsx
+++ b/libraries/core-react/src/components/SelectionControls/Radio/Radio.tsx
@@ -83,9 +83,11 @@ const InputWrapper = styled.span<StyledInputWrapperProps>`
   display: inline-flex;
   border-radius: 50%;
   padding: ${enabled.padding};
-  &:hover {
-    background-color: ${({ disabled }) =>
-      disabled ? 'transparent' : color.hover};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ disabled }) =>
+        disabled ? 'transparent' : color.hover};
+    }
   }
 `
 export type RadioProps = {

--- a/libraries/core-react/src/components/SelectionControls/Switch/InputWrapper.tsx
+++ b/libraries/core-react/src/components/SelectionControls/Switch/InputWrapper.tsx
@@ -16,19 +16,23 @@ const BaseInputWrapper = styled.span<StyledProps>`
 `
 
 const InputWrapperDefault = styled(BaseInputWrapper)`
-  &:hover {
-    background-color: ${({ isDisabled }) =>
-      isDisabled ? 'transparent' : enabled.hover.background};
-  }
-  &:hover > span:last-child {
-    background-color: ${({ isDisabled }) =>
-      isDisabled ? _disabled.background : enabled.hover.handle.background};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ isDisabled }) =>
+        isDisabled ? 'transparent' : enabled.hover.background};
+    }
+    &:hover > span:last-child {
+      background-color: ${({ isDisabled }) =>
+        isDisabled ? _disabled.background : enabled.hover.handle.background};
+    }
   }
 `
 const InputWrapperSmall = styled(BaseInputWrapper)`
-  &:hover {
-    background-color: ${({ isDisabled }) =>
-      isDisabled ? 'transparent' : enabled.hover.background};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ isDisabled }) =>
+        isDisabled ? 'transparent' : enabled.hover.background};
+    }
   }
 `
 


### PR DESCRIPTION
Solves #987 

Using [CSS media query](https://medium.com/@mezoistvan/finally-a-css-only-solution-to-hover-on-touchscreens-c498af39c31c) approach to check if device has a mouse before applying hover styles