### PR TITLE
Table cell improvements

### DIFF
--- a/apps/storybook-react/stories/Table.stories.tsx
+++ b/apps/storybook-react/stories/Table.stories.tsx
@@ -224,12 +224,24 @@ export const Sortable: Story<TableProps> = () => {
   const onSortClick = (sortCol: Column) => {
     const updateColumns = state.columns.map((col) => {
       if (sortCol.accessor === col.accessor) {
-        const sortDirection: SortDirection =
-          sortCol.sortDirection === 'descending' ? 'ascending' : 'descending'
+        let isSorted = true
+        let sortDirection: SortDirection = 'none'
+        switch (sortCol.sortDirection) {
+          case 'descending':
+            isSorted = false
+            sortDirection = 'none'
+            break
+          case 'ascending':
+            sortDirection = 'descending'
+            break
+          default:
+            sortDirection = 'ascending'
+            break
+        }
 
         return {
           ...sortCol,
-          isSorted: true,
+          isSorted,
           sortDirection,
         }
       }

--- a/apps/storybook-react/stories/Table.stories.tsx
+++ b/apps/storybook-react/stories/Table.stories.tsx
@@ -130,9 +130,7 @@ export const simpleTable: Story<TableProps> = (args) => {
       <Head>
         <Row>
           {columns.map((col) => (
-            <Cell as="th" key={`head-${col.accessor}`}>
-              {col.name}
-            </Cell>
+            <Cell key={`head-${col.accessor}`}>{col.name}</Cell>
           ))}
         </Row>
       </Head>
@@ -154,12 +152,14 @@ const FixedContainer = styled.div`
   overflow: auto;
 `
 
+const StickyCell = styled(Cell)`
+  position: sticky;
+  top: 0;
+`
+
 export const FixedTableHeader: Story<TableProps> = () => {
   const cellValues = toCellValues(data, columns)
-  const cellStyle: CSSProperties = {
-    position: 'sticky',
-    top: 0,
-  }
+
   return (
     <FixedContainer>
       <Table>
@@ -169,9 +169,7 @@ export const FixedTableHeader: Story<TableProps> = () => {
         <Head>
           <Row>
             {columns.map((col) => (
-              <Cell as="th" key={`head-${col.accessor}`} style={cellStyle}>
-                {col.name}
-              </Cell>
+              <StickyCell key={`head-${col.accessor}`}>{col.name}</StickyCell>
             ))}
           </Row>
         </Head>
@@ -200,9 +198,7 @@ export const CompactTable: Story<TableProps> = () => {
       <Head>
         <Row>
           {columns.map((col) => (
-            <Cell as="th" key={`head-${col.accessor}`}>
-              {col.name}
-            </Cell>
+            <Cell key={`head-${col.accessor}`}>{col.name}</Cell>
           ))}
         </Row>
       </Head>
@@ -281,7 +277,6 @@ export const Sortable: Story<TableProps> = () => {
         <Row>
           {state.columns.map((col) => (
             <Cell
-              as="th"
               sort={col.sortDirection}
               key={`head-${col.accessor}`}
               onClick={col.sortDirection ? () => onSortClick(col) : undefined}

--- a/apps/storybook-react/stories/Table.stories.tsx
+++ b/apps/storybook-react/stories/Table.stories.tsx
@@ -220,7 +220,7 @@ export const CompactTable: Story<TableProps> = () => {
   )
 }
 
-const SortCell = styled<CellProps>(Cell)`
+const SortCell = styled(Cell)<{ isSorted: boolean } & CellProps>`
   svg {
     visibility: ${({ isSorted }) => (isSorted ? 'visible' : 'hidden')};
   }
@@ -296,7 +296,7 @@ export const Sortable: Story<TableProps> = () => {
   }, [state.columns])
 
   return (
-    <Table>
+    <Table density="compact">
       <Caption>
         <Typography variant="h2">Fruits cost price</Typography>
       </Caption>

--- a/apps/storybook-react/stories/Table.stories.tsx
+++ b/apps/storybook-react/stories/Table.stories.tsx
@@ -296,7 +296,7 @@ export const Sortable: Story<TableProps> = () => {
   }, [state.columns])
 
   return (
-    <Table density="compact">
+    <Table>
       <Caption>
         <Typography variant="h2">Fruits cost price</Typography>
       </Caption>

--- a/apps/storybook-react/stories/Table.stories.tsx
+++ b/apps/storybook-react/stories/Table.stories.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
-import type { CSSProperties } from 'styled-components'
 import { Story, Meta } from '@storybook/react'
-import { Table, TableProps, Typography, Icon } from '@equinor/eds-core-react'
+import {
+  Table,
+  TableProps,
+  Typography,
+  Icon,
+  CellProps,
+} from '@equinor/eds-core-react'
 import { chevron_down, chevron_up } from '@equinor/eds-icons'
 import './../style.css'
 
@@ -215,6 +220,16 @@ export const CompactTable: Story<TableProps> = () => {
   )
 }
 
+const SortCell = styled<CellProps>(Cell)`
+  svg {
+    visibility: ${({ isSorted }) => (isSorted ? 'visible' : 'hidden')};
+  }
+  &:hover {
+    svg {
+      visibility: visible;
+    }
+  }
+`
 export const Sortable: Story<TableProps> = () => {
   const [state, setState] = React.useState<{
     columns: Column[]
@@ -288,21 +303,21 @@ export const Sortable: Story<TableProps> = () => {
       <Head>
         <Row>
           {state.columns.map((col) => (
-            <Cell
+            <SortCell
               sort={col.sortDirection}
               key={`head-${col.accessor}`}
               onClick={col.sortDirection ? () => onSortClick(col) : undefined}
+              isSorted={col.isSorted}
             >
               {col.name}
               <Icon
-                style={col.isSorted ? {} : { visibility: 'hidden' }}
                 name={
-                  col.sortDirection === 'ascending'
-                    ? 'chevron_down'
-                    : 'chevron_up'
+                  col.sortDirection === 'descending'
+                    ? 'chevron_up'
+                    : 'chevron_down'
                 }
               />
-            </Cell>
+            </SortCell>
           ))}
         </Row>
       </Head>

--- a/libraries/core-react/src/components/Table/Body.tsx
+++ b/libraries/core-react/src/components/Table/Body.tsx
@@ -5,9 +5,9 @@ import { InnerContext } from './Inner.context'
 
 const TableBase = styled.tbody``
 
-type Props = HTMLAttributes<HTMLTableSectionElement>
+export type BodyProps = HTMLAttributes<HTMLTableSectionElement>
 
-export const Body = ({ children, ...props }: Props): JSX.Element => {
+export const Body = ({ children, ...props }: BodyProps): JSX.Element => {
   return (
     <InnerContext.Provider value={{ variant: 'body' }}>
       <TableBase {...props}>{children}</TableBase>

--- a/libraries/core-react/src/components/Table/Body.tsx
+++ b/libraries/core-react/src/components/Table/Body.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react'
 import { HTMLAttributes } from 'react'
 import styled from 'styled-components'
+import { InnerContext } from './Inner.context'
 
 const TableBase = styled.tbody``
 
 type Props = HTMLAttributes<HTMLTableSectionElement>
 
 export const Body = ({ children, ...props }: Props): JSX.Element => {
-  return <TableBase {...props}>{children}</TableBase>
+  return (
+    <InnerContext.Provider value={{ variant: 'body' }}>
+      <TableBase {...props}>{children}</TableBase>
+    </InnerContext.Provider>
+  )
 }
 
 // Body.displayName = 'eds-table-body'

--- a/libraries/core-react/src/components/Table/Caption.tsx
+++ b/libraries/core-react/src/components/Table/Caption.tsx
@@ -8,7 +8,7 @@ const StyledCaption = styled.caption<CaptionProps>(
   }),
 )
 
-type CaptionProps = Pick<CSSObject, 'captionSide'> &
+export type CaptionProps = Pick<CSSObject, 'captionSide'> &
   HTMLAttributes<HTMLTableCaptionElement>
 
 export const Caption = forwardRef<HTMLTableCaptionElement, CaptionProps>(

--- a/libraries/core-react/src/components/Table/Cell/index.tsx
+++ b/libraries/core-react/src/components/Table/Cell/index.tsx
@@ -5,7 +5,7 @@ import { TableDataCell } from './DataCell'
 import { TableHeaderCell } from './HeaderCell'
 import { InnerContext } from '../Inner.context'
 
-type CellProps = {
+export type CellProps = {
   /** Specifies which variant to use */
   variant?: Variants
   /** Specifies cell background color */

--- a/libraries/core-react/src/components/Table/Cell/index.tsx
+++ b/libraries/core-react/src/components/Table/Cell/index.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
 import { TdHTMLAttributes, ThHTMLAttributes } from 'react'
-import { Is, Variants, Colors } from '../Table.types'
+import { Variants, Colors } from '../Table.types'
 import { TableDataCell } from './DataCell'
 import { TableHeaderCell } from './HeaderCell'
+import { InnerContext } from '../Inner.context'
 
 type CellProps = {
-  /** Specifies which td or th to use */
-  as?: Is
   /** Specifies which variant to use */
   variant?: Variants
   /** Specifies cell background color */
@@ -18,14 +17,18 @@ type CellProps = {
   | ThHTMLAttributes<HTMLTableHeaderCellElement>
 )
 
-export const Cell = ({ as = 'td', ...props }: CellProps): JSX.Element => {
-  switch (as) {
-    case 'th':
-      return <TableHeaderCell {...props} />
-    default:
-    case 'td':
-      return <TableDataCell {...props} />
-  }
-}
+export const Cell = (props: CellProps): JSX.Element => (
+  <InnerContext.Consumer>
+    {(value) => {
+      switch (value.variant) {
+        case 'head':
+          return <TableHeaderCell {...props} />
+        default:
+        case 'body':
+          return <TableDataCell {...props} />
+      }
+    }}
+  </InnerContext.Consumer>
+)
 
 // Cell.displayName = 'eds-table-cell'

--- a/libraries/core-react/src/components/Table/Head.tsx
+++ b/libraries/core-react/src/components/Table/Head.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent } from 'react'
 import styled from 'styled-components'
 import { token } from './Cell/HeaderCell.tokens'
 import { bordersTemplate } from '@utils'
+import { InnerContext } from './Inner.context'
 
 const StyledTableHead = styled.thead`
   ${bordersTemplate(token.border)}
@@ -10,7 +11,11 @@ const StyledTableHead = styled.thead`
 `
 
 export const Head: FunctionComponent = ({ children, ...props }) => {
-  return <StyledTableHead {...props}>{children}</StyledTableHead>
+  return (
+    <InnerContext.Provider value={{ variant: 'head' }}>
+      <StyledTableHead {...props}>{children}</StyledTableHead>
+    </InnerContext.Provider>
+  )
 }
 
 // Head.displayName = 'eds-table-head'

--- a/libraries/core-react/src/components/Table/Inner.context.tsx
+++ b/libraries/core-react/src/components/Table/Inner.context.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+type State = {
+  variant: 'body' | 'head'
+}
+
+const initalState: State = {
+  variant: 'body',
+}
+
+export const InnerContext = React.createContext<State>(initalState)

--- a/libraries/core-react/src/components/Table/Row.tsx
+++ b/libraries/core-react/src/components/Table/Row.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react'
 import styled from 'styled-components'
 import { token } from './Cell/DataCell.tokens'
 
-type StyledProps = Pick<Props, 'active'>
+type StyledProps = Pick<RowProps, 'active'>
 
 const TableBase = styled.tr<StyledProps>(({ active }) => ({
   background: active ? token.states.active?.background : null,
@@ -12,12 +12,12 @@ const TableBase = styled.tr<StyledProps>(({ active }) => ({
   },
 }))
 
-type Props = {
+export type RowProps = {
   /** Hightlight row as active */
   active?: boolean
 } & React.HTMLAttributes<HTMLTableRowElement>
 
-export const Row: FunctionComponent<Props> = (props) => {
+export const Row: FunctionComponent<RowProps> = (props) => {
   const { children } = props
 
   return <TableBase {...props}>{children}</TableBase>

--- a/libraries/core-react/src/components/Table/Table.test.tsx
+++ b/libraries/core-react/src/components/Table/Table.test.tsx
@@ -29,7 +29,7 @@ describe('Caption', () => {
       <Table>
         <Head>
           <Row>
-            <Cell as="th">{text}</Cell>
+            <Cell>{text}</Cell>
           </Row>
         </Head>
       </Table>,
@@ -67,7 +67,7 @@ describe('Table', () => {
       <Table>
         <Head>
           <Row>
-            <Cell as="th">{text}</Cell>
+            <Cell>{text}</Cell>
           </Row>
         </Head>
       </Table>,
@@ -85,7 +85,7 @@ describe('Table', () => {
       <Table>
         <Head>
           <Row>
-            <Cell as="th">{header}</Cell>
+            <Cell>{header}</Cell>
           </Row>
         </Head>
         <Body>
@@ -182,7 +182,7 @@ describe('Table', () => {
       <Table>
         <Head>
           <Row>
-            <Cell as="th">{headerText}</Cell>
+            <Cell>{headerText}</Cell>
           </Row>
         </Head>
         <Body>
@@ -206,7 +206,7 @@ describe('Table', () => {
       <Table density="compact">
         <Head>
           <Row>
-            <Cell as="th">{headerText}</Cell>
+            <Cell>{headerText}</Cell>
           </Row>
         </Head>
         <Body>
@@ -232,9 +232,7 @@ describe('Table', () => {
       <Table>
         <Head>
           <Row>
-            <Cell as="th" sort="ascending">
-              {headerText}
-            </Cell>
+            <Cell sort="ascending">{headerText}</Cell>
           </Row>
         </Head>
       </Table>,
@@ -249,12 +247,8 @@ describe('Table', () => {
       <Table>
         <Head>
           <Row>
-            <Cell as="th" sort="ascending">
-              {headerText1}
-            </Cell>
-            <Cell as="th" sort="descending">
-              {headerText2}
-            </Cell>
+            <Cell sort="ascending">{headerText1}</Cell>
+            <Cell sort="descending">{headerText2}</Cell>
           </Row>
         </Head>
       </Table>,

--- a/libraries/core-react/src/components/Table/Table.types.ts
+++ b/libraries/core-react/src/components/Table/Table.types.ts
@@ -1,4 +1,3 @@
 export type Variants = 'text' | 'icon' | 'numeric' | 'input'
-export type Is = 'td' | 'th'
 export type Colors = 'error'
 export type Density = 'compact' | 'comfortable'

--- a/libraries/core-react/src/components/Table/index.tsx
+++ b/libraries/core-react/src/components/Table/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Table as BaseTable, TableProps } from './Table'
 import { Body } from './Body'
-import { Cell } from './Cell'
+import { Cell, CellProps } from './Cell'
 import { Head } from './Head'
 import { Row } from './Row'
 import { Caption } from './Caption'
@@ -31,3 +31,4 @@ Table.Caption = Caption
 
 export { Table }
 export type { TableProps }
+export type { CellProps }

--- a/libraries/core-react/src/components/Table/index.tsx
+++ b/libraries/core-react/src/components/Table/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { Table as BaseTable, TableProps } from './Table'
-import { Body } from './Body'
+import { Body, BodyProps } from './Body'
 import { Cell, CellProps } from './Cell'
 import { Head } from './Head'
-import { Row } from './Row'
-import { Caption } from './Caption'
+import { Row, RowProps } from './Row'
+import { Caption, CaptionProps } from './Caption'
 import { TableProvider } from './Table.context'
 
 const TableWrapper = (props: TableProps) => (
@@ -32,3 +32,6 @@ Table.Caption = Caption
 export { Table }
 export type { TableProps }
 export type { CellProps }
+export type { BodyProps }
+export type { RowProps }
+export type { CaptionProps }


### PR DESCRIPTION
resolves #997 

* Created a `Inner.context`, which determines which variant `Cell` within that context are rendered as. 
* ⚠️ Removed property "as", as its no longer needed and causes bugs when trying to extend `Cell` with styling using `styled()`
* Exposed typings for the other `Table` components as needed when "extending" our components with additional styling. 
* Added icon on hover for sortable cells in example