### PR TITLE
Adjustments for elements inside button

### DIFF
--- a/libraries/core-react/src/components/Button/Button.tsx
+++ b/libraries/core-react/src/components/Button/Button.tsx
@@ -42,13 +42,28 @@ const getToken = (variant: Variants, color: Colors): ButtonToken => {
   }
 }
 
-// display:grid; does not work on Webkit browser engine, so we have to wrap content in element where css-grid works
+const ButtonInnerText = styled.span`
+  text-align: center;
+`
+
 const ButtonInner = styled.span`
-  display: grid;
-  grid-gap: 8px;
-  grid-auto-flow: column;
+  display: flex;
   align-items: center;
   height: 100%;
+
+  > * {
+    flex: 1;
+  }
+
+  > svg:last-child {
+    flex: 0 24px;
+    margin-left: 8px;
+  }
+
+  > svg:first-child {
+    flex: 0 24px;
+    margin-right: 8px;
+  }
 `
 
 const Base = ({ token }: { token: ButtonToken }) => {
@@ -177,9 +192,18 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       ...other,
     }
 
+    // We need everything in elements for proper flexing 💪
+    const updatedChildren = React.Children.map(children, (child) =>
+      typeof child === 'string' ? (
+        <ButtonInnerText>{child}</ButtonInnerText>
+      ) : (
+        child
+      ),
+    )
+
     return (
       <ButtonBase {...buttonProps}>
-        <ButtonInner>{children}</ButtonInner>
+        <ButtonInner>{updatedChildren}</ButtonInner>
       </ButtonBase>
     )
   },

--- a/libraries/core-react/src/components/Button/Button.tsx
+++ b/libraries/core-react/src/components/Button/Button.tsx
@@ -55,13 +55,16 @@ const ButtonInner = styled.span<{ isIcon: boolean }>`
   grid-gap: 8px;
   grid-template-areas: 'left center right';
 
+  > img:nth-child(1),
   > svg:nth-child(1) {
     grid-area: left;
   }
 
+  > img:nth-child(n + 2),
   > svg:nth-child(n + 2) {
     grid-area: right;
   }
+  > img:only-child,
   > svg:only-child {
     grid-area: center;
   }

--- a/libraries/core-react/src/components/Button/Button.tsx
+++ b/libraries/core-react/src/components/Button/Button.tsx
@@ -44,25 +44,26 @@ const getToken = (variant: Variants, color: Colors): ButtonToken => {
 
 const ButtonInnerText = styled.span`
   text-align: center;
+  grid-area: center;
 `
 
-const ButtonInner = styled.span`
-  display: flex;
-  align-items: center;
+const ButtonInner = styled.span<{ isIcon: boolean }>`
   height: 100%;
+  display: grid;
+  align-items: center;
+  grid-template-columns: ${({ isIcon }) => (isIcon ? 'auto' : '24px 1fr 24px')};
+  grid-gap: 8px;
+  grid-template-areas: 'left center right';
 
-  > * {
-    flex: 1;
+  > svg:nth-child(1) {
+    grid-area: left;
   }
 
-  > svg:last-child {
-    flex: 0 24px;
-    margin-left: 8px;
+  > svg:nth-child(n + 2) {
+    grid-area: right;
   }
-
-  > svg:first-child {
-    flex: 0 24px;
-    margin-right: 8px;
+  > svg:only-child {
+    grid-area: center;
   }
 `
 
@@ -180,6 +181,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const as: ElementType = href ? 'a' : other.as ? other.as : 'button'
     const type = href || other.as ? undefined : 'button'
     tabIndex = disabled ? -1 : tabIndex
+    const isIcon = variant === 'ghost_icon'
 
     const buttonProps = {
       ref,
@@ -203,7 +205,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <ButtonBase {...buttonProps}>
-        <ButtonInner>{updatedChildren}</ButtonInner>
+        <ButtonInner isIcon={isIcon}>{updatedChildren}</ButtonInner>
       </ButtonBase>
     )
   },

--- a/libraries/core-react/src/components/Button/Button.tsx
+++ b/libraries/core-react/src/components/Button/Button.tsx
@@ -45,28 +45,41 @@ const getToken = (variant: Variants, color: Colors): ButtonToken => {
 const ButtonInnerText = styled.span`
   text-align: center;
   grid-area: center;
+  flex: 1;
 `
 
-const ButtonInner = styled.span<{ isIcon: boolean }>`
+const ButtonInner = styled.span`
   height: 100%;
-  display: grid;
+  display: flex;
   align-items: center;
-  grid-template-columns: ${({ isIcon }) => (isIcon ? 'auto' : '24px 1fr 24px')};
-  grid-gap: 8px;
-  grid-template-areas: 'left center right';
 
-  > img:nth-child(1),
-  > svg:nth-child(1) {
-    grid-area: left;
+  > img:first-child,
+  > svg:first-child {
+    margin-right: 8px;
   }
 
-  > img:nth-child(n + 2),
-  > svg:nth-child(n + 2) {
-    grid-area: right;
+  > img:last-child,
+  > svg:last-child {
+    margin-left: 8px;
   }
+
   > img:only-child,
   > svg:only-child {
-    grid-area: center;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  > span:first-child {
+    margin-left: 32px;
+  }
+
+  > span:last-child {
+    margin-right: 32px;
+  }
+
+  > span:only-child {
+    margin-right: 0;
+    margin-left: 0;
   }
 `
 
@@ -184,7 +197,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const as: ElementType = href ? 'a' : other.as ? other.as : 'button'
     const type = href || other.as ? undefined : 'button'
     tabIndex = disabled ? -1 : tabIndex
-    const isIcon = variant === 'ghost_icon'
 
     const buttonProps = {
       ref,
@@ -208,7 +220,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <ButtonBase {...buttonProps}>
-        <ButtonInner isIcon={isIcon}>{updatedChildren}</ButtonInner>
+        <ButtonInner>{updatedChildren}</ButtonInner>
       </ButtonBase>
     )
   },

--- a/libraries/core-react/stories/components/Button.stories.tsx
+++ b/libraries/core-react/stories/components/Button.stories.tsx
@@ -13,6 +13,14 @@ const Wrapper = styled.div`
   grid-template-columns: repeat(4, fit-content(100%));
 `
 
+const FullWidthWrapper = styled.div`
+  margin: 32px;
+  display: grid;
+  justify-content: stretch;
+  flex-direction: column;
+  grid-gap: 16px;
+`
+
 export default {
   title: 'Components/Button',
   component: Button,
@@ -255,4 +263,40 @@ export const Link: Story<ButtonProps> = () => (
   <Wrapper>
     <Button href="#">Link</Button>
   </Wrapper>
+)
+
+export const FullWidth: Story<ButtonProps> = () => (
+  <FullWidthWrapper>
+    <Button>Primary</Button>
+    <Button color="secondary">Secondary</Button>
+    <Button color="danger">Danger</Button>
+    <Button disabled>Disabled</Button>
+    <Button>
+      <Icon name="save" title="save"></Icon>Primary
+    </Button>
+    <Button color="secondary">
+      <Icon name="save" title="save"></Icon>Secondary
+    </Button>
+    <Button color="danger">
+      <Icon name="save" title="save"></Icon>Danger
+    </Button>
+    <Button disabled>
+      <Icon name="save" title="save"></Icon>Disabled
+    </Button>
+    <Button>
+      Primary <Icon name="save" title="save"></Icon>
+    </Button>
+    <Button color="secondary">
+      Secondary
+      <Icon name="save" title="save"></Icon>
+    </Button>
+    <Button color="danger">
+      Danger
+      <Icon name="save" title="save"></Icon>
+    </Button>
+    <Button disabled>
+      Disabled
+      <Icon name="save" title="save"></Icon>
+    </Button>
+  </FullWidthWrapper>
 )


### PR DESCRIPTION
resolves #992 

Tried solutions:
* Different CSS Grid variants using js to place elements in correct areas.
* Different Flex-variants

Not tried:

Having a `prefix/suffix` prop where we can pass a component for rendering icons and progress indicators would be a solution here, but it goes against our component-design philosophy of not passing components/elements as props. 


This was the best solution I could make work, using flexbox:

It works unless you have them full-width and stacked with different directions, its not optimal, but better that today atleast 🤷‍♂️
![image](https://user-images.githubusercontent.com/1070981/105845425-fc940380-5fda-11eb-96b0-a20b7a246c43.png)
