### PR TITLE
🐛 Fixed centering of content when its not text in Button

### DIFF
--- a/libraries/core-react/src/components/Button/Button.test.tsx
+++ b/libraries/core-react/src/components/Button/Button.test.tsx
@@ -91,4 +91,28 @@ describe('Button', () => {
     const { container } = render(<MarginButton>Test me!</MarginButton>)
     expect(container.firstChild).toHaveStyleRule('margin', '12px')
   })
+
+  it('has put non-react content inside center container', () => {
+    render(
+      <>
+        <Button>123</Button>
+        <Button>text</Button>
+        <Button>
+          <div>other-content</div>
+        </Button>
+      </>,
+    )
+    const numericalContent = screen.queryByText('123')
+    const textContent = screen.queryByText('text')
+    const otherContent = screen.queryByText('other-content')
+
+    expect(numericalContent).toHaveStyleRule('flex', '1')
+    expect(numericalContent.nodeName).toBe('SPAN')
+
+    expect(textContent).toHaveStyleRule('flex', '1')
+    expect(textContent.nodeName).toBe('SPAN')
+
+    expect(otherContent).not.toHaveStyleRule('flex', '1')
+    expect(otherContent.nodeName).toBe('DIV')
+  })
 })

--- a/libraries/core-react/src/components/Button/Button.tsx
+++ b/libraries/core-react/src/components/Button/Button.tsx
@@ -44,7 +44,6 @@ const getToken = (variant: Variants, color: Colors): ButtonToken => {
 
 const ButtonCenterContent = styled.span`
   text-align: center;
-  grid-area: center;
   flex: 1;
 `
 

--- a/libraries/core-react/src/components/Button/Button.tsx
+++ b/libraries/core-react/src/components/Button/Button.tsx
@@ -42,7 +42,7 @@ const getToken = (variant: Variants, color: Colors): ButtonToken => {
   }
 }
 
-const ButtonInnerText = styled.span`
+const ButtonCenterContent = styled.span`
   text-align: center;
   grid-area: center;
   flex: 1;
@@ -209,8 +209,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     // We need everything in elements for proper flexing 💪
     const updatedChildren = React.Children.map(children, (child) =>
-      typeof child === 'string' ? (
-        <ButtonInnerText>{child}</ButtonInnerText>
+      typeof child !== 'object' ? (
+        <ButtonCenterContent>{child}</ButtonCenterContent>
       ) : (
         child
       ),


### PR DESCRIPTION
fixes #1093 
Inversed operator for when an child gets put in a element inside `Button` since react elements are `objects`,