### PR TITLE
Fix AccordionHeader toggleExpanded

### DIFF
--- a/libraries/core-react/src/components/Accordion/Accordion.test.tsx
+++ b/libraries/core-react/src/components/Accordion/Accordion.test.tsx
@@ -81,6 +81,17 @@ describe('Accordion', () => {
     fireEvent.click(header)
     expect(header).toHaveAttribute('aria-expanded', 'true')
   })
+  it('triggers onToggle callback', () => {
+    const mockOnToggle = jest.fn()
+    render(
+      <AccordionItem isExpanded>
+        <AccordionHeader onToggle={mockOnToggle}>Summary 1</AccordionHeader>
+      </AccordionItem>,
+    )
+    const header = screen.queryByText('Summary 1').parentNode
+    fireEvent.click(header)
+    expect(mockOnToggle).toHaveBeenCalled()
+  })
   it('Set header level', () => {
     render(<SimpleAccordion headerLevel="h3" />)
     expect(document.querySelectorAll('h3')).toHaveLength(2)

--- a/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
+++ b/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
@@ -90,6 +90,8 @@ type AccordionHeaderProps = {
   disabled?: boolean
   /** @ignore */
   toggleExpanded?: () => void
+  /** Accordion item toggle callback */
+  onToggle?: () => void
 } & AccordionProps &
   HTMLAttributes<HTMLDivElement>
 
@@ -116,6 +118,9 @@ const AccordionHeader = forwardRef<HTMLDivElement, AccordionHeaderProps>(
     const handleClick = () => {
       if (!disabled) {
         toggleExpanded()
+        if (props.onToggle) {
+          props.onToggle()
+        }
       }
     }
 
@@ -123,6 +128,9 @@ const AccordionHeader = forwardRef<HTMLDivElement, AccordionHeaderProps>(
       const { key } = event
       if (key === 'Enter' || key === ' ') {
         toggleExpanded()
+        if (props.onToggle) {
+          props.onToggle()
+        }
         event.preventDefault()
       }
     }


### PR DESCRIPTION
**problem:** 
AccordionItem shadows external toggleExpanded. The internal and external props are mixed.
A common use case is to defer  render of components that are not visible to the user. I many of the inhouse application do have a lot of data and hidden components may be expensive to render. 

**solution:** 
add a new onToggle prop to support toggleExpanded when it's wrapped in AccordionItem. 

#1120 
