### PR TITLE
Some cleanup for CSS variables

### DIFF
--- a/libraries/core-react/.storybook/preview.js
+++ b/libraries/core-react/.storybook/preview.js
@@ -1,13 +1,13 @@
 import { addDecorator } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { GlobalStyle } from '../stories/testing/GlobalStyles'
+import { GlobalStyleDark } from '../stories/testing/GlobalStyles'
 
 addDecorator(withInfo)
 
 export const decorators = [
   (Story) => (
     <>
-      <GlobalStyle />
+      <GlobalStyleDark />
       <Story />
     </>
   ),

--- a/libraries/core-react/.storybook/preview.js
+++ b/libraries/core-react/.storybook/preview.js
@@ -1,7 +1,17 @@
 import { addDecorator } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
+import { GlobalStyle } from '../stories/testing/GlobalStyles'
 
 addDecorator(withInfo)
+
+export const decorators = [
+  (Story) => (
+    <>
+      <GlobalStyle />
+      <Story />
+    </>
+  ),
+]
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/libraries/core-react/.storybook/preview.js
+++ b/libraries/core-react/.storybook/preview.js
@@ -1,10 +1,10 @@
 import { addDecorator } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { GlobalStyleDark } from '../stories/testing/GlobalStyles'
-
+/* import { GlobalStyleDark } from '../stories/testing/GlobalStyles'
+ */
 addDecorator(withInfo)
 
-export const decorators = [
+/* export const decorators = [
   (Story) => (
     <>
       <GlobalStyleDark />
@@ -12,7 +12,7 @@ export const decorators = [
     </>
   ),
 ]
-
+ */
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   viewMode: 'docs',

--- a/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
+++ b/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
@@ -1,5 +1,5 @@
 import { tokens } from '@equinor/eds-tokens'
-import type { Typography, Border } from '@equinor/eds-tokens'
+import type { Typography } from '@equinor/eds-tokens'
 
 const {
   typography: {

--- a/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
+++ b/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
@@ -1,5 +1,5 @@
 import { tokens } from '@equinor/eds-tokens'
-import type { Typography } from '@equinor/eds-tokens'
+import type { Typography, Border } from '@equinor/eds-tokens'
 
 const {
   typography: {
@@ -29,6 +29,7 @@ type AccordionToken = {
     color: typeof token.header.color
     background: typeof token.header.background
   }
+  //border: Border
   border: string
   outline: string
   outlineOffset: string
@@ -50,6 +51,11 @@ const token = {
     },
   },
   border: `1px solid ${borderColor}`,
+  /*   border: {
+    width: '1px',
+    color: borderColor,
+    type: 'border',
+  }, */
   outline: `1px dashed ${focusOutlineColor}`,
   outlineOffset: '2px',
   chevronColor: {

--- a/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
+++ b/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
@@ -1,5 +1,5 @@
 import { tokens } from '@equinor/eds-tokens'
-import type { Typography } from '@equinor/eds-tokens'
+import type { Typography, Border } from '@equinor/eds-tokens'
 
 const {
   typography: {
@@ -41,32 +41,32 @@ const token = {
   header: {
     typography,
     color: {
-      default: `var(--eds_text_static_icons__default, ${typography.color})`,
-      disabled: `var(--eds_interactive_disabled__text, ${disabledColor})`,
-      activated: `var(--eds_interactive_primary__resting, ${activatedColor})`,
+      default: typography.color,
+      disabled: disabledColor,
+      activated: activatedColor,
     },
     background: {
-      default: `var(--eds_ui_background__default, ${backgroundDefault})`,
+      default: backgroundDefault,
       /* Mismatch i Figma!!!! --eds_ui_background__light */
-      hover: `var(--eds_ui_background__raised, ${backgroundHover})`,
+      hover: backgroundHover,
     },
   },
   /* Mismatch i Figma!! 
-  border: `1px solid var(--eds_ui_background__medium, ${borderColor})`,
+  border: `1px solid var(--eds_ui_background__medium, ${borderColor,
   */
-  border: `1px solid var(--eds_ui_background__lighten, ${borderColor})`,
-  outline: `1px dashed var(--eds_interactive_focus, ${focusOutlineColor})`,
+  border: borderColor,
+  outline: focusOutlineColor,
   outlineOffset: '2px',
   chevronColor: {
-    default: `var(--eds_interactive_primary__resting, ${activatedColor})`,
-    disabled: `var(--eds_interactive_disabled__fill, ${disabledIconColor})`,
+    default: activatedColor,
+    disabled: disabledIconColor,
   },
   iconColor: {
     interactive: {
-      color: `var(--eds_interactive_primary__resting, ${activatedColor})`,
+      color: activatedColor,
     },
     static: {
-      color: `var(--eds_text_static_icons__default, ${focusHoverColor})`,
+      color: focusHoverColor,
     },
   },
 }

--- a/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
+++ b/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
@@ -29,7 +29,6 @@ type AccordionToken = {
     color: typeof token.header.color
     background: typeof token.header.background
   }
-  //border: Border
   border: string
   outline: string
   outlineOffset: string
@@ -47,15 +46,11 @@ const token = {
     },
     background: {
       default: backgroundDefault,
-      /* Mismatch i Figma!!!! --eds_ui_background__light */
       hover: backgroundHover,
     },
   },
-  /* Mismatch i Figma!! 
-  border: `1px solid var(--eds_ui_background__medium, ${borderColor,
-  */
-  border: borderColor,
-  outline: focusOutlineColor,
+  border: `1px solid ${borderColor}`,
+  outline: `1px dashed ${focusOutlineColor}`,
   outlineOffset: '2px',
   chevronColor: {
     default: activatedColor,

--- a/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
+++ b/libraries/core-react/src/components/Accordion/Accordion.tokens.ts
@@ -1,5 +1,5 @@
 import { tokens } from '@equinor/eds-tokens'
-import type { Typography, Border } from '@equinor/eds-tokens'
+import type { Typography } from '@equinor/eds-tokens'
 
 const {
   typography: {
@@ -41,33 +41,32 @@ const token = {
   header: {
     typography,
     color: {
-      default: typography.color,
-      disabled: disabledColor,
-      activated: activatedColor,
+      default: `var(--eds_text_static_icons__default, ${typography.color})`,
+      disabled: `var(--eds_interactive_disabled__text, ${disabledColor})`,
+      activated: `var(--eds_interactive_primary__resting, ${activatedColor})`,
     },
     background: {
-      default: backgroundDefault,
-      hover: backgroundHover,
+      default: `var(--eds_ui_background__default, ${backgroundDefault})`,
+      /* Mismatch i Figma!!!! --eds_ui_background__light */
+      hover: `var(--eds_ui_background__raised, ${backgroundHover})`,
     },
   },
-  border: `1px solid ${borderColor}`,
-  /*   border: {
-    width: '1px',
-    color: borderColor,
-    type: 'border',
-  }, */
-  outline: `1px dashed ${focusOutlineColor}`,
+  /* Mismatch i Figma!! 
+  border: `1px solid var(--eds_ui_background__medium, ${borderColor})`,
+  */
+  border: `1px solid var(--eds_ui_background__lighten, ${borderColor})`,
+  outline: `1px dashed var(--eds_interactive_focus, ${focusOutlineColor})`,
   outlineOffset: '2px',
   chevronColor: {
-    default: activatedColor,
-    disabled: disabledIconColor,
+    default: `var(--eds_interactive_primary__resting, ${activatedColor})`,
+    disabled: `var(--eds_interactive_disabled__fill, ${disabledIconColor})`,
   },
   iconColor: {
     interactive: {
-      color: activatedColor,
+      color: `var(--eds_interactive_primary__resting, ${activatedColor})`,
     },
     static: {
-      color: focusHoverColor,
+      color: `var(--eds_text_static_icons__default, ${focusHoverColor})`,
     },
   },
 }

--- a/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
+++ b/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
@@ -8,6 +8,7 @@ import { Icon } from '../Icon'
 import { AccordionHeaderTitle } from './AccordionHeaderTitle'
 import { accordion as tokens } from './Accordion.tokens'
 import type { AccordionProps } from './Accordion.types'
+// import { bordersTemplate } from '@utils'
 
 Icon.add({ chevron_down, chevron_up })
 
@@ -58,7 +59,10 @@ const StyledAccordionHeader = styled.div.attrs<StyledAccordionHeaderProps>(
     borderBottom: border,
     borderLeft: border,
     boxSizing: 'border-box',
-    color: (disabled && headerColor.disabled) || headerColor.default,
+    color:
+      (disabled &&
+        `var(--eds_interactive_disabled__text, ${headerColor.disabled})`) ||
+      `var(--eds_text_static_icons__default, ${headerColor.default})`,
     outline: 'none',
     '&[data-focus-visible-added]:focus': {
       outline,

--- a/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
+++ b/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
@@ -8,7 +8,6 @@ import { Icon } from '../Icon'
 import { AccordionHeaderTitle } from './AccordionHeaderTitle'
 import { accordion as tokens } from './Accordion.tokens'
 import type { AccordionProps } from './Accordion.types'
-// import { bordersTemplate } from '@utils'
 
 Icon.add({ chevron_down, chevron_up })
 

--- a/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
+++ b/libraries/core-react/src/components/Accordion/AccordionHeader.tsx
@@ -48,6 +48,7 @@ const StyledAccordionHeader = styled.div.attrs<StyledAccordionHeaderProps>(
     fontFamily: typography.fontFamily,
     fontSize: typography.fontSize,
     fontWeight: typography.fontWeight as number,
+    backgroundColor: headerBackground.default,
     lineHeight: typography.lineHeight,
     textAlign: typography.textAlign as CSSObject['textAlign'],
     margin: 0,
@@ -59,10 +60,7 @@ const StyledAccordionHeader = styled.div.attrs<StyledAccordionHeaderProps>(
     borderBottom: border,
     borderLeft: border,
     boxSizing: 'border-box',
-    color:
-      (disabled &&
-        `var(--eds_interactive_disabled__text, ${headerColor.disabled})`) ||
-      `var(--eds_text_static_icons__default, ${headerColor.default})`,
+    color: (disabled && headerColor.disabled) || headerColor.default,
     outline: 'none',
     '&[data-focus-visible-added]:focus': {
       outline,

--- a/libraries/core-react/src/components/Banner/Banner.test.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.test.tsx
@@ -16,8 +16,6 @@ const StyledBanner = styled(Banner)`
   position: relative;
 `
 
-const { enabled } = tokens
-
 const rgbaTrim = (x: string) => x.split(' ').join('')
 
 afterEach(cleanup)
@@ -83,9 +81,9 @@ describe('Banner', () => {
     const iconSvg = container.querySelector('svg')
     expect(queryByTestId(iconWrapperTestId)).toHaveStyleRule(
       'background-color',
-      rgbaTrim(enabled.icon.info.background),
+      rgbaTrim(tokens.icon.info.background),
     )
-    expect(iconSvg).toHaveAttribute('fill', enabled.icon.info.color)
+    expect(iconSvg).toHaveAttribute('fill', tokens.icon.info.color)
   })
   it('Has correct warning icon styling', () => {
     const bannerText = 'Banner test'
@@ -101,8 +99,8 @@ describe('Banner', () => {
     const iconSvg = container.querySelector('svg')
     expect(queryByTestId(iconWrapperTestId)).toHaveStyleRule(
       'background-color',
-      rgbaTrim(enabled.icon.warning.background),
+      rgbaTrim(tokens.icon.warning.background),
     )
-    expect(iconSvg).toHaveAttribute('fill', enabled.icon.warning.color)
+    expect(iconSvg).toHaveAttribute('fill', tokens.icon.warning.color)
   })
 })

--- a/libraries/core-react/src/components/Banner/Banner.test.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.test.tsx
@@ -7,12 +7,12 @@ import styled from 'styled-components'
 import { add } from '@equinor/eds-icons'
 import { Banner } from '.'
 import { Icon } from '../Icon'
-import { banner as tokens } from './Banner.tokens'
+import * as tokens from './Banner.tokens'
 
 const { BannerMessage, BannerIcon, BannerActions } = Banner
 Icon.add({ add })
 
-const { entities } = tokens
+const { primary, info, warning } = tokens
 
 const StyledBanner = styled(Banner)`
   position: relative;
@@ -83,12 +83,9 @@ describe('Banner', () => {
     const iconSvg = container.querySelector('svg')
     expect(queryByTestId(iconWrapperTestId)).toHaveStyleRule(
       'background-color',
-      rgbaTrim(entities.icon.variants.info.background),
+      rgbaTrim(info.entities.icon.background),
     )
-    expect(iconSvg).toHaveAttribute(
-      'fill',
-      entities.icon.variants.info.typography.color,
-    )
+    expect(iconSvg).toHaveAttribute('fill', info.entities.icon.typography.color)
   })
   it('Has correct warning icon styling', () => {
     const bannerText = 'Banner test'
@@ -104,11 +101,11 @@ describe('Banner', () => {
     const iconSvg = container.querySelector('svg')
     expect(queryByTestId(iconWrapperTestId)).toHaveStyleRule(
       'background-color',
-      rgbaTrim(entities.icon.variants.warning.background),
+      rgbaTrim(warning.entities.icon.background),
     )
     expect(iconSvg).toHaveAttribute(
       'fill',
-      entities.icon.variants.warning.typography.color,
+      warning.entities.icon.typography.color,
     )
   })
 })

--- a/libraries/core-react/src/components/Banner/Banner.test.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.test.tsx
@@ -12,7 +12,7 @@ import * as tokens from './Banner.tokens'
 const { BannerMessage, BannerIcon, BannerActions } = Banner
 Icon.add({ add })
 
-const { primary, info, warning } = tokens
+const { info, warning } = tokens
 
 const StyledBanner = styled(Banner)`
   position: relative;

--- a/libraries/core-react/src/components/Banner/Banner.test.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.test.tsx
@@ -12,6 +12,8 @@ import { banner as tokens } from './Banner.tokens'
 const { BannerMessage, BannerIcon, BannerActions } = Banner
 Icon.add({ add })
 
+const { entities } = tokens
+
 const StyledBanner = styled(Banner)`
   position: relative;
 `
@@ -81,9 +83,12 @@ describe('Banner', () => {
     const iconSvg = container.querySelector('svg')
     expect(queryByTestId(iconWrapperTestId)).toHaveStyleRule(
       'background-color',
-      rgbaTrim(tokens.icon.info.background),
+      rgbaTrim(entities.icon.variants.info.background),
     )
-    expect(iconSvg).toHaveAttribute('fill', tokens.icon.info.color)
+    expect(iconSvg).toHaveAttribute(
+      'fill',
+      entities.icon.variants.info.typography.color,
+    )
   })
   it('Has correct warning icon styling', () => {
     const bannerText = 'Banner test'
@@ -99,8 +104,11 @@ describe('Banner', () => {
     const iconSvg = container.querySelector('svg')
     expect(queryByTestId(iconWrapperTestId)).toHaveStyleRule(
       'background-color',
-      rgbaTrim(tokens.icon.warning.background),
+      rgbaTrim(entities.icon.variants.warning.background),
     )
-    expect(iconSvg).toHaveAttribute('fill', tokens.icon.warning.color)
+    expect(iconSvg).toHaveAttribute(
+      'fill',
+      entities.icon.variants.warning.typography.color,
+    )
   })
 })

--- a/libraries/core-react/src/components/Banner/Banner.tokens.ts
+++ b/libraries/core-react/src/components/Banner/Banner.tokens.ts
@@ -26,17 +26,12 @@ const {
 } = tokens
 
 export type BannerToken = ComponentToken & {
-  entities: {
-    icon: ComponentToken & {
-      variants: {
-        info: ComponentToken
-        warning: ComponentToken
-      }
-    }
+  entities?: {
+    icon: ComponentToken
   }
 }
 
-export const banner: BannerToken = {
+export const primary: BannerToken = {
   typography: {
     ...messageTypography,
   },
@@ -57,19 +52,27 @@ export const banner: BannerToken = {
         width: 0,
         color: 'transparent',
       },
-      variants: {
-        info: {
-          background: infoBackground,
-          typography: {
-            color: infoColor,
-          },
-        },
-        warning: {
-          background: warningBackground,
-          typography: {
-            color: warningColor,
-          },
-        },
+    },
+  },
+}
+
+export const info: BannerToken = {
+  entities: {
+    icon: {
+      background: infoBackground,
+      typography: {
+        color: infoColor,
+      },
+    },
+  },
+}
+
+export const warning: BannerToken = {
+  entities: {
+    icon: {
+      background: warningBackground,
+      typography: {
+        color: warningColor,
       },
     },
   },

--- a/libraries/core-react/src/components/Banner/Banner.tokens.ts
+++ b/libraries/core-react/src/components/Banner/Banner.tokens.ts
@@ -1,12 +1,13 @@
 /* eslint-disable camelcase */
 import { tokens } from '@equinor/eds-tokens'
+import type { ComponentToken } from '@equinor/eds-tokens'
 
 const {
   typography: {
     paragraph: { body_long: messageTypography },
   },
   spacings: {
-    comfortable: { medium: spacingMedium },
+    comfortable: { medium },
   },
   colors: {
     infographic: {
@@ -15,33 +16,57 @@ const {
       primary__moss_green_100: { rgba: infoColor },
       primary__energy_red_100: { rgba: warningColor },
     },
+    ui: {
+      background__default: { rgba: backgroundColor },
+    },
   },
   shape: {
     circle: { minHeight, minWidth, borderRadius },
   },
 } = tokens
 
-export const banner = {
-  enabled: {
-    typography: {
-      ...messageTypography,
-    },
-    spacings: spacingMedium,
-    icon: {
-      info: {
-        background: infoBackground,
-        color: infoColor,
-      },
-      warning: {
-        background: warningBackground,
-        color: warningColor,
-      },
+export type BannerToken = ComponentToken & {
+  icon: {
+    info: {
+      background: string
+      color: string
+    }
+    warning: {
+      background: string
+      color: string
+    }
+    shape: {
+      minHeight: string
+      minWidth: string
+      borderRadius: string
+    }
+  }
+}
 
-      shape: {
-        minHeight,
-        minWidth,
-        borderRadius,
-      },
+export const banner: BannerToken = {
+  typography: {
+    ...messageTypography,
+  },
+  background: backgroundColor,
+  spacings: {
+    left: medium,
+    right: medium,
+    top: medium,
+    bottom: medium,
+  },
+  icon: {
+    info: {
+      background: infoBackground,
+      color: infoColor,
+    },
+    warning: {
+      background: warningBackground,
+      color: warningColor,
+    },
+    shape: {
+      minHeight,
+      minWidth,
+      borderRadius,
     },
   },
 }

--- a/libraries/core-react/src/components/Banner/Banner.tokens.ts
+++ b/libraries/core-react/src/components/Banner/Banner.tokens.ts
@@ -31,7 +31,7 @@ export type BannerToken = ComponentToken & {
   }
 }
 
-export const primary: BannerToken = {
+export const enabled: BannerToken = {
   typography: {
     ...messageTypography,
   },

--- a/libraries/core-react/src/components/Banner/Banner.tokens.ts
+++ b/libraries/core-react/src/components/Banner/Banner.tokens.ts
@@ -26,19 +26,12 @@ const {
 } = tokens
 
 export type BannerToken = ComponentToken & {
-  icon: {
-    info: {
-      background: string
-      color: string
-    }
-    warning: {
-      background: string
-      color: string
-    }
-    shape: {
-      minHeight: string
-      minWidth: string
-      borderRadius: string
+  entities: {
+    icon: ComponentToken & {
+      variants: {
+        info: ComponentToken
+        warning: ComponentToken
+      }
     }
   }
 }
@@ -54,19 +47,30 @@ export const banner: BannerToken = {
     top: medium,
     bottom: medium,
   },
-  icon: {
-    info: {
-      background: infoBackground,
-      color: infoColor,
-    },
-    warning: {
-      background: warningBackground,
-      color: warningColor,
-    },
-    shape: {
-      minHeight,
-      minWidth,
-      borderRadius,
+  entities: {
+    icon: {
+      height: minHeight,
+      width: minWidth,
+      border: {
+        type: 'border',
+        radius: borderRadius,
+        width: 0,
+        color: 'transparent',
+      },
+      variants: {
+        info: {
+          background: infoBackground,
+          typography: {
+            color: infoColor,
+          },
+        },
+        warning: {
+          background: warningBackground,
+          typography: {
+            color: warningColor,
+          },
+        },
+      },
     },
   },
 }

--- a/libraries/core-react/src/components/Banner/Banner.tokens.ts
+++ b/libraries/core-react/src/components/Banner/Banner.tokens.ts
@@ -26,7 +26,7 @@ const {
 } = tokens
 
 export type BannerToken = ComponentToken & {
-  entities?: {
+  entities: {
     icon: ComponentToken
   }
 }

--- a/libraries/core-react/src/components/Banner/Banner.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.tsx
@@ -5,8 +5,6 @@ import { banner as tokens } from './Banner.tokens'
 import { Divider } from '../Divider'
 import { BannerIcon } from './BannerIcon'
 
-const { enabled } = tokens
-
 const StyledBanner = styled.div``
 
 type ContentProps = {
@@ -14,11 +12,13 @@ type ContentProps = {
 }
 
 const Content = styled.div<ContentProps>`
-  padding: ${enabled.spacings};
+  padding: ${tokens.spacings.top} ${tokens.spacings.right}
+    ${tokens.spacings.bottom} ${tokens.spacings.left};
   display: grid;
   grid-template-columns: ${({ hasIcon }) =>
     hasIcon ? 'min-content 1fr auto' : '1fr auto'};
   align-items: center;
+  background-color: ${tokens.background};
 `
 
 const NonMarginDivider = styled(Divider)`

--- a/libraries/core-react/src/components/Banner/Banner.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { banner as tokens } from './Banner.tokens'
 import { Divider } from '../Divider'
 import { BannerIcon } from './BannerIcon'
+import { spacingsTemplate } from '@utils'
 
 const StyledBanner = styled.div``
 
@@ -11,14 +12,16 @@ type ContentProps = {
   hasIcon: boolean
 }
 
+const { spacings, background } = tokens
+
 const Content = styled.div<ContentProps>`
-  padding: ${tokens.spacings.top} ${tokens.spacings.right}
-    ${tokens.spacings.bottom} ${tokens.spacings.left};
+  ${spacingsTemplate(spacings)}
+
   display: grid;
   grid-template-columns: ${({ hasIcon }) =>
     hasIcon ? 'min-content 1fr auto' : '1fr auto'};
   align-items: center;
-  background-color: ${tokens.background};
+  background-color: ${background};
 `
 
 const NonMarginDivider = styled(Divider)`

--- a/libraries/core-react/src/components/Banner/Banner.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.tsx
@@ -12,16 +12,16 @@ type ContentProps = {
   hasIcon: boolean
 }
 
-const { primary } = tokens
+const { enabled } = tokens
 
 const Content = styled.div<ContentProps>`
-  ${spacingsTemplate(primary.spacings)}
+  ${spacingsTemplate(enabled.spacings)}
 
   display: grid;
   grid-template-columns: ${({ hasIcon }) =>
     hasIcon ? 'min-content 1fr auto' : '1fr auto'};
   align-items: center;
-  background-color: ${primary.background};
+  background-color: ${enabled.background};
 `
 
 const NonMarginDivider = styled(Divider)`

--- a/libraries/core-react/src/components/Banner/Banner.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
-import { banner as tokens } from './Banner.tokens'
+import * as tokens from './Banner.tokens'
 import { Divider } from '../Divider'
 import { BannerIcon } from './BannerIcon'
 import { spacingsTemplate } from '@utils'
@@ -12,16 +12,16 @@ type ContentProps = {
   hasIcon: boolean
 }
 
-const { spacings, background } = tokens
+const { primary } = tokens
 
 const Content = styled.div<ContentProps>`
-  ${spacingsTemplate(spacings)}
+  ${spacingsTemplate(primary.spacings)}
 
   display: grid;
   grid-template-columns: ${({ hasIcon }) =>
     hasIcon ? 'min-content 1fr auto' : '1fr auto'};
   align-items: center;
-  background-color: ${background};
+  background-color: ${primary.background};
 `
 
 const NonMarginDivider = styled(Divider)`
@@ -49,5 +49,3 @@ export const Banner: FC<BannerProps> = ({ children, className, ...props }) => {
     </StyledBanner>
   )
 }
-
-// Banner.displayName = 'eds-banner'

--- a/libraries/core-react/src/components/Banner/BannerActions.tsx
+++ b/libraries/core-react/src/components/Banner/BannerActions.tsx
@@ -15,7 +15,7 @@ const StyledBannerActions = styled.div<StyledBannerActionsProps>`
   grid-column: ${({ placement }) => (placement === 'bottom' ? '1/-1' : 'auto')};
   ${({ placement }) =>
     placement === 'bottom' && {
-      marginTop: tokens.spacings.left,
+      marginTop: tokens.spacings.top,
       marginLeft: '0',
     }}
 `

--- a/libraries/core-react/src/components/Banner/BannerActions.tsx
+++ b/libraries/core-react/src/components/Banner/BannerActions.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
-import { banner as tokens } from './Banner.tokens'
+import * as tokens from './Banner.tokens'
+
+const { primary } = tokens
 
 type BannerActionsPlacement = 'bottom' | 'left'
 
@@ -11,11 +13,11 @@ type StyledBannerActionsProps = {
 }
 
 const StyledBannerActions = styled.div<StyledBannerActionsProps>`
-  margin-left: ${tokens.spacings.left};
+  margin-left: ${primary.spacings.left};
   grid-column: ${({ placement }) => (placement === 'bottom' ? '1/-1' : 'auto')};
   ${({ placement }) =>
     placement === 'bottom' && {
-      marginTop: tokens.spacings.top,
+      marginTop: primary.spacings.top,
       marginLeft: '0',
     }}
 `
@@ -37,5 +39,3 @@ export const BannerActions: FC<BannerActionProps> = ({
     </StyledBannerActions>
   )
 }
-
-// BannerActions.displayName = 'eds-banner-actions'

--- a/libraries/core-react/src/components/Banner/BannerActions.tsx
+++ b/libraries/core-react/src/components/Banner/BannerActions.tsx
@@ -3,8 +3,6 @@ import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import { banner as tokens } from './Banner.tokens'
 
-const { enabled } = tokens
-
 type BannerActionsPlacement = 'bottom' | 'left'
 
 type StyledBannerActionsProps = {
@@ -13,11 +11,11 @@ type StyledBannerActionsProps = {
 }
 
 const StyledBannerActions = styled.div<StyledBannerActionsProps>`
-  margin-left: ${enabled.spacings};
+  margin-left: ${tokens.spacings.left};
   grid-column: ${({ placement }) => (placement === 'bottom' ? '1/-1' : 'auto')};
   ${({ placement }) =>
     placement === 'bottom' && {
-      marginTop: enabled.spacings,
+      marginTop: tokens.spacings.left,
       marginLeft: '0',
     }}
 `

--- a/libraries/core-react/src/components/Banner/BannerActions.tsx
+++ b/libraries/core-react/src/components/Banner/BannerActions.tsx
@@ -3,7 +3,7 @@ import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import * as tokens from './Banner.tokens'
 
-const { primary } = tokens
+const { enabled } = tokens
 
 type BannerActionsPlacement = 'bottom' | 'left'
 
@@ -13,11 +13,11 @@ type StyledBannerActionsProps = {
 }
 
 const StyledBannerActions = styled.div<StyledBannerActionsProps>`
-  margin-left: ${primary.spacings.left};
+  margin-left: ${enabled.spacings.left};
   grid-column: ${({ placement }) => (placement === 'bottom' ? '1/-1' : 'auto')};
   ${({ placement }) =>
     placement === 'bottom' && {
-      marginTop: primary.spacings.top,
+      marginTop: enabled.spacings.top,
       marginLeft: '0',
     }}
 `

--- a/libraries/core-react/src/components/Banner/BannerIcon.tsx
+++ b/libraries/core-react/src/components/Banner/BannerIcon.tsx
@@ -11,21 +11,21 @@ type StyledBannerIconProps = {
   variant: BannerIconVariant
 }
 
-const { primary, info, warning } = tokens
+const { enabled, info, warning } = tokens
 
 const StyledBannerIcon = styled.span<StyledBannerIconProps>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  ${bordersTemplate(primary.entities.icon.border)};
+  ${bordersTemplate(enabled.entities.icon.border)};
   background-color: ${({ variant }) =>
     variant === 'warning'
       ? warning.entities.icon.background
       : info.entities.icon.background};
-  width: ${primary.entities.icon.width};
-  height: ${primary.entities.icon.height};
-  margin-right: ${primary.spacings.right};
+  width: ${enabled.entities.icon.width};
+  height: ${enabled.entities.icon.height};
+  margin-right: ${enabled.spacings.right};
 `
 
 type BannerIconProps = {

--- a/libraries/core-react/src/components/Banner/BannerIcon.tsx
+++ b/libraries/core-react/src/components/Banner/BannerIcon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
-import { banner as tokens } from './Banner.tokens'
+import * as tokens from './Banner.tokens'
 import { Icon } from '../Icon'
 import { bordersTemplate } from '@utils'
 
@@ -11,22 +11,21 @@ type StyledBannerIconProps = {
   variant: BannerIconVariant
 }
 
-const { entities } = tokens
-const { icon } = entities
+const { primary, info, warning } = tokens
 
 const StyledBannerIcon = styled.span<StyledBannerIconProps>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  ${bordersTemplate(icon.border)};
+  ${bordersTemplate(primary.entities.icon.border)};
   background-color: ${({ variant }) =>
     variant === 'warning'
-      ? icon.variants.warning.background
-      : icon.variants.info.background};
-  width: ${icon.width};
-  height: ${icon.height};
-  margin-right: ${tokens.spacings.right};
+      ? warning.entities.icon.background
+      : info.entities.icon.background};
+  width: ${primary.entities.icon.width};
+  height: ${primary.entities.icon.height};
+  margin-right: ${primary.spacings.right};
 `
 
 type BannerIconProps = {
@@ -44,8 +43,8 @@ export const BannerIcon: FC<BannerIconProps> = ({
   const childrenWithColor = React.Children.map(children, (child) => {
     const color =
       variant === 'warning'
-        ? icon.variants.warning.typography.color
-        : icon.variants.info.typography.color
+        ? warning.entities.icon.typography.color
+        : info.entities.icon.typography.color
     return (
       (React.isValidElement(child) &&
         child.type === Icon &&

--- a/libraries/core-react/src/components/Banner/BannerIcon.tsx
+++ b/libraries/core-react/src/components/Banner/BannerIcon.tsx
@@ -3,6 +3,7 @@ import { FC, HTMLAttributes, ReactNode } from 'react'
 import styled from 'styled-components'
 import { banner as tokens } from './Banner.tokens'
 import { Icon } from '../Icon'
+import { bordersTemplate } from '@utils'
 
 type BannerIconVariant = 'info' | 'warning'
 
@@ -10,18 +11,21 @@ type StyledBannerIconProps = {
   variant: BannerIconVariant
 }
 
+const { entities } = tokens
+const { icon } = entities
+
 const StyledBannerIcon = styled.span<StyledBannerIconProps>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  border-radius: ${tokens.icon.shape.borderRadius};
+  ${bordersTemplate(icon.border)};
   background-color: ${({ variant }) =>
     variant === 'warning'
-      ? tokens.icon.warning.background
-      : tokens.icon.info.background};
-  width: ${tokens.icon.shape.minWidth};
-  height: ${tokens.icon.shape.minHeight};
+      ? icon.variants.warning.background
+      : icon.variants.info.background};
+  width: ${icon.width};
+  height: ${icon.height};
   margin-right: ${tokens.spacings.right};
 `
 
@@ -39,7 +43,9 @@ export const BannerIcon: FC<BannerIconProps> = ({
 }) => {
   const childrenWithColor = React.Children.map(children, (child) => {
     const color =
-      variant === 'warning' ? tokens.icon.warning.color : tokens.icon.info.color
+      variant === 'warning'
+        ? icon.variants.warning.typography.color
+        : icon.variants.info.typography.color
     return (
       (React.isValidElement(child) &&
         child.type === Icon &&
@@ -55,5 +61,3 @@ export const BannerIcon: FC<BannerIconProps> = ({
     </StyledBannerIcon>
   )
 }
-
-// BannerIcon.displayName = 'eds-banner-icon'

--- a/libraries/core-react/src/components/Banner/BannerIcon.tsx
+++ b/libraries/core-react/src/components/Banner/BannerIcon.tsx
@@ -4,8 +4,6 @@ import styled from 'styled-components'
 import { banner as tokens } from './Banner.tokens'
 import { Icon } from '../Icon'
 
-const { enabled } = tokens
-
 type BannerIconVariant = 'info' | 'warning'
 
 type StyledBannerIconProps = {
@@ -17,14 +15,14 @@ const StyledBannerIcon = styled.span<StyledBannerIconProps>`
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  border-radius: ${enabled.icon.shape.borderRadius};
+  border-radius: ${tokens.icon.shape.borderRadius};
   background-color: ${({ variant }) =>
     variant === 'warning'
-      ? enabled.icon.warning.background
-      : enabled.icon.info.background};
-  width: ${enabled.icon.shape.minWidth};
-  height: ${enabled.icon.shape.minHeight};
-  margin-right: ${enabled.spacings};
+      ? tokens.icon.warning.background
+      : tokens.icon.info.background};
+  width: ${tokens.icon.shape.minWidth};
+  height: ${tokens.icon.shape.minHeight};
+  margin-right: ${tokens.spacings.right};
 `
 
 type BannerIconProps = {
@@ -41,9 +39,7 @@ export const BannerIcon: FC<BannerIconProps> = ({
 }) => {
   const childrenWithColor = React.Children.map(children, (child) => {
     const color =
-      variant === 'warning'
-        ? enabled.icon.warning.color
-        : enabled.icon.info.color
+      variant === 'warning' ? tokens.icon.warning.color : tokens.icon.info.color
     return (
       (React.isValidElement(child) &&
         child.type === Icon &&

--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -4,27 +4,29 @@ import styled, { css } from 'styled-components'
 import { Typography } from '../Typography'
 import { Tooltip } from '../Tooltip'
 import { breadcrumbs as tokens } from './Breadcrumbs.tokens'
+import { outlineTemplate } from '@utils'
 
 type StyledProps = Pick<BreadcrumbProps, 'maxWidth'>
+
+const { states, typography } = tokens
 
 const StyledTypography = styled(Typography)<StyledProps>`
   &:hover {
     text-decoration: underline;
-    color: ${tokens.colors.hover};
+    color: ${states.hover.typography.color};
   }
   &:focus {
     outline: none;
   }
   &[data-focus-visible-added]:focus {
-    outline: ${tokens.outline};
-    outline-offset: 6px;
+    ${outlineTemplate(states.focus.outline)}
   }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
   text-decoration: none;
-  color: ${tokens.colors.enabled};
+  color: ${typography.color};
   ${({ maxWidth }) => css({ maxWidth })}
 `
 

--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tokens.ts
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tokens.ts
@@ -40,6 +40,4 @@ export const breadcrumbs: ComponentToken = {
       },
     },
   },
-
-  //outline: `1px dashed ${focusOutlineColor}`,
 }

--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tokens.ts
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tokens.ts
@@ -1,4 +1,5 @@
 import { tokens } from '@equinor/eds-tokens'
+import type { ComponentToken } from '@equinor/eds-tokens'
 
 const {
   colors: {
@@ -15,11 +16,29 @@ const {
   },
 } = tokens
 
-export const breadcrumbs = {
-  colors: {
-    enabled: enabledColor,
-    hover: hoverColor,
+export const breadcrumbs: ComponentToken = {
+  spacings: {
+    x: spacingMedium,
   },
-  margin: spacingMedium,
-  outline: `1px dashed ${focusOutlineColor}`,
+  typography: {
+    color: enabledColor,
+  },
+  states: {
+    hover: {
+      typography: {
+        color: hoverColor,
+      },
+    },
+    focus: {
+      outline: {
+        width: '1px',
+        color: focusOutlineColor,
+        style: 'dashed',
+        type: 'outline',
+        offset: '6px',
+      },
+    },
+  },
+
+  //outline: `1px dashed ${focusOutlineColor}`,
 }

--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tokens.ts
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tokens.ts
@@ -18,7 +18,8 @@ const {
 
 export const breadcrumbs: ComponentToken = {
   spacings: {
-    x: spacingMedium,
+    left: spacingMedium,
+    right: spacingMedium,
   },
   typography: {
     color: enabledColor,

--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -9,7 +9,7 @@ import {
 import styled from 'styled-components'
 import { breadcrumbs as tokens } from './Breadcrumbs.tokens'
 import { Typography } from '../Typography'
-import { outlineTemplate } from '@utils'
+import { outlineTemplate, spacingsTemplate } from '@utils'
 
 const { spacings, typography, states } = tokens
 
@@ -27,7 +27,7 @@ const ListItem = styled.li`
 
 const Separator = styled(Typography)`
   color: ${typography.color};
-  margin: 0 ${spacings.x};
+  ${spacingsTemplate(spacings)}
 `
 
 const Collapsed = styled(Typography)`

--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -9,6 +9,9 @@ import {
 import styled from 'styled-components'
 import { breadcrumbs as tokens } from './Breadcrumbs.tokens'
 import { Typography } from '../Typography'
+import { outlineTemplate } from '@utils'
+
+const { spacings, typography, states } = tokens
 
 const OrderedList = styled.ol`
   list-style: none;
@@ -23,23 +26,22 @@ const ListItem = styled.li`
 `
 
 const Separator = styled(Typography)`
-  color: ${tokens.colors.enabled};
-  margin: 0 ${tokens.margin};
+  color: ${typography.color};
+  margin: 0 ${spacings.x};
 `
 
 const Collapsed = styled(Typography)`
   &:hover {
     text-decoration: underline;
-    color: ${tokens.colors.hover};
+    color: ${states.hover.typography.color};
   }
   &:focus {
     outline: none;
   }
   &[data-focus-visible-added]:focus {
-    outline: ${tokens.outline};
-    outline-offset: 6px;
+    ${outlineTemplate(states.focus.outline)}
   }
-  color: ${tokens.colors.enabled};
+  color: ${typography.color};
   text-decoration: none;
 `
 

--- a/libraries/core-react/src/components/Card/Card.test.tsx
+++ b/libraries/core-react/src/components/Card/Card.test.tsx
@@ -48,7 +48,7 @@ describe('Card', () => {
     const card = container.firstChild
     expect(card).toHaveStyleRule(
       'background-color',
-      trimSpaces(token.background.info),
+      trimSpaces(token.backgroundVariants.info),
     )
   })
   it('Has provided title and subtitle in CardHeaderTitle', () => {

--- a/libraries/core-react/src/components/Card/Card.test.tsx
+++ b/libraries/core-react/src/components/Card/Card.test.tsx
@@ -4,12 +4,14 @@ import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import styled from 'styled-components'
 import { Typography } from '../Typography'
-import { card as token } from './Card.tokens'
+import * as tokens from './Card.tokens'
 import { trimSpaces } from '@utils'
 
 import { Card } from '.'
 
 const { CardHeader, CardHeaderTitle, CardMedia, CardActions } = Card
+
+const { info } = tokens
 
 const StyledCard = styled(Card)`
   position: relative;
@@ -48,7 +50,7 @@ describe('Card', () => {
     const card = container.firstChild
     expect(card).toHaveStyleRule(
       'background-color',
-      trimSpaces(token.backgroundVariants.info),
+      trimSpaces(info.background),
     )
   })
   it('Has provided title and subtitle in CardHeaderTitle', () => {

--- a/libraries/core-react/src/components/Card/Card.tokens.ts
+++ b/libraries/core-react/src/components/Card/Card.tokens.ts
@@ -14,29 +14,18 @@ const {
     comfortable: { medium: spacingMedium },
   },
   shape: {
-    corners: { minHeight, minWidth, borderRadius },
+    corners: { borderRadius },
   },
 } = tokens
 
-export type CardToken = ComponentToken & {
-  shape: {
-    minHeight: string
-    minWidth: string
-    borderRadius: string
-  }
-  backgroundVariants: {
-    default: string
-    info: string
-    danger: string
-    warning: string
-  }
-}
+export type CardToken = ComponentToken
 
-export const card: CardToken = {
-  shape: {
-    minHeight,
-    minWidth,
-    borderRadius,
+export const primary: CardToken = {
+  background: background,
+  border: {
+    type: 'border',
+    radius: borderRadius,
+    width: 0,
   },
   spacings: {
     left: spacingMedium,
@@ -44,10 +33,14 @@ export const card: CardToken = {
     right: spacingMedium,
     top: spacingMedium,
   },
-  backgroundVariants: {
-    default: background,
-    info: backgroundInfo,
-    danger: backgroundDanger,
-    warning: backgroundWarning,
-  },
+}
+
+export const info: CardToken = {
+  background: backgroundInfo,
+}
+export const danger: CardToken = {
+  background: backgroundDanger,
+}
+export const warning: CardToken = {
+  background: backgroundWarning,
 }

--- a/libraries/core-react/src/components/Card/Card.tokens.ts
+++ b/libraries/core-react/src/components/Card/Card.tokens.ts
@@ -1,4 +1,5 @@
 import { tokens } from '@equinor/eds-tokens'
+import type { ComponentToken } from '@equinor/eds-tokens'
 
 const {
   colors: {
@@ -17,7 +18,21 @@ const {
   },
 } = tokens
 
-export const card = {
+export type CardToken = ComponentToken & {
+  shape: {
+    minHeight: string
+    minWidth: string
+    borderRadius: string
+  }
+  backgroundVariants: {
+    default: string
+    info: string
+    danger: string
+    warning: string
+  }
+}
+
+export const card: CardToken = {
   shape: {
     minHeight,
     minWidth,
@@ -29,7 +44,7 @@ export const card = {
     right: spacingMedium,
     top: spacingMedium,
   },
-  background: {
+  backgroundVariants: {
     default: background,
     info: backgroundInfo,
     danger: backgroundDanger,

--- a/libraries/core-react/src/components/Card/Card.tsx
+++ b/libraries/core-react/src/components/Card/Card.tsx
@@ -34,28 +34,21 @@ const StyledCard = styled.div<StyledCardProps>`
 
 type backgroundVariants = { variant: string; backgroundColor: string }[]
 
-const backgroundVariants: backgroundVariants = [
-  { variant: 'default', backgroundColor: primary.background },
-  { variant: 'info', backgroundColor: info.background },
-  { variant: 'warning', backgroundColor: warning.background },
-  { variant: 'danger', backgroundColor: danger.background },
-]
-
 export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   { children, className, variant = 'default', onClick, ...rest },
   ref,
 ) {
-  const cardVariant = backgroundVariants.find((elem) => {
-    return elem.variant === variant
-  })
-
   const cursor = onClick ? 'pointer' : 'default'
+
+  const cardVariant = variant === 'default' ? 'primary' : variant
+
+  const token = tokens[cardVariant]
 
   const props = {
     ...rest,
     className,
     ref,
-    background: cardVariant && cardVariant.backgroundColor,
+    background: token.background,
     cursor,
   }
 

--- a/libraries/core-react/src/components/Card/Card.tsx
+++ b/libraries/core-react/src/components/Card/Card.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import * as tokens from './Card.tokens'
 import { spacingsTemplate, bordersTemplate } from '@utils'
 
-const { primary, info, warning, danger } = tokens
+const { primary } = tokens
 
 type StyledCardProps = {
   background: string
@@ -31,8 +31,6 @@ const StyledCard = styled.div<StyledCardProps>`
   ${bordersTemplate(primary.border)};
   ${spacingsTemplate(primary.spacings)}
 `
-
-type backgroundVariants = { variant: string; backgroundColor: string }[]
 
 export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   { children, className, variant = 'default', onClick, ...rest },

--- a/libraries/core-react/src/components/Card/Card.tsx
+++ b/libraries/core-react/src/components/Card/Card.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
-import { card as tokens } from './Card.tokens'
-import { spacingsTemplate } from '@utils'
+import * as tokens from './Card.tokens'
+import { spacingsTemplate, bordersTemplate } from '@utils'
 
-const { spacings, shape, backgroundVariants } = tokens
+const { primary, info, warning, danger } = tokens
 
 type StyledCardProps = {
   background: string
@@ -19,7 +19,6 @@ export type CardProps = {
 const StyledCard = styled.div<StyledCardProps>`
   height: fit-content;
   width: 100%;
-  min-width: ${shape.minWidth};
   position: relative;
   background-color: ${({ background }) => background};
   box-sizing: border-box;
@@ -28,24 +27,35 @@ const StyledCard = styled.div<StyledCardProps>`
   grid-auto-columns: auto;
   align-items: center;
   align-content: start;
-  border-radius: ${shape.borderRadius};
-  min-height: ${shape.minHeight};
   cursor: ${({ cursor }) => cursor};
-
-  ${spacingsTemplate(spacings)}
+  ${bordersTemplate(primary.border)};
+  ${spacingsTemplate(primary.spacings)}
 `
+
+type backgroundVariants = { variant: string; backgroundColor: string }[]
+
+const backgroundVariants: backgroundVariants = [
+  { variant: 'default', backgroundColor: primary.background },
+  { variant: 'info', backgroundColor: info.background },
+  { variant: 'warning', backgroundColor: warning.background },
+  { variant: 'danger', backgroundColor: danger.background },
+]
 
 export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   { children, className, variant = 'default', onClick, ...rest },
   ref,
 ) {
+  const cardVariant = backgroundVariants.find((elem) => {
+    return elem.variant === variant
+  })
+
   const cursor = onClick ? 'pointer' : 'default'
 
   const props = {
     ...rest,
     className,
     ref,
-    background: backgroundVariants[variant],
+    background: cardVariant && cardVariant.backgroundColor,
     cursor,
   }
 
@@ -55,5 +65,3 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
     </StyledCard>
   )
 })
-
-// Card.displayName = 'eds-card'

--- a/libraries/core-react/src/components/Card/Card.tsx
+++ b/libraries/core-react/src/components/Card/Card.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { card as tokens } from './Card.tokens'
 import { spacingsTemplate } from '@utils'
 
-const { spacings, shape } = tokens
+const { spacings, shape, backgroundVariants } = tokens
 
 type StyledCardProps = {
   background: string
@@ -45,7 +45,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
     ...rest,
     className,
     ref,
-    background: tokens.background[variant],
+    background: backgroundVariants[variant],
     cursor,
   }
 

--- a/libraries/core-react/src/components/Card/CardActions.tsx
+++ b/libraries/core-react/src/components/Card/CardActions.tsx
@@ -41,5 +41,3 @@ export const CardActions = forwardRef<HTMLDivElement, CardActionProps>(
     )
   },
 )
-
-// CardActions.displayName = 'eds-card-actions'

--- a/libraries/core-react/src/components/Card/CardHeader.tsx
+++ b/libraries/core-react/src/components/Card/CardHeader.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components'
 
 import { card as tokens } from './Card.tokens'
 
+const { spacings } = tokens
+
 export type CardHeaderProps = HTMLAttributes<HTMLDivElement>
 
 const StyledCardHeader = styled.div`
@@ -12,7 +14,7 @@ const StyledCardHeader = styled.div`
   align-items: center;
 
   > :not(:first-child) {
-    margin-left: ${tokens.spacings.left};
+    margin-left: ${spacings.left};
   }
 `
 

--- a/libraries/core-react/src/components/Card/CardHeader.tsx
+++ b/libraries/core-react/src/components/Card/CardHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { forwardRef, HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
-import { card as tokens } from './Card.tokens'
+import { primary as tokens } from './Card.tokens'
 
 const { spacings } = tokens
 
@@ -29,5 +29,3 @@ export const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
     return <StyledCardHeader {...props}>{children}</StyledCardHeader>
   },
 )
-
-// CardHeader.displayName = 'eds-card-header'

--- a/libraries/core-react/src/components/Card/CardHeaderTitle.tsx
+++ b/libraries/core-react/src/components/Card/CardHeaderTitle.tsx
@@ -21,5 +21,3 @@ export const CardHeaderTitle = forwardRef<HTMLDivElement, CardHeaderTitleProps>(
     return <StyledCardHeaderTitle {...props}>{children}</StyledCardHeaderTitle>
   },
 )
-
-// CardHeaderTitle.displayName = 'eds-card-header-title'

--- a/libraries/core-react/src/components/Card/CardMedia.tsx
+++ b/libraries/core-react/src/components/Card/CardMedia.tsx
@@ -4,6 +4,8 @@ import styled, { css } from 'styled-components'
 
 import { card as tokens } from './Card.tokens'
 
+const { spacings, shape } = tokens
+
 export type CardMediaProps = {
   /** Should the media be full width or not */
   fullWidth?: boolean
@@ -20,18 +22,16 @@ const StyledCardMedia = styled.div<CardMediaProps>`
     fullWidth
       ? css`
           > * {
-            width: calc(
-              100% + ${tokens.spacings.left} + ${tokens.spacings.right}
-            );
-            margin-left: -${tokens.spacings.left};
-            margin-right: -${tokens.spacings.right};
+            width: calc(100% + ${spacings.left} + ${spacings.right});
+            margin-left: -${spacings.left};
+            margin-right: -${spacings.right};
           }
 
           &:first-child {
-            margin-top: -${tokens.spacings.top};
+            margin-top: -${spacings.top};
             img {
-              border-top-right-radius: ${tokens.shape.borderRadius};
-              border-top-left-radius: ${tokens.shape.borderRadius};
+              border-top-right-radius: ${shape.borderRadius};
+              border-top-left-radius: ${shape.borderRadius};
             }
           }
         `

--- a/libraries/core-react/src/components/Card/CardMedia.tsx
+++ b/libraries/core-react/src/components/Card/CardMedia.tsx
@@ -2,9 +2,9 @@ import * as React from 'react'
 import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 
-import { card as tokens } from './Card.tokens'
+import { primary as tokens } from './Card.tokens'
 
-const { spacings, shape } = tokens
+const { spacings, border } = tokens
 
 export type CardMediaProps = {
   /** Should the media be full width or not */
@@ -30,8 +30,10 @@ const StyledCardMedia = styled.div<CardMediaProps>`
           &:first-child {
             margin-top: -${spacings.top};
             img {
-              border-top-right-radius: ${shape.borderRadius};
-              border-top-left-radius: ${shape.borderRadius};
+              border-top-right-radius: ${border.type === 'border' &&
+              border.radius};
+              border-top-left-radius: ${border.type === 'border' &&
+              border.radius};
             }
           }
         `
@@ -57,5 +59,3 @@ export const CardMedia = forwardRef<HTMLDivElement, CardMediaProps>(
     return <StyledCardMedia {...props}>{children}</StyledCardMedia>
   },
 )
-
-// CardMedia.displayName = 'eds-card-media'

--- a/libraries/core-react/src/components/Chip/Chip.test.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.test.tsx
@@ -15,7 +15,7 @@ const StyledChips = styled(Chip)`
   position: relative;
 `
 
-const { active: activeToken, error } = tokens
+const { states, error, border } = tokens
 
 const rgbaTrim = (x: string) => x.split(' ').join('')
 
@@ -57,11 +57,11 @@ describe('Chips', () => {
 
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
-    expect(chip).toHaveStyleRule('padding-right', tokens.enabled.spacings.right)
-    expect(chip).toHaveStyleRule('border-radius', tokens.enabled.border.radius)
+    expect(chip).toHaveStyleRule('padding-right', tokens.spacings.right)
+    // expect(chip).toHaveStyleRule('border-radius', border.radius)
     expect(icon).toBeDefined()
-    expect(icon).toHaveAttribute('height', tokens.enabled.icon.height)
-    expect(icon).toHaveAttribute('width', tokens.enabled.icon.width)
+    expect(icon).toHaveAttribute('height', tokens.icon.height)
+    expect(icon).toHaveAttribute('width', tokens.icon.width)
   })
   it('Has provided Avatar', () => {
     const chipText = 'hello, I am a chip'
@@ -96,12 +96,12 @@ describe('Chips', () => {
 
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
-    expect(chip).toHaveStyleRule('padding-right', tokens.enabled.spacings.right)
-    expect(chip).toHaveStyleRule('border-radius', tokens.enabled.border.radius)
+    expect(chip).toHaveStyleRule('padding-right', tokens.spacings.right)
+    //expect(chip).toHaveStyleRule('border-radius', tokens.border.radius)
     expect(avatar).toBeDefined()
     expect(avatar.firstChild).toHaveAttribute('src', imageUrl)
-    expect(avatar).toHaveStyleRule('height', tokens.enabled.icon.height)
-    expect(avatar).toHaveStyleRule('width', tokens.enabled.icon.width)
+    expect(avatar).toHaveStyleRule('height', tokens.icon.height)
+    expect(avatar).toHaveStyleRule('width', tokens.icon.width)
   })
 
   it('Has called handleDelete once with props when close icon is clicked', () => {
@@ -170,7 +170,7 @@ describe('Chips', () => {
     const { queryByText } = render(<Chip variant="active">{chipText}</Chip>)
     expect(queryByText(chipText)).toHaveStyleRule(
       'background',
-      rgbaTrim(activeToken.background),
+      rgbaTrim(states.active.background),
     )
   })
   it('Has some correct error styling', () => {
@@ -189,8 +189,8 @@ describe('Chips', () => {
     )
 
     expect(chip).toHaveStyleRule('background', rgbaTrim(error.background))
-    expect(chip).toHaveStyleRule('border-color', rgbaTrim(error.border.color))
+    //expect(chip).toHaveStyleRule('border-color', rgbaTrim(error.border.color))
     expect(chip).toHaveStyleRule('color', rgbaTrim(error.typography.color))
-    expect(chipIconStyle.fill).toBe(rgbaTrim(error.icon.color))
+    expect(chipIconStyle.fill).toBe(rgbaTrim(error.icon.typography.color))
   })
 })

--- a/libraries/core-react/src/components/Chip/Chip.test.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.test.tsx
@@ -58,7 +58,10 @@ describe('Chips', () => {
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
     expect(chip).toHaveStyleRule('padding-right', tokens.spacings.right)
-    // expect(chip).toHaveStyleRule('border-radius', border.radius)
+    expect(chip).toHaveStyleRule(
+      'border-radius',
+      border.type === 'border' && border.radius,
+    )
     expect(icon).toBeDefined()
     expect(icon).toHaveAttribute('height', tokens.icon.height)
     expect(icon).toHaveAttribute('width', tokens.icon.width)
@@ -93,11 +96,13 @@ describe('Chips', () => {
     )
     const chip = queryByText(chipText)
     const avatar = queryByTestId(avatarTestId)
-
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
     expect(chip).toHaveStyleRule('padding-right', tokens.spacings.right)
-    //expect(chip).toHaveStyleRule('border-radius', tokens.border.radius)
+    expect(chip).toHaveStyleRule(
+      'border-radius',
+      tokens.border.type === 'border' && tokens.border.radius,
+    )
     expect(avatar).toBeDefined()
     expect(avatar.firstChild).toHaveAttribute('src', imageUrl)
     expect(avatar).toHaveStyleRule('height', tokens.icon.height)
@@ -189,7 +194,12 @@ describe('Chips', () => {
     )
 
     expect(chip).toHaveStyleRule('background', rgbaTrim(error.background))
-    //expect(chip).toHaveStyleRule('border-color', rgbaTrim(error.border.color))
+    expect(chip).toHaveStyleRule(
+      'border',
+      `1px solid ${rgbaTrim(
+        error.border.type === 'border' && error.border.color,
+      )}`,
+    )
     expect(chip).toHaveStyleRule('color', rgbaTrim(error.typography.color))
     expect(chipIconStyle.fill).toBe(rgbaTrim(error.icon.typography.color))
   })

--- a/libraries/core-react/src/components/Chip/Chip.test.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.test.tsx
@@ -15,7 +15,7 @@ const StyledChips = styled(Chip)`
   position: relative;
 `
 
-const { primary, error } = tokens
+const { enabled, error } = tokens
 
 const rgbaTrim = (x: string) => x.split(' ').join('')
 
@@ -57,14 +57,14 @@ describe('Chips', () => {
 
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
-    expect(chip).toHaveStyleRule('padding-right', primary.spacings.right)
+    expect(chip).toHaveStyleRule('padding-right', enabled.spacings.right)
     expect(chip).toHaveStyleRule(
       'border-radius',
-      primary.border.type === 'border' && primary.border.radius,
+      enabled.border.type === 'border' && enabled.border.radius,
     )
     expect(icon).toBeDefined()
-    expect(icon).toHaveAttribute('height', primary.entities.icon.height)
-    expect(icon).toHaveAttribute('width', primary.entities.icon.width)
+    expect(icon).toHaveAttribute('height', enabled.entities.icon.height)
+    expect(icon).toHaveAttribute('width', enabled.entities.icon.width)
   })
   it('Has provided Avatar', () => {
     const chipText = 'hello, I am a chip'
@@ -98,15 +98,15 @@ describe('Chips', () => {
     const avatar = queryByTestId(avatarTestId)
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
-    expect(chip).toHaveStyleRule('padding-right', primary.spacings.right)
+    expect(chip).toHaveStyleRule('padding-right', enabled.spacings.right)
     expect(chip).toHaveStyleRule(
       'border-radius',
-      primary.border.type === 'border' && primary.border.radius,
+      enabled.border.type === 'border' && enabled.border.radius,
     )
     expect(avatar).toBeDefined()
     expect(avatar.firstChild).toHaveAttribute('src', imageUrl)
-    expect(avatar).toHaveStyleRule('height', primary.entities.icon.height)
-    expect(avatar).toHaveStyleRule('width', primary.entities.icon.width)
+    expect(avatar).toHaveStyleRule('height', enabled.entities.icon.height)
+    expect(avatar).toHaveStyleRule('width', enabled.entities.icon.width)
   })
 
   it('Has called handleDelete once with props when close icon is clicked', () => {
@@ -175,7 +175,7 @@ describe('Chips', () => {
     const { queryByText } = render(<Chip variant="active">{chipText}</Chip>)
     expect(queryByText(chipText)).toHaveStyleRule(
       'background',
-      rgbaTrim(primary.states.active.background),
+      rgbaTrim(enabled.states.active.background),
     )
   })
   it('Has some correct error styling', () => {

--- a/libraries/core-react/src/components/Chip/Chip.test.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.test.tsx
@@ -7,7 +7,7 @@ import { add } from '@equinor/eds-icons'
 import { Chip } from './Chip'
 import { Avatar } from '../Avatar'
 import { Icon } from '../Icon'
-import { chip as tokens } from './Chip.tokens'
+import * as tokens from './Chip.tokens'
 
 Icon.add({ add })
 
@@ -15,7 +15,7 @@ const StyledChips = styled(Chip)`
   position: relative;
 `
 
-const { states, error, border } = tokens
+const { primary, error } = tokens
 
 const rgbaTrim = (x: string) => x.split(' ').join('')
 
@@ -57,14 +57,14 @@ describe('Chips', () => {
 
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
-    expect(chip).toHaveStyleRule('padding-right', tokens.spacings.right)
+    expect(chip).toHaveStyleRule('padding-right', primary.spacings.right)
     expect(chip).toHaveStyleRule(
       'border-radius',
-      border.type === 'border' && border.radius,
+      primary.border.type === 'border' && primary.border.radius,
     )
     expect(icon).toBeDefined()
-    expect(icon).toHaveAttribute('height', tokens.icon.height)
-    expect(icon).toHaveAttribute('width', tokens.icon.width)
+    expect(icon).toHaveAttribute('height', primary.entities.icon.height)
+    expect(icon).toHaveAttribute('width', primary.entities.icon.width)
   })
   it('Has provided Avatar', () => {
     const chipText = 'hello, I am a chip'
@@ -98,15 +98,15 @@ describe('Chips', () => {
     const avatar = queryByTestId(avatarTestId)
     expect(chip).toBeDefined()
     expect(chip).toHaveStyleRule('padding-left', '4px')
-    expect(chip).toHaveStyleRule('padding-right', tokens.spacings.right)
+    expect(chip).toHaveStyleRule('padding-right', primary.spacings.right)
     expect(chip).toHaveStyleRule(
       'border-radius',
-      tokens.border.type === 'border' && tokens.border.radius,
+      primary.border.type === 'border' && primary.border.radius,
     )
     expect(avatar).toBeDefined()
     expect(avatar.firstChild).toHaveAttribute('src', imageUrl)
-    expect(avatar).toHaveStyleRule('height', tokens.icon.height)
-    expect(avatar).toHaveStyleRule('width', tokens.icon.width)
+    expect(avatar).toHaveStyleRule('height', primary.entities.icon.height)
+    expect(avatar).toHaveStyleRule('width', primary.entities.icon.width)
   })
 
   it('Has called handleDelete once with props when close icon is clicked', () => {
@@ -175,7 +175,7 @@ describe('Chips', () => {
     const { queryByText } = render(<Chip variant="active">{chipText}</Chip>)
     expect(queryByText(chipText)).toHaveStyleRule(
       'background',
-      rgbaTrim(states.active.background),
+      rgbaTrim(primary.states.active.background),
     )
   })
   it('Has some correct error styling', () => {
@@ -201,6 +201,8 @@ describe('Chips', () => {
       )}`,
     )
     expect(chip).toHaveStyleRule('color', rgbaTrim(error.typography.color))
-    expect(chipIconStyle.fill).toBe(rgbaTrim(error.icon.typography.color))
+    expect(chipIconStyle.fill).toBe(
+      rgbaTrim(error.entities.icon.typography.color),
+    )
   })
 })

--- a/libraries/core-react/src/components/Chip/Chip.tokens.ts
+++ b/libraries/core-react/src/components/Chip/Chip.tokens.ts
@@ -34,7 +34,7 @@ export type ChipToken = ComponentToken & {
   entities: { icon: ComponentToken }
 }
 
-export const primary: ChipToken = {
+export const enabled: ChipToken = {
   background: backgroundColor,
   height: '22px',
   border: {

--- a/libraries/core-react/src/components/Chip/Chip.tokens.ts
+++ b/libraries/core-react/src/components/Chip/Chip.tokens.ts
@@ -31,13 +31,10 @@ const {
 } = tokens
 
 export type ChipToken = ComponentToken & {
-  icon: ComponentToken
-  error: ComponentToken & {
-    icon: ComponentToken
-  }
+  entities: { icon: ComponentToken }
 }
 
-export const chip: ChipToken = {
+export const primary: ChipToken = {
   background: backgroundColor,
   height: '22px',
   border: {
@@ -79,39 +76,44 @@ export const chip: ChipToken = {
       background: activeColor,
     },
   },
-  icon: {
-    height: medium,
-    width: medium,
-    border: {
-      radius: borderRadius,
-      type: 'border',
-      width: 0,
-    },
-    states: {
-      hover: {
-        background: primaryHoverAlt,
+  entities: {
+    icon: {
+      height: medium,
+      width: medium,
+      border: {
+        radius: borderRadius,
+        type: 'border',
+        width: 0,
       },
-    },
-  },
-  error: {
-    background: backgroundColorDefault,
-    border: {
-      type: 'border',
-      color: errorColor,
-      width: '1px',
-      style: 'solid',
-      radius: borderRadius,
-    },
-    typography: {
-      color: errorColor,
-    },
-    states: {
-      hover: {
-        typography: {
-          color: errorColorHover,
+      states: {
+        hover: {
+          background: primaryHoverAlt,
         },
       },
     },
+  },
+}
+
+export const error: ChipToken = {
+  background: backgroundColorDefault,
+  border: {
+    type: 'border',
+    color: errorColor,
+    width: '1px',
+    style: 'solid',
+    radius: borderRadius,
+  },
+  typography: {
+    color: errorColor,
+  },
+  states: {
+    hover: {
+      typography: {
+        color: errorColorHover,
+      },
+    },
+  },
+  entities: {
     icon: {
       typography: {
         color: errorColor,

--- a/libraries/core-react/src/components/Chip/Chip.tokens.ts
+++ b/libraries/core-react/src/components/Chip/Chip.tokens.ts
@@ -1,4 +1,5 @@
 import { tokens } from '@equinor/eds-tokens'
+import type { ComponentToken } from '@equinor/eds-tokens'
 
 const {
   spacings: {
@@ -29,66 +30,93 @@ const {
   },
 } = tokens
 
-export const chip = {
-  enabled: {
-    background: backgroundColor,
-    height: '24px',
+export type ChipToken = ComponentToken & {
+  icon: ComponentToken
+  error: ComponentToken & {
+    icon: ComponentToken
+  }
+}
+
+export const chip: ChipToken = {
+  background: backgroundColor,
+  height: '22px',
+  border: {
+    radius: borderRadius,
+    color: 'transparent',
+    type: 'border',
+    width: '1px',
+  },
+  spacings: {
+    left: x_small,
+    right: small,
+  },
+  typography: {
+    ...chipTypography,
+    color: primaryColor,
+  },
+
+  states: {
+    hover: {
+      typography: {
+        color: primaryHover,
+      },
+    },
+    disabled: {
+      typography: {
+        color: disabledColor,
+      },
+    },
+    focus: {
+      outline: {
+        width: '1px',
+        color: focusOutlineColor,
+        style: 'dashed',
+        type: 'outline',
+        offset: '2px',
+      },
+    },
+    active: {
+      background: activeColor,
+    },
+  },
+  icon: {
+    height: medium,
+    width: medium,
     border: {
       radius: borderRadius,
+      type: 'border',
+      width: 0,
     },
-    spacings: {
-      left: x_small,
-      right: small,
-    },
-    typography: {
-      ...chipTypography,
-      color: primaryColor,
-    },
-    icon: {
-      height: medium,
-      width: medium,
-      border: {
-        radius: borderRadius,
-      },
+    states: {
       hover: {
         background: primaryHoverAlt,
       },
     },
   },
-  hover: {
-    icon: {
-      background: primaryHoverAlt,
-    },
-    typography: {
-      color: primaryHover,
-    },
-  },
-  disabled: {
-    typography: {
-      color: disabledColor,
-    },
-  },
-  outline: `1px dashed ${focusOutlineColor}`,
-  outlineOffset: '2px',
-  active: {
-    background: activeColor,
-  },
   error: {
     background: backgroundColorDefault,
     border: {
+      type: 'border',
       color: errorColor,
       width: '1px',
-      type: 'solid',
+      style: 'solid',
+      radius: borderRadius,
     },
     typography: {
       color: errorColor,
     },
-    icon: {
-      color: errorColor,
-      background: errorBackgroundHover,
+    states: {
+      hover: {
+        typography: {
+          color: errorColorHover,
+        },
+      },
     },
-    hover: {
-      color: errorColorHover,
+    icon: {
+      typography: {
+        color: errorColor,
+      },
+      background: errorBackgroundHover,
     },
   },
 }

--- a/libraries/core-react/src/components/Chip/Chip.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.tsx
@@ -10,9 +10,9 @@ import {
   bordersTemplate,
 } from '@utils'
 
-const { primary, error } = tokens
+const { enabled, error } = tokens
 
-const { background, height, typography, spacings, border, states } = primary
+const { background, height, typography, spacings, border, states } = enabled
 
 type StyleProps = {
   variant: 'active' | 'error' | 'default'

--- a/libraries/core-react/src/components/Chip/Chip.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.tsx
@@ -3,16 +3,21 @@ import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { Icon } from './Icon'
 import { chip as tokens } from './Chip.tokens'
-import { spacingsTemplate, typographyTemplate } from '@utils'
+import {
+  spacingsTemplate,
+  typographyTemplate,
+  outlineTemplate,
+  bordersTemplate,
+} from '@utils'
 
 const {
-  enabled,
-  disabled: disabledToken,
-  active: activeToken,
-  hover,
+  background,
+  height,
+  typography,
+  spacings,
+  border,
+  states,
   error,
-  outline,
-  outlineOffset,
 } = tokens
 
 type StyleProps = {
@@ -29,8 +34,8 @@ const StyledChips = styled.div.attrs<StyleProps>(
     role: clickable ? 'button' : null,
   }),
 )<StyleProps>`
-  background: ${enabled.background};
-  height: ${enabled.height};
+  background: ${background};
+  height: ${height};
   width: fit-content;
   display: grid;
   grid-gap: 8px;
@@ -40,13 +45,13 @@ const StyledChips = styled.div.attrs<StyleProps>(
   z-index: 10;
 
   svg {
-    fill: ${enabled.typography.color};
+    fill: ${typography.color};
   }
 
   &:hover {
-    color: ${hover.typography.color};
+    color: ${states.hover.typography.color};
     svg {
-      fill: ${hover.typography.color};
+      fill: ${states.hover.typography.color};
     }
   }
 
@@ -55,13 +60,12 @@ const StyledChips = styled.div.attrs<StyleProps>(
   }
 
   &[data-focus-visible-added]:focus {
-    outline: ${outline};
-    outline-offset: ${outlineOffset};
+    ${outlineTemplate(states.focus.outline)}
   }
+  ${bordersTemplate(border)}
 
-  border-radius: ${enabled.border.radius};
-  ${spacingsTemplate(enabled.spacings)}
-  ${typographyTemplate(enabled.typography)}
+  ${spacingsTemplate(spacings)}
+  ${typographyTemplate(typography)}
 
   ${({ clickable }) =>
     clickable &&
@@ -71,28 +75,25 @@ const StyledChips = styled.div.attrs<StyleProps>(
       }
     `}
 
-    ${({ variant }) => {
+  ${({ variant }) => {
     switch (variant) {
       case 'active':
         return css`
-          background: ${activeToken.background};
+          background: ${states.active.background};
         `
       case 'error':
         return css`
           background: ${error.background};
-          border-color: ${error.border.color};
-          border-width: ${error.border.width};
-          border-style: ${error.border.type};
           color: ${error.typography.color};
           svg {
-            fill: ${error.icon.color};
+            fill: ${error.icon.typography.color};
           }
-
+          ${bordersTemplate(error.border)};
           &:hover {
-            border-color: ${error.hover.color};
-            color: ${error.hover.color};
+            border-color: ${error.states.hover.typography.color};
+            color: ${error.states.hover.typography.color};
             svg {
-              fill: ${error.hover.color};
+              fill: ${error.states.hover.typography.color};
             }
           }
         `
@@ -105,16 +106,16 @@ const StyledChips = styled.div.attrs<StyleProps>(
     disabled &&
     css`
       cursor: not-allowed;
-      background: ${enabled.background};
-      color: ${disabledToken.typography.color};
+      background: ${background};
+      color: ${states.disabled.typography.color};
       svg {
-        fill: ${disabledToken.typography.color};
+        fill: ${states.disabled.typography.color};
       }
       &:hover {
-        color: ${disabledToken.typography.color};
+        color: ${states.disabled.typography.color};
         cursor: not-allowed;
         svg {
-          fill: ${disabledToken.typography.color};
+          fill: ${states.disabled.typography.color};
         }
       }
     `}

--- a/libraries/core-react/src/components/Chip/Chip.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { forwardRef, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { Icon } from './Icon'
-import { chip as tokens } from './Chip.tokens'
+import * as tokens from './Chip.tokens'
 import {
   spacingsTemplate,
   typographyTemplate,
@@ -10,15 +10,9 @@ import {
   bordersTemplate,
 } from '@utils'
 
-const {
-  background,
-  height,
-  typography,
-  spacings,
-  border,
-  states,
-  error,
-} = tokens
+const { primary, error } = tokens
+
+const { background, height, typography, spacings, border, states } = primary
 
 type StyleProps = {
   variant: 'active' | 'error' | 'default'
@@ -86,7 +80,7 @@ const StyledChips = styled.div.attrs<StyleProps>(
           background: ${error.background};
           color: ${error.typography.color};
           svg {
-            fill: ${error.icon.typography.color};
+            fill: ${error.entities.icon.typography.color};
           }
           ${bordersTemplate(error.border)};
           &:hover {

--- a/libraries/core-react/src/components/Chip/Icon.tsx
+++ b/libraries/core-react/src/components/Chip/Icon.tsx
@@ -1,12 +1,12 @@
 import styled, { css } from 'styled-components'
 import { close } from '@equinor/eds-icons'
 import { Icon as Icon_ } from '../Icon'
-import { chip as tokens } from './Chip.tokens'
+import * as tokens from './Chip.tokens'
 import { bordersTemplate } from '@utils'
 
 Icon_.add({ close })
 
-const { states, error, icon } = tokens
+const { primary, error } = tokens
 
 type IconProps = {
   variant: 'active' | 'error' | 'default'
@@ -16,7 +16,7 @@ type IconProps = {
 export const Icon = styled(Icon_)<IconProps>`
   cursor: pointer;
   padding: 1px;
-  ${bordersTemplate(icon.border)}
+  ${bordersTemplate(primary.entities.icon.border)}
 
   z-index: 11;
 
@@ -25,16 +25,16 @@ export const Icon = styled(Icon_)<IconProps>`
       switch (variant) {
         case 'error':
           return css`
-            background: ${error.icon.background};
+            background: ${error.entities.icon.background};
             svg {
-              fill: ${error.icon.typography.color};
+              fill: ${error.entities.icon.typography.color};
             }
           `
         default:
           return css`
-            background: ${icon.states.hover.background};
+            background: ${primary.entities.icon.states.hover.background};
             svg {
-              fill: ${states.hover.typography.color};
+              fill: ${primary.states.hover.typography.color};
             }
           `
       }

--- a/libraries/core-react/src/components/Chip/Icon.tsx
+++ b/libraries/core-react/src/components/Chip/Icon.tsx
@@ -2,10 +2,11 @@ import styled, { css } from 'styled-components'
 import { close } from '@equinor/eds-icons'
 import { Icon as Icon_ } from '../Icon'
 import { chip as tokens } from './Chip.tokens'
+import { bordersTemplate } from '@utils'
 
 Icon_.add({ close })
 
-const { enabled, hover, error } = tokens
+const { states, error, icon } = tokens
 
 type IconProps = {
   variant: 'active' | 'error' | 'default'
@@ -15,7 +16,8 @@ type IconProps = {
 export const Icon = styled(Icon_)<IconProps>`
   cursor: pointer;
   padding: 1px;
-  border-radius: ${enabled.icon.border.radius};
+  ${bordersTemplate(icon.border)}
+
   z-index: 11;
 
   &:hover {
@@ -25,14 +27,14 @@ export const Icon = styled(Icon_)<IconProps>`
           return css`
             background: ${error.icon.background};
             svg {
-              fill: ${error.icon.color};
+              fill: ${error.icon.typography.color};
             }
           `
         default:
           return css`
-            background: ${hover.icon.background};
+            background: ${icon.states.hover.background};
             svg {
-              fill: ${hover.typography.color};
+              fill: ${states.hover.typography.color};
             }
           `
       }

--- a/libraries/core-react/src/components/Chip/Icon.tsx
+++ b/libraries/core-react/src/components/Chip/Icon.tsx
@@ -6,7 +6,7 @@ import { bordersTemplate } from '@utils'
 
 Icon_.add({ close })
 
-const { primary, error } = tokens
+const { enabled, error } = tokens
 
 type IconProps = {
   variant: 'active' | 'error' | 'default'
@@ -16,7 +16,7 @@ type IconProps = {
 export const Icon = styled(Icon_)<IconProps>`
   cursor: pointer;
   padding: 1px;
-  ${bordersTemplate(primary.entities.icon.border)}
+  ${bordersTemplate(enabled.entities.icon.border)}
 
   z-index: 11;
 
@@ -32,9 +32,9 @@ export const Icon = styled(Icon_)<IconProps>`
           `
         default:
           return css`
-            background: ${primary.entities.icon.states.hover.background};
+            background: ${enabled.entities.icon.states.hover.background};
             svg {
-              fill: ${primary.states.hover.typography.color};
+              fill: ${enabled.states.hover.typography.color};
             }
           `
       }

--- a/libraries/core-react/stories/components/Breadcrumbs.stories.tsx
+++ b/libraries/core-react/stories/components/Breadcrumbs.stories.tsx
@@ -11,14 +11,6 @@ const Body = styled.div`
   grid-gap: 8px;
 `
 
-const TextWrapper = styled.div`
-  margin: 18px 0;
-`
-
-const Wrapper = styled.div`
-  width: 100px;
-`
-
 export default {
   title: 'Components/Breadcrumbs',
   component: Breadcrumbs,
@@ -54,85 +46,76 @@ export const Default: Story<BreadcrumbsProps> = (args) => {
   )
 }
 
-export const Variations: Story<BreadcrumbsProps> = () => {
-  return (
-    <Body>
-      <TextWrapper>
-        <Typography variant="h2">Normal</Typography>
-      </TextWrapper>
-      <Breadcrumbs>
-        <Breadcrumbs.Breadcrumb onClick={handleClick}>
-          Store
-        </Breadcrumbs.Breadcrumb>
-        <Breadcrumbs.Breadcrumb onClick={handleClick}>
-          Fruits
-        </Breadcrumbs.Breadcrumb>
-        <Breadcrumbs.Breadcrumb onClick={handleClick} aria-current="page">
-          Apple
-        </Breadcrumbs.Breadcrumb>
-      </Breadcrumbs>
-      <TextWrapper>
-        <Typography variant="h2">Collapsed</Typography>
-        <Typography variant="body_long">
-          Choose collapse prop to use ellipses to indicate the middle pages.
-          Click ellipses (...) to expand.
-        </Typography>
-      </TextWrapper>
-      <Breadcrumbs collapse>
-        <Breadcrumbs.Breadcrumb onClick={handleClick}>
-          Store
-        </Breadcrumbs.Breadcrumb>
-        <Breadcrumbs.Breadcrumb onClick={handleClick}>
-          Fruits
-        </Breadcrumbs.Breadcrumb>
-        <Breadcrumbs.Breadcrumb onClick={handleClick}>
-          Apple
-        </Breadcrumbs.Breadcrumb>
-        <Breadcrumbs.Breadcrumb onClick={handleClick} aria-current="page">
-          Apple Juice
-        </Breadcrumbs.Breadcrumb>
-      </Breadcrumbs>
-      <TextWrapper>
-        <Typography variant="h2">Truncated labels</Typography>
-        <Typography variant="body_long">
-          Choose maxWidth in pixels to truncate labels. Hover on label to see
-          full text.
-        </Typography>
-      </TextWrapper>
-      <Breadcrumbs>
-        <Breadcrumbs.Breadcrumb maxWidth={30} onClick={handleClick}>
-          Store
-        </Breadcrumbs.Breadcrumb>
-        <Breadcrumbs.Breadcrumb maxWidth={30} onClick={handleClick}>
-          Fruits
-        </Breadcrumbs.Breadcrumb>
-        <Breadcrumbs.Breadcrumb
-          maxWidth={30}
-          onClick={handleClick}
-          aria-current="page"
-        >
-          Apple
-        </Breadcrumbs.Breadcrumb>
-      </Breadcrumbs>
-      <TextWrapper>
-        <Typography variant="h2">Wrapped</Typography>
-        <Typography variant="body_long">
-          Wraps over two or more lines. Controlled by parent width.
-        </Typography>
-      </TextWrapper>
-      <Wrapper>
-        <Breadcrumbs>
-          <Breadcrumbs.Breadcrumb onClick={handleClick}>
-            Store
-          </Breadcrumbs.Breadcrumb>
-          <Breadcrumbs.Breadcrumb onClick={handleClick}>
-            Fruits
-          </Breadcrumbs.Breadcrumb>
-          <Breadcrumbs.Breadcrumb onClick={handleClick} aria-current="page">
-            Apple
-          </Breadcrumbs.Breadcrumb>
-        </Breadcrumbs>
-      </Wrapper>
-    </Body>
-  )
+export const Normal: Story<BreadcrumbsProps> = () => (
+  <Breadcrumbs>
+    <Breadcrumbs.Breadcrumb onClick={handleClick}>Store</Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb onClick={handleClick}>
+      Fruits
+    </Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb onClick={handleClick} aria-current="page">
+      Apple
+    </Breadcrumbs.Breadcrumb>
+  </Breadcrumbs>
+)
+
+export const Collapsed: Story<BreadcrumbsProps> = () => (
+  <Breadcrumbs collapse>
+    <Breadcrumbs.Breadcrumb onClick={handleClick}>Store</Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb onClick={handleClick}>
+      Fruits
+    </Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb onClick={handleClick}>Apple</Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb onClick={handleClick} aria-current="page">
+      Apple Juice
+    </Breadcrumbs.Breadcrumb>
+  </Breadcrumbs>
+)
+
+Collapsed.parameters = {
+  docs: {
+    storyDescription: `Choose collapse prop to use ellipses to indicate the middle pages.
+    Click ellipses (...) to expand.`,
+  },
+}
+
+export const TruncatedLabels: Story<BreadcrumbsProps> = () => (
+  <Breadcrumbs>
+    <Breadcrumbs.Breadcrumb maxWidth={30} onClick={handleClick}>
+      Store
+    </Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb maxWidth={30} onClick={handleClick}>
+      Fruits
+    </Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb
+      maxWidth={30}
+      onClick={handleClick}
+      aria-current="page"
+    >
+      Apple
+    </Breadcrumbs.Breadcrumb>
+  </Breadcrumbs>
+)
+TruncatedLabels.parameters = {
+  docs: {
+    storyDescription: `Choose maxWidth in pixels to truncate labels. Hover on label to see
+    full text.`,
+  },
+}
+TruncatedLabels.storyName = 'Truncated labels'
+
+export const Wrapped: Story<BreadcrumbsProps> = () => (
+  <Breadcrumbs>
+    <Breadcrumbs.Breadcrumb onClick={handleClick}>Store</Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb onClick={handleClick}>
+      Fruits
+    </Breadcrumbs.Breadcrumb>
+    <Breadcrumbs.Breadcrumb onClick={handleClick} aria-current="page">
+      Apple
+    </Breadcrumbs.Breadcrumb>
+  </Breadcrumbs>
+)
+Wrapped.parameters = {
+  docs: {
+    storyDescription: `Wraps over two or more lines. Controlled by parent width.`,
+  },
 }

--- a/libraries/core-react/stories/testing/GlobalStyles.ts
+++ b/libraries/core-react/stories/testing/GlobalStyles.ts
@@ -1,0 +1,96 @@
+// Testing global variables when migrating
+
+import { createGlobalStyle } from 'styled-components'
+
+export const GlobalStyle = createGlobalStyle`
+:root {
+  --eds_text_static_icons__default: rgba(61, 61, 61, 1);
+  --eds_text_static_icons__secondary: rgba(86, 86, 86, 1);
+  --eds_text_static_icons__tertiary: rgba(111, 111, 111, 1);
+  --eds_text_static_icons__primary_white: rgba(255, 255, 255, 1);
+  --eds_ui_background__default: rgba(255, 255, 255, 1);
+  --eds_ui_background__semitransparent: rgba(255, 255, 255, 0.2);
+  --eds_ui_background__light: rgba(247, 247, 247, 1);
+  --eds_ui_background__scrim: rgba(0, 0, 0, 0.4);
+  --eds_ui_background__overlay: rgba(0, 0, 0, 0.8);
+  --eds_ui_background__medium: rgba(220, 220, 220, 1);
+  --eds_ui_background__info: rgba(213, 234, 244, 1);
+  --eds_ui_background__warning: rgba(255, 231, 214, 1);
+  --eds_ui_background__danger: rgba(255, 193, 193, 1);
+  --eds_infographic_substitute__purple_berry: rgba(140, 17, 89, 1);
+  --eds_infographic_substitute__pink_rose: rgba(226, 73, 115, 1);
+  --eds_infographic_substitute__pink_salmon: rgba(255, 146, 168, 1);
+  --eds_infographic_substitute__green_cucumber: rgba(0, 95, 87, 1);
+  --eds_infographic_substitute__green_succulent: rgba(0, 151, 123, 1);
+  --eds_infographic_substitute__green_mint: rgba(64, 211, 143, 1);
+  --eds_infographic_substitute__blue_ocean: rgba(0, 64, 136, 1);
+  --eds_infographic_substitute__blue_overcast: rgba(0, 132, 196, 1);
+  --eds_infographic_substitute__blue_sky: rgba(82, 192, 255, 1);
+  --eds_infographic_primary__moss_green_100: rgba(0, 112, 121, 1);
+  --eds_infographic_primary__moss_green_55: rgba(115, 177, 181, 1);
+  --eds_infographic_primary__moss_green_34: rgba(168, 206, 209, 1);
+  --eds_infographic_primary__moss_green_21: rgba(201, 224, 226, 1);
+  --eds_infographic_primary__moss_green_13: rgba(222, 237, 238, 1);
+  --eds_infographic_primary__energy_red_100: rgba(235, 0, 55, 1);
+  --eds_infographic_primary__energy_red_55: rgba(255, 125, 152, 1);
+  --eds_infographic_primary__energy_red_34: rgba(255, 174, 191, 1);
+  --eds_infographic_primary__energy_red_21: rgba(255, 205, 215, 1);
+  --eds_infographic_primary__energy_red_13: rgba(255, 224, 231, 1);
+  --eds_infographic_primary__weathered_red: rgba(125, 0, 35, 1);
+  --eds_infographic_primary__slate_blue: rgba(36, 55, 70, 1);
+  --eds_infographic_primary__spruce_wood: rgba(255, 231, 214, 1);
+  --eds_infographic_primary__mist_blue: rgba(213, 234, 244, 1);
+  --eds_infographic_primary__lichen_green: rgba(230, 250, 236, 1);
+  --eds_logo_fill_positive: rgba(235, 0, 55, 1);
+  --eds_logo_fill_negative: rgba(255, 255, 255, 1);
+  --eds_interactive_primary__selected_highlight: rgba(230, 250, 236, 1);
+  --eds_interactive_primary__selected_hover: rgba(195, 243, 210, 1);
+  --eds_interactive_primary__resting: rgba(0, 112, 121, 1);
+  --eds_interactive_primary__hover: rgba(0, 79, 85, 1);
+  --eds_interactive_primary__hover_alt: rgba(222, 237, 238, 1);
+  --eds_interactive_secondary__highlight: rgba(213, 234, 244, 1);
+  --eds_interactive_secondary__resting: rgba(36, 55, 70, 1);
+  --eds_interactive_secondary__link_hover: rgba(23, 36, 47, 1);
+  --eds_interactive_danger__highlight: rgba(255, 193, 193, 1);
+  --eds_interactive_danger__resting: rgba(235, 0, 0, 1);
+  --eds_interactive_danger__hover: rgba(179, 13, 47, 1);
+  --eds_interactive_danger__text: rgba(179, 13, 47, 1);
+  --eds_interactive_warning__highlight: rgba(255, 231, 214, 1);
+  --eds_interactive_warning__resting: rgba(255, 146, 0, 1);
+  --eds_interactive_warning__hover: rgba(173, 98, 0, 1);
+  --eds_interactive_warning__text: rgba(173, 98, 0, 1);
+  --eds_interactive_success__highlight: rgba(230, 250, 236, 1);
+  --eds_interactive_success__resting: rgba(75, 183, 72, 1);
+  --eds_interactive_success__hover: rgba(53, 129, 50, 1);
+  --eds_interactive_success__text: rgba(53, 129, 50, 1);
+  --eds_interactive_table__cell__fill_resting: rgba(255, 255, 255, 1);
+  --eds_interactive_table__cell__fill_hover: rgba(234, 234, 234, 1);
+  --eds_interactive_table__cell__fill_activated: rgba(230, 250, 236, 1);
+  --eds_interactive_table__header__fill_activated: rgba(234, 234, 234, 1);
+  --eds_interactive_table__header__fill_hover: rgba(220, 220, 220, 1);
+  --eds_interactive_table__header__fill_resting: rgba(247, 247, 247, 1);
+  --eds_interactive_disabled__text: rgba(190, 190, 190, 1);
+  --eds_interactive_text_highlight: rgba(213, 234, 244, 1);
+  --eds_interactive_focus: rgba(0, 112, 121, 1);
+  --eds_interactive_disabled__border: rgba(220, 220, 220, 1);
+  --eds_interactive_disabled__fill: rgba(234, 234, 234, 1);
+  --eds_interactive_link_on_interactive_colors: rgba(255, 255, 255, 1);
+  --eds_interactive_icon_on_interactive_colors: rgba(255, 255, 255, 1);
+  --eds_interactive_link_in_snackbars: rgba(151, 202, 206, 1);
+  --eds_interactive_pressed_overlay_dark: rgba(0, 0, 0, 0.2);
+  --eds_interactive_pressed_overlay_light: rgba(255, 255, 255, 0.2);
+
+  --eds_elevation_raised: 0 1px 5px rgba(0, 0, 0, 0.2),0 3px 4px rgba(0, 0, 0, 0.12),0 2px 4px rgba(0, 0, 0, 0.14);
+  --eds_elevation_none: 0 0 1px rgba(0, 0, 0, 0.14);
+  --eds_elevation_overlay: 0 1px 10px rgba(0, 0, 0, 0.2),0 4px 5px rgba(0, 0, 0, 0.12),0 2px 4px rgba(0, 0, 0, 0.14);
+  --eds_elevation_sticky: 0 4px 5px rgba(0, 0, 0, 0.2),0 3px 14px rgba(0, 0, 0, 0.12),0 8px 10px rgba(0, 0, 0, 0.14);
+  --eds_elevation_temporary_nav: 0 7px 8px rgba(0, 0, 0, 0.2),0 5px 22px rgba(0, 0, 0, 0.12),0 12px 17px rgba(0, 0, 0, 0.14);
+  --eds_elevation_above_scrim: 0 11px 15px rgba(0, 0, 0, 0.2),0 9px 46px rgba(0, 0, 0, 0.12),0 24px 38px rgba(0, 0, 0, 0.14);
+
+
+
+}
+  
+
+
+`

--- a/libraries/core-react/stories/testing/GlobalStyles.ts
+++ b/libraries/core-react/stories/testing/GlobalStyles.ts
@@ -2,7 +2,93 @@
 
 import { createGlobalStyle } from 'styled-components'
 
-export const GlobalStyle = createGlobalStyle`
+export const GlobalStyleDark = createGlobalStyle`
+:root {
+  --eds_text_static_icons__default: rgba(255,255,255, 1);
+  --eds_text_static_icons__secondary: rgba(222,229,231, 1);
+  --eds_text_static_icons__tertiary: rgba(156,166,172, 1);
+  --eds_text_static_icons__primary_white: rgba(0,0,0, 1);
+
+  /** Her er light/dark-navnene helt ulike, så jeg skjønner ikke helt hva som er tanken her */
+  --eds_ui_background__default: rgba(19,38,52, 1);
+  --eds_ui_background__semitransparent: rgba(255, 255, 255, 0.2);
+
+  --eds_ui_background__light: rgba(247, 247, 247, 1);
+  --eds_ui_background__raised: rgba(36,55,70,1);
+
+  --eds_ui_background__lighten: rgba(255,255,255,0.16);
+
+  --eds_ui_background__scrim: rgba(0, 0, 0, 0.4);
+  --eds_ui_background__overlay: rgba(0, 0, 0, 0.8);
+  --eds_ui_background__medium: rgba(220, 220, 220, 1);
+  --eds_ui_background__info: rgba(213, 234, 244, 1);
+  --eds_ui_background__warning: rgba(255, 231, 214, 1);
+  --eds_ui_background__danger: rgba(255, 193, 193, 1);
+
+
+  --eds_logo_fill_positive: rgba(235, 0, 55, 1);
+  --eds_logo_fill_negative: rgba(255, 255, 255, 1);
+
+  /** Mangler i darkmode */
+  --eds_interactive_primary__selected_highlight: rgba(230, 250, 236, 1);
+  --eds_interactive_primary__selected_hover: rgba(195, 243, 210, 1);
+
+  --eds_interactive_primary__resting: rgba(151,202,206, 1);
+  --eds_interactive_primary__hover: rgba(173,226,230, 1);
+    /** Skjønner ikke helt figma her */
+  --eds_interactive_primary__hover_alt: rgba(173,226,230,0.1);
+  --eds_interactive_secondary__highlight: rgba(255,255,255, 0.1);
+  --eds_interactive_secondary__resting: rgba(222,229,231, 1);
+  /** Interactive secondary hover mangler */
+
+  --eds_interactive_secondary__link_hover: rgba(23, 36, 47, 1);
+
+  --eds_interactive_danger__highlight: rgba(255,102,112, 0.1);
+  --eds_interactive_danger__resting: rgba(235,0,0, 1);
+  --eds_interactive_danger__hover: rgba(255,148,155, 1);
+  --eds_interactive_danger__text: rgba(255,102,112, 1);
+
+  --eds_interactive_warning__highlight: rgba(255,198,122, 0.1);
+  --eds_interactive_warning__resting: rgba(255,146,0, 1);
+  --eds_interactive_warning__hover: rgba(255,218,168, 1);
+  --eds_interactive_warning__text: rgba(255,198,122,1);
+
+  --eds_interactive_success__highlight: rgba(161,218,160, 0.1);
+  --eds_interactive_success__resting: rgba(75, 183, 72, 1);
+  --eds_interactive_success__hover: rgba(193,231,193, 1);
+  --eds_interactive_success__text: rgba(161,218,160, 1);
+
+  --eds_interactive_table__cell__fill_resting: rgba(255, 255, 255, 1);
+  --eds_interactive_table__cell__fill_hover: rgba(234, 234, 234, 1);
+  --eds_interactive_table__cell__fill_activated: rgba(230, 250, 236, 1);
+  --eds_interactive_table__header__fill_activated: rgba(234, 234, 234, 1);
+  --eds_interactive_table__header__fill_hover: rgba(220, 220, 220, 1);
+  --eds_interactive_table__header__fill_resting: rgba(247, 247, 247, 1);
+
+  --eds_infographic_primary__moss_green_100: rgba(0, 112, 121, 1);
+  --eds_infographic_primary__moss_green_13: rgba(222, 237, 238, 1);
+  --eds_infographic_primary__energy_red_100: rgba(235, 0, 55, 1);
+  --eds_infographic_primary__energy_red_13: rgba(255, 224, 231, 1);
+  
+ /** Har ingen verdi i darkmode */
+  --eds_interactive_text_highlight: rgba(18,18,18, 1);
+  --eds_interactive_focus: rgba(151,202,206, 1);
+  --eds_interactive_disabled__border: rgba(64,84,98, 1);
+  --eds_interactive_disabled__fill: rgba(52,68,80, 1);
+  --eds_interactive_disabled__text: rgba(99,117,131, 1);
+  /** Har ingen verdi i darkmode */
+  --eds_interactive_link_on_interactive_colors: rgba(255, 255, 255, 1);
+  --eds_interactive_icon_on_interactive_colors: rgba(0,0,0, 1);
+  --eds_interactive_link_in_snackbars: rgba(0,112,121, 1);
+  /** Slått sammen til en */
+  --eds_interactive_pressed_overlay_dark: rgba(0, 0, 0, 0.2);
+  --eds_interactive_pressed_overlay_light: rgba(255, 255, 255, 0.2);
+ .mickey {
+   background-color: var(--eds_interactive_danger__highlight);
+ }
+}
+  `
+export const GlobalStyleDefault = createGlobalStyle`
 :root {
   --eds_text_static_icons__default: rgba(61, 61, 61, 1);
   --eds_text_static_icons__secondary: rgba(86, 86, 86, 1);

--- a/libraries/tokens/src/types/component.ts
+++ b/libraries/tokens/src/types/component.ts
@@ -22,6 +22,7 @@ export type ComponentToken = {
     hover?: ComponentState
     pressed?: ComponentState & { pressed?: Pressed }
   }
+  entities?: Record<string, ComponentToken>
 }
 
 type ComponentState = Partial<Omit<ComponentToken, 'states'>>

--- a/libraries/tokens/src/types/index.ts
+++ b/libraries/tokens/src/types/index.ts
@@ -32,8 +32,6 @@ export type Spacing = {
   right?: string
   top?: string
   bottom?: string
-  x?: string
-  y?: string
 }
 
 export type SpacingTokens = {

--- a/libraries/tokens/src/types/index.ts
+++ b/libraries/tokens/src/types/index.ts
@@ -28,10 +28,12 @@ export type TypographyTokens = {
 }
 
 export type Spacing = {
-  left: string
-  right: string
+  left?: string
+  right?: string
   top?: string
   bottom?: string
+  x?: string
+  y?: string
 }
 
 export type SpacingTokens = {


### PR DESCRIPTION
Part of #1129 

Edit: The initial approach of this PR was to rewrite the React components to use CSS vars. it quickly became evident that it was too difficult. The approach was changed to rewrite the tokens of the components, but that was cumbersome as well. The final approach was to add CSS color variables inside the tokens, see #1137 . 

This PR features some tokens cleanup to make it easier to add CSS vars and a test file for CSS vars used for testing inside Storybook