### PR TITLE
🔧  Update config files to exclude test and stories files

### DIFF
--- a/libraries/core-react/.storybook/main.js
+++ b/libraries/core-react/.storybook/main.js
@@ -5,6 +5,7 @@ module.exports = {
     '../stories/docs/*.stories.mdx',
     '../stories/components/**/*.stories.@(ts|tsx|mdx)',
     // '../stories/screens/**/*.@(ts|tsx|mdx)',
+    '../src/**/*.stories.tsx',
   ],
   addons: [
     '@storybook/addon-a11y',

--- a/libraries/core-react/tsconfig.json
+++ b/libraries/core-react/tsconfig.json
@@ -11,6 +11,6 @@
       "@components": ["src", "src/*"]
     }
   },
-  "include": ["./src/**/*.ts*"],
-  "exclude": ["node_modules"]
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules", "src/**/*.stories.ts*", "src/**/*.test.ts*"]
 }


### PR DESCRIPTION
For a long time we had typings for test being included in `core-react`. 

Excluded files including `.test` and `.stories` (so its ready for moving story files 👌)