### PR TITLE
Fix wrong use of cache in actions

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -102,13 +102,13 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}
-      - name: Build
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
-      - name: Save build to cache
+      - name: Use token build cache
         uses: actions/cache@v2
         with:
           path: ./libraries/tokens
           key: ${{ github.sha }}-build-tokens
+      - name: Build
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
   build-icons:
     name: Build eds-icons
     runs-on: ubuntu-latest
@@ -122,13 +122,13 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}
-      - name: Build
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-icons run build
-      - name: Save build to cache
+      - name: Use icons build cache
         uses: actions/cache@v2
         with:
           path: ./libraries/icons
           key: ${{ github.sha }}-build-icons
+      - name: Build
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-icons run build
   build-core-react:
     name: Build eds-core-react
     runs-on: ubuntu-latest
@@ -152,9 +152,7 @@ jobs:
         with:
           path: ./libraries/tokens
           key: ${{ github.sha }}-build-tokens
-      - name: Build
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-core-react run build
-      - name: Save build to cache
+      - name: Use core-react build cache
         uses: actions/cache@v2
         with:
           path: |
@@ -162,6 +160,8 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}-build-core-react
+      - name: Build
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-core-react run build
   publish-core-react:
     name: Publish eds-core-react to npm
     runs-on: ubuntu-latest
@@ -192,16 +192,16 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}
-      - name: Build storybook
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-core-react run build:storybook
       - uses: actions/cache@v2
-        name: Save build to cache
+        name: Use storybook build cache
         with:
           path: |
             ./*
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}-build-storybook
+      - name: Build storybook
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-core-react run build:storybook
   build_push_docker:
     name: Build & Deploy Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_icons.yaml
+++ b/.github/workflows/publish_icons.yaml
@@ -40,7 +40,7 @@ jobs:
             - recursive: true
       - name: Lint
         run: ./pnpm/bin/pnpm run lint ./libraries/icons
-      - name: Cache base files
+      - name: Use base files cache
         uses: actions/cache@v2
         with:
           path: |
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - name: Get base files
+      - name: Use base files cache
         uses: actions/cache@v2
         with:
           path: |
@@ -76,29 +76,30 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}
-      - name: Build
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-icons run build
-      - name: Save files to cache
+      - name: Use icons build cache
         uses: actions/cache@v2
         with:
           path: |
             ./*
             ~/.pnpm-store
             ~/setup-pnpm
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-build-icons
+      - name: Build
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-icons run build
+
   publish-icons:
     name: Publish eds-icons to npm
     runs-on: ubuntu-latest
     needs: [build-icons]
     steps:
-      - name: Get files
+      - name: Use icons build cache
         uses: actions/cache@v2
         with:
           path: |
             ./*
             ~/.pnpm-store
             ~/setup-pnpm
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-build-icons
       - name: Publish to npm
         run: ./pnpm/bin/pnpm --filter @equinor/eds-icons publish --access public --tag ${{ github.event.inputs.npm-tag }} --no-git-checks
         env:

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -66,6 +66,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
+      - name: Get base files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./*
+            ~/.pnpm-store
+            ~/setup-pnpm
+          key: ${{ github.sha }}
+      - name: Build
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
       - name: Tokens build cache
         uses: actions/cache@v2
         with:
@@ -73,9 +83,7 @@ jobs:
             ./*
             ~/.pnpm-store
             ~/setup-pnpm
-          key: ${{ github.sha }}-build-tokens
-      - name: Build
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
+        key: ${{ github.sha }}-build-tokens
   publish-tokens:
     name: Publish eds-tokens to npm
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -11,14 +11,6 @@ jobs:
     name: Setup base files
     runs-on: ubuntu-latest
     steps:
-      - name: Cache base files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./*
-            ~/.pnpm-store
-            ~/setup-pnpm
-          key: ${{ github.sha }}
       - name: Checkout
         run: |
           REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -46,6 +38,14 @@ jobs:
           bin_dest: ./pnpm/bin
           run_install: |
             - recursive: true
+      - name: Cache base files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./*
+            ~/.pnpm-store
+            ~/setup-pnpm
+          key: ${{ github.sha }}
   lint:
     name: Lint eds-tokens
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - name: Get files
+      - name: Use cache
         uses: actions/cache@v2
         with:
           path: |
@@ -78,14 +78,6 @@ jobs:
           key: ${{ github.sha }}
       - name: Build
         run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
-      - name: Save files to cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./*
-            ~/.pnpm-store
-            ~/setup-pnpm
-          key: ${{ github.sha }}
   publish-tokens:
     name: Publish eds-tokens to npm
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -83,7 +83,7 @@ jobs:
             ./*
             ~/.pnpm-store
             ~/setup-pnpm
-        key: ${{ github.sha }}-build-tokens
+          key: ${{ github.sha }}-build-tokens
   publish-tokens:
     name: Publish eds-tokens to npm
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -31,14 +31,7 @@ jobs:
           # echo ...
           git -c protocol.version=2 fetch --no-tags --prune --progress --depth=10 origin +${GITHUB_SHA}:refs/remotes/origin/${BRANCH}
           git checkout --progress --force -B $BRANCH refs/remotes/origin/$BRANCH
-      - name: Install pnpm & dependencies 📦
-        uses: pnpm/action-setup@v1.2.1
-        with:
-          version: latest
-          bin_dest: ./pnpm/bin
-          run_install: |
-            - recursive: true
-      - name: Cache base files
+      - name: Use base files cache
         uses: actions/cache@v2
         with:
           path: |
@@ -46,12 +39,19 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}
+      - name: Install pnpm & dependencies 📦
+        uses: pnpm/action-setup@v1.2.1
+        with:
+          version: latest
+          bin_dest: ./pnpm/bin
+          run_install: |
+            - recursive: true
   lint:
     name: Lint eds-tokens
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - name: Get base files
+      - name: Use base files cache
         uses: actions/cache@v2
         with:
           path: |
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - name: Get base files
+      - name: Use base files cache
         uses: actions/cache@v2
         with:
           path: |
@@ -74,9 +74,7 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}
-      - name: Build
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
-      - name: Tokens build cache
+      - name: Use tokens build cache
         uses: actions/cache@v2
         with:
           path: |
@@ -84,12 +82,15 @@ jobs:
             ~/.pnpm-store
             ~/setup-pnpm
           key: ${{ github.sha }}-build-tokens
+      - name: Build
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
+
   publish-tokens:
     name: Publish eds-tokens to npm
     runs-on: ubuntu-latest
     needs: [build-tokens]
     steps:
-      - name: Tokens build cache
+      - name: Use tokens build cache
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -100,6 +100,6 @@ jobs:
             ~/setup-pnpm
           key: ${{ github.sha }}
       - name: Publish to npm
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens publish --access public --tag ${{ github.event.inputs.npm-tag }} --no-git-checks
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens publish --access public --tag ${{ github.event.inputs.npm-tag }} --no-git-checks --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -68,14 +68,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - name: Use cache
+      - name: Tokens build cache
         uses: actions/cache@v2
         with:
           path: |
             ./*
             ~/.pnpm-store
             ~/setup-pnpm
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-build-tokens
       - name: Build
         run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens run build
   publish-tokens:
@@ -83,14 +83,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-tokens]
     steps:
-      - name: Get files
+      - name: Tokens build cache
         uses: actions/cache@v2
         with:
           path: |
             ./*
             ~/.pnpm-store
             ~/setup-pnpm
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-build-tokens
       - name: Publish to npm
         run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens publish --access public --tag ${{ github.event.inputs.npm-tag }} --no-git-checks --dry-run
         env:

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -99,6 +99,6 @@ jobs:
             ~/setup-pnpm
           key: ${{ github.sha }}-build-tokens
       - name: Publish to npm
-        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens publish --access public --tag ${{ github.event.inputs.npm-tag }} --no-git-checks --dry-run
+        run: ./pnpm/bin/pnpm --filter @equinor/eds-tokens publish --access public --tag ${{ github.event.inputs.npm-tag }} --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -11,6 +11,14 @@ jobs:
     name: Setup base files
     runs-on: ubuntu-latest
     steps:
+      - name: Cache base files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./*
+            ~/.pnpm-store
+            ~/setup-pnpm
+          key: ${{ github.sha }}
       - name: Checkout
         run: |
           REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -38,16 +46,6 @@ jobs:
           bin_dest: ./pnpm/bin
           run_install: |
             - recursive: true
-      - name: Lint
-        run: ./pnpm/bin/pnpm run lint ./libraries/tokens
-      - name: Cache base files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./*
-            ~/.pnpm-store
-            ~/setup-pnpm
-          key: ${{ github.sha }}
   lint:
     name: Lint eds-tokens
     runs-on: ubuntu-latest

--- a/libraries/tokens/package.json
+++ b/libraries/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-tokens",
-  "version": "0.5.7",
+  "version": "0.5.7-testpublish.1",
   "description": "Design tokens for the Equinor Design System",
   "main": "dist/tokens.cjs.js",
   "module": "dist/tokens.esm.js",

--- a/libraries/tokens/package.json
+++ b/libraries/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-tokens",
-  "version": "0.5.7-testpublish.1",
+  "version": "0.5.7",
   "description": "Design tokens for the Equinor Design System",
   "main": "dist/tokens.cjs.js",
   "module": "dist/tokens.esm.js",


### PR DESCRIPTION
fixes #1166 

The problem was due to a cache being used multiple times, expecting it to be updated.  Caches in github actions are fixed once they have been greated. You have to save it under a different key if you want to add new files.