### PR TITLE
🔨 Keep pnpm after prebuild

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN brew install pnpm

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
 tasks:
   - name: Install
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,6 @@
 tasks:
   - name: Install
     init: |
-      npm i -g pnpm@6
       pnpm install
       pnpm recursive install --filter ./libraries
       gp sync-done install

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ tasks:
     command: pnpm storybook
   - name: Lint
     init: gp sync-await install
-    command: pnpm lint:all
+    command: pnpm lint:core-react
     openMode: split-right
   - name: Test
     init: gp sync-await install


### PR DESCRIPTION
When installing pnpm globablly using npm, it’s not available when the environment is prebuilt. Using a minimal dockerfile with pnpm installed with homebrew will (hopefully) fix the problem. 