### PR TITLE
Fix/input readonly styles

### DIFF
--- a/libraries/core-react/src/components/Input/Input.tokens.ts
+++ b/libraries/core-react/src/components/Input/Input.tokens.ts
@@ -54,6 +54,10 @@ export const input: InputToken = {
         color: disabled__text.rgba,
       },
     },
+    readOnly: {
+      background: 'transparent',
+      boxShadow: 'none',
+    },
     active: {
       outline: {
         type: 'outline',

--- a/libraries/core-react/src/components/Input/Input.tsx
+++ b/libraries/core-react/src/components/Input/Input.tsx
@@ -17,6 +17,7 @@ const StyledInput = styled.input(({ theme }: StyledProps) => {
       focus: { outline: focusOutline },
       active: { outline: activeOutline },
       disabled,
+      readOnly,
     },
     boxShadow,
   } = theme
@@ -57,8 +58,8 @@ const StyledInput = styled.input(({ theme }: StyledProps) => {
       }
     }
     &[readOnly] {
-      background: transparent;
-      box-shadow: none;
+      background: ${readOnly.background};
+      box-shadow: ${readOnly.boxShadow};
     }
   `
 })

--- a/libraries/core-react/src/components/Input/Input.tsx
+++ b/libraries/core-react/src/components/Input/Input.tsx
@@ -11,7 +11,7 @@ import type { Variants } from '../TextField/types'
 import { useEds } from '../EdsProvider'
 import { useToken } from '../../hooks'
 
-const StyledInput = styled.input(({ theme, isReadOnly }: StyledProps) => {
+const StyledInput = styled.input(({ theme }: StyledProps) => {
   const {
     states: {
       focus: { outline: focusOutline },
@@ -26,10 +26,10 @@ const StyledInput = styled.input(({ theme, isReadOnly }: StyledProps) => {
     box-sizing: border-box;
     margin: 0;
     appearance: none;
-    background: ${isReadOnly ? 'transparent' : theme.background};
+    background: ${theme.background};
     border: none;
     height: ${theme.minHeight};
-    box-shadow: ${isReadOnly ? 'none' : boxShadow};
+    box-shadow: ${boxShadow};
 
     ${outlineTemplate(activeOutline)}
     ${typographyTemplate(theme.typography)}
@@ -56,12 +56,15 @@ const StyledInput = styled.input(({ theme, isReadOnly }: StyledProps) => {
         outline: none;
       }
     }
+    &[readOnly] {
+      background: transparent;
+      box-shadow: none;
+    }
   `
 })
 
 type StyledProps = {
   theme: InputToken
-  isReadOnly: boolean
 }
 
 export type InputProps = {
@@ -78,13 +81,7 @@ export type InputProps = {
 } & InputHTMLAttributes<HTMLInputElement>
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  {
-    variant = 'default',
-    disabled = false,
-    readOnly = false,
-    type = 'text',
-    ...other
-  },
+  { variant = 'default', disabled = false, type = 'text', ...other },
   ref,
 ) {
   const actualVariant = variant === 'default' ? 'input' : variant
@@ -96,13 +93,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     ref,
     type,
     disabled,
-    readOnly,
     ...other,
   }
 
   return (
     <ThemeProvider theme={token}>
-      <StyledInput isReadOnly={readOnly} {...inputProps} />
+      <StyledInput {...inputProps} />
     </ThemeProvider>
   )
 })

--- a/libraries/core-react/src/components/Input/Input.tsx
+++ b/libraries/core-react/src/components/Input/Input.tsx
@@ -11,7 +11,7 @@ import type { Variants } from '../TextField/types'
 import { useEds } from '../EdsProvider'
 import { useToken } from '../../hooks'
 
-const StyledInput = styled.input(({ theme }: StyledProps) => {
+const StyledInput = styled.input(({ theme, isReadOnly }: StyledProps) => {
   const {
     states: {
       focus: { outline: focusOutline },
@@ -26,10 +26,10 @@ const StyledInput = styled.input(({ theme }: StyledProps) => {
     box-sizing: border-box;
     margin: 0;
     appearance: none;
-    background: ${theme.background};
+    background: ${isReadOnly ? 'transparent' : theme.background};
     border: none;
     height: ${theme.minHeight};
-    box-shadow: ${boxShadow};
+    box-shadow: ${isReadOnly ? 'none' : boxShadow};
 
     ${outlineTemplate(activeOutline)}
     ${typographyTemplate(theme.typography)}
@@ -61,6 +61,7 @@ const StyledInput = styled.input(({ theme }: StyledProps) => {
 
 type StyledProps = {
   theme: InputToken
+  isReadOnly: boolean
 }
 
 export type InputProps = {
@@ -73,11 +74,17 @@ export type InputProps = {
   /** Type */
   type?: string
   /** Read Only */
-  readonly?: boolean
+  readOnly?: boolean
 } & InputHTMLAttributes<HTMLInputElement>
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { variant = 'default', disabled = false, type = 'text', ...other },
+  {
+    variant = 'default',
+    disabled = false,
+    readOnly = false,
+    type = 'text',
+    ...other
+  },
   ref,
 ) {
   const actualVariant = variant === 'default' ? 'input' : variant
@@ -89,12 +96,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     ref,
     type,
     disabled,
+    readOnly,
     ...other,
   }
 
   return (
     <ThemeProvider theme={token}>
-      <StyledInput {...inputProps} />
+      <StyledInput isReadOnly={readOnly} {...inputProps} />
     </ThemeProvider>
   )
 })

--- a/libraries/core-react/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/libraries/core-react/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`Input Matches snapshot 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background: var(--eds_ui_background__light,rgba(247,247,247,1));
+  background: transparent;
   border: none;
   height: 36px;
-  box-shadow: inset 0px -1px 0px 0px var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+  box-shadow: none;
   outline: 1px solid transparent;
   outline-offset: 0px;
   margin: 0;

--- a/libraries/core-react/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/libraries/core-react/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`Input Matches snapshot 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background: transparent;
+  background: var(--eds_ui_background__light,rgba(247,247,247,1));
   border: none;
   height: 36px;
-  box-shadow: none;
+  box-shadow: inset 0px -1px 0px 0px var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
   outline: 1px solid transparent;
   outline-offset: 0px;
   margin: 0;
@@ -66,6 +66,11 @@ exports[`Input Matches snapshot 1`] = `
 .c0:disabled:focus,
 .c0:disabled:active {
   outline: none;
+}
+
+.c0[readOnly] {
+  background: transparent;
+  box-shadow: none;
 }
 
 <input

--- a/libraries/core-react/src/components/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/libraries/core-react/src/components/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -94,6 +94,11 @@ exports[`SingleSelect Matches snapshot 1`] = `
   outline: none;
 }
 
+.c4[readOnly] {
+  background: transparent;
+  box-shadow: none;
+}
+
 .c9 {
   margin: 0;
   color: rgba(61,61,61,1);

--- a/libraries/core-react/src/components/TextField/Field.tsx
+++ b/libraries/core-react/src/components/TextField/Field.tsx
@@ -60,6 +60,7 @@ const StrippedTextarea = styled(Textarea)`
 type InputWrapperType = {
   isFocused: boolean
   isDisabled: boolean
+  isReadOnly: boolean
   variant: string
   token: TextFieldToken
   inputIcon?: ReactNode
@@ -68,7 +69,7 @@ type InputWrapperType = {
 }
 
 export const InputWrapper = styled.div<InputWrapperType>(
-  ({ inputIcon, unit, isDisabled, multiline, variant }) => css`
+  ({ inputIcon, unit, isDisabled, isReadOnly, multiline, variant }) => css`
     ${Variation}
     ${(inputIcon || unit) &&
     css`
@@ -77,7 +78,11 @@ export const InputWrapper = styled.div<InputWrapperType>(
       background: ${textfield.background};
       padding-right: ${textfield.spacings.right};
     `}
-
+    ${isReadOnly &&
+    css`
+      box-shadow: none;
+      background: transparent;
+    `}
     ${isDisabled &&
     css`
       box-shadow: none;
@@ -142,7 +147,7 @@ type FieldProps = {
   /** Type */
   type?: string
   /** Read Only */
-  readonly?: boolean
+  readOnly?: boolean
   /** Unit text */
   unit?: string
   /* Input icon */
@@ -159,6 +164,7 @@ export const Field = forwardRef<
     multiline,
     variant,
     disabled,
+    readOnly,
     type,
     unit,
     inputIcon,
@@ -192,6 +198,7 @@ export const Field = forwardRef<
   const inputWrapperProps = {
     isFocused,
     isDisabled: disabled,
+    isReadOnly: readOnly,
     variant,
     token: inputVariant,
     inputIcon,
@@ -203,6 +210,7 @@ export const Field = forwardRef<
     ref: ref as Ref<HTMLInputElement>,
     type,
     disabled,
+    readOnly,
     variant,
     onBlur: blurHandler,
     onFocus: focusHandler,

--- a/libraries/core-react/src/components/TextField/Field.tsx
+++ b/libraries/core-react/src/components/TextField/Field.tsx
@@ -80,8 +80,8 @@ export const InputWrapper = styled.div<InputWrapperType>(
     `}
     ${isReadOnly &&
     css`
-      box-shadow: none;
-      background: transparent;
+      box-shadow: ${textfield.states.readOnly.boxShadow};
+      background: ${textfield.states.readOnly.background};
     `}
     ${isDisabled &&
     css`

--- a/libraries/core-react/src/components/TextField/TextField.stories.tsx
+++ b/libraries/core-react/src/components/TextField/TextField.stories.tsx
@@ -231,6 +231,49 @@ export const Disabled: Story<TextFieldProps> = () => (
     />
   </Wrapper>
 )
+
+export const ReadOnly: Story<TextFieldProps> = () => (
+  <Wrapper>
+    <TextField
+      id="storybook-readonly"
+      placeholder="Placeholder text"
+      label="Read only"
+      meta="Meta"
+      helperText="Helper Text"
+      readOnly
+    />
+    <TextField
+      id="storybook-readonly-two"
+      defaultValue="Input text"
+      label="Read only"
+      meta="Meta"
+      helperText="Helper Text"
+      readOnly
+    />
+    <TextField
+      id="storybook-unit-readonly-three"
+      defaultValue="Input value"
+      label="Read only icon + unit"
+      unit="$"
+      readOnly
+      inputIcon={<Icon name="thumbs_up" />}
+    />
+    <TextField
+      id="storybook-multi-readonly"
+      label="Multiline variant read only"
+      defaultValue="Input value that spans multiple lines"
+      multiline
+      variant="error"
+      readOnly
+      style={{ resize: 'none' }}
+      rows={2}
+      helperText="helper text"
+      inputIcon={<Icon name="warning_filled" title="Warning" />}
+    />
+  </Wrapper>
+)
+ReadOnly.storyName = 'Read only'
+
 export const WithUnit: Story<TextFieldProps> = () => (
   <Wrapper>
     <TextField

--- a/libraries/core-react/src/components/TextField/TextField.tokens.ts
+++ b/libraries/core-react/src/components/TextField/TextField.tokens.ts
@@ -37,6 +37,10 @@ export const textfield: TextFieldToken = {
         offset: '0px',
       },
     },
+    readOnly: {
+      background: 'transparent',
+      boxShadow: 'none',
+    },
   },
   entities: {
     unit: {

--- a/libraries/core-react/src/components/Textarea/Textarea.tsx
+++ b/libraries/core-react/src/components/Textarea/Textarea.tsx
@@ -13,7 +13,7 @@ import { useEds } from '../EdsProvider'
 
 const { input } = tokens
 
-const Variation = ({ variant, token, density }: StyledProps) => {
+const Variation = ({ variant, token, density, readOnly }: StyledProps) => {
   if (!variant) {
     return ``
   }
@@ -36,6 +36,7 @@ const Variation = ({ variant, token, density }: StyledProps) => {
     ${spacingsTemplate(spacings)}
     ${outlineTemplate(activeOutline)}
     box-shadow: ${boxShadow};
+    box-shadow: ${readOnly ? 'none' : boxShadow};
 
     &:active,
     &:focus {
@@ -60,6 +61,7 @@ type StyledProps = {
   token: InputToken
   variant: string
   density: string
+  readOnly: boolean
 }
 
 const StyledTextarea = styled.textarea<StyledProps>`
@@ -68,7 +70,8 @@ const StyledTextarea = styled.textarea<StyledProps>`
   margin: 0;
   border: none;
   appearance: none;
-  background: ${input.background};
+  background: ${({ readOnly }) =>
+    readOnly ? 'transparent' : input.background};
   height: auto;
   ${typographyTemplate(input.typography)}
 
@@ -91,14 +94,21 @@ export type TextareaProps = {
   /** Type */
   type?: string
   /** Read Only */
-  readonly?: boolean
+  readOnly?: boolean
   /** Specifies max rows for multiline input */
   rowsMax?: number
 } & TextareaHTMLAttributes<HTMLTextAreaElement>
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   function Textarea(
-    { variant = 'default', disabled = false, type = 'text', rowsMax, ...other },
+    {
+      variant = 'default',
+      disabled = false,
+      readOnly = false,
+      type = 'text',
+      rowsMax,
+      ...other
+    },
     ref,
   ) {
     const actualVariant = variant === 'default' ? 'input' : variant
@@ -123,6 +133,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       ref: useCombinedRefs<HTMLTextAreaElement>(ref, setTextareaEl),
       type,
       disabled,
+      readOnly,
       variant,
       token: inputVariant,
       density,

--- a/libraries/core-react/src/components/Textarea/Textarea.tsx
+++ b/libraries/core-react/src/components/Textarea/Textarea.tsx
@@ -13,7 +13,7 @@ import { useEds } from '../EdsProvider'
 
 const { input } = tokens
 
-const Variation = ({ variant, token, density, readOnly }: StyledProps) => {
+const Variation = ({ variant, token, density }: StyledProps) => {
   if (!variant) {
     return ``
   }
@@ -36,7 +36,6 @@ const Variation = ({ variant, token, density, readOnly }: StyledProps) => {
     ${spacingsTemplate(spacings)}
     ${outlineTemplate(activeOutline)}
     box-shadow: ${boxShadow};
-    box-shadow: ${readOnly ? 'none' : boxShadow};
 
     &:active,
     &:focus {
@@ -61,7 +60,6 @@ type StyledProps = {
   token: InputToken
   variant: string
   density: string
-  readOnly: boolean
 }
 
 const StyledTextarea = styled.textarea<StyledProps>`
@@ -70,8 +68,7 @@ const StyledTextarea = styled.textarea<StyledProps>`
   margin: 0;
   border: none;
   appearance: none;
-  background: ${({ readOnly }) =>
-    readOnly ? 'transparent' : input.background};
+  background: ${input.background};
   height: auto;
   ${typographyTemplate(input.typography)}
 
@@ -81,6 +78,10 @@ const StyledTextarea = styled.textarea<StyledProps>`
   }
   &:disabled {
     color: ${input.states.disabled.typography.color};
+  }
+  &[readOnly] {
+    box-shadow: ${input.states.readOnly.boxShadow};
+    background: ${input.states.readOnly.background};
   }
 `
 
@@ -101,14 +102,7 @@ export type TextareaProps = {
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   function Textarea(
-    {
-      variant = 'default',
-      disabled = false,
-      readOnly = false,
-      type = 'text',
-      rowsMax,
-      ...other
-    },
+    { variant = 'default', disabled = false, type = 'text', rowsMax, ...other },
     ref,
   ) {
     const actualVariant = variant === 'default' ? 'input' : variant
@@ -133,7 +127,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       ref: useCombinedRefs<HTMLTextAreaElement>(ref, setTextareaEl),
       type,
       disabled,
-      readOnly,
       variant,
       token: inputVariant,
       density,

--- a/libraries/tokens/src/types/component.ts
+++ b/libraries/tokens/src/types/component.ts
@@ -23,6 +23,7 @@ export type ComponentToken = {
   states?: {
     active?: ComponentToken & { outline?: Outline }
     disabled?: ComponentToken
+    readOnly?: ComponentToken & { outline?: Outline }
     focus?: ComponentToken & { outline?: Outline }
     hover?: ComponentToken
     pressed?: ComponentToken & { pressed?: Pressed }


### PR DESCRIPTION
Fixes #1162 

Should ComponentToken be updated with a readOnly state? the only style change is transparent background and no box-shadow to make an underline so maybe it isn't neccessary.. 
I followed the behaviour of read only text input in material ui, where it still gets a visual focus 