### PR TITLE
WIP: Wrapping focus selectors in media query

### DIFF
--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -9,10 +9,12 @@ type StyledProps = Pick<BreadcrumbProps, 'maxWidth'>
 const { states, typography } = tokens
 
 const StyledTypography = styled(Typography)<StyledProps>`
-  &:hover {
-    text-decoration: underline;
-    color: ${states.hover.typography.color};
-    cursor: pointer;
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      text-decoration: underline;
+      color: ${states.hover.typography.color};
+      cursor: pointer;
+    }
   }
   white-space: nowrap;
   overflow: hidden;

--- a/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/libraries/core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -31,9 +31,11 @@ const Separator = styled(Typography)`
 `
 
 const Collapsed = styled(Typography)`
-  &:hover {
-    text-decoration: underline;
-    color: ${states.hover.typography.color};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      text-decoration: underline;
+      color: ${states.hover.typography.color};
+    }
   }
   color: ${typography.color};
   text-decoration: none;

--- a/libraries/core-react/src/components/Button/Button.tsx
+++ b/libraries/core-react/src/components/Button/Button.tsx
@@ -94,10 +94,12 @@ const ButtonBase = styled.button(({ theme }: { theme: ButtonToken }) => {
       content: '';
     }
 
-    &:hover {
-      background: ${hover.background};
-      color: ${hover.typography?.color};
-      ${bordersTemplate(hover?.border)}
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: ${hover.background};
+        color: ${hover.typography?.color};
+        ${bordersTemplate(hover?.border)};
+      }
     }
 
     &:focus {
@@ -115,11 +117,13 @@ const ButtonBase = styled.button(({ theme }: { theme: ButtonToken }) => {
     &:disabled {
       cursor: not-allowed;
       background: ${disabled.background};
-      ${bordersTemplate(disabled.border)}
-      ${typographyTemplate(disabled.typography)}
+      ${bordersTemplate(disabled.border)};
+      ${typographyTemplate(disabled.typography)};
 
-      &:hover {
-        background: ${disabled.background};
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          background: ${disabled.background};
+        }
       }
     }
   `

--- a/libraries/core-react/src/components/Chip/Chip.tsx
+++ b/libraries/core-react/src/components/Chip/Chip.tsx
@@ -46,7 +46,8 @@ const StyledChips = styled.div.attrs<StyleProps>(
     fill: ${typography.color};
   }
 
-  &:hover {
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
     color: ${states.hover.typography.color};
     svg {
       fill: ${states.hover.typography.color};
@@ -68,8 +69,10 @@ const StyledChips = styled.div.attrs<StyleProps>(
   ${({ clickable }) =>
     clickable &&
     css`
-      &:hover {
-        cursor: pointer;
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          cursor: pointer;
+        }
       }
     `}
 
@@ -87,11 +90,14 @@ const StyledChips = styled.div.attrs<StyleProps>(
             fill: ${error.entities.icon.typography.color};
           }
           ${bordersTemplate(error.border)};
-          &:hover {
-            border-color: ${error.states.hover.typography.color};
-            color: ${error.states.hover.typography.color};
-            svg {
-              fill: ${error.states.hover.typography.color};
+          @media (hover: hover) and (pointer: fine) {
+            &:hover {
+              border-color: ${error.states.hover.typography.color};
+              color: ${error.states.hover.typography.color};
+
+              svg {
+                fill: ${error.states.hover.typography.color};
+              }
             }
           }
         `
@@ -109,11 +115,14 @@ const StyledChips = styled.div.attrs<StyleProps>(
       svg {
         fill: ${states.disabled.typography.color};
       }
-      &:hover {
-        color: ${states.disabled.typography.color};
-        cursor: not-allowed;
-        svg {
-          fill: ${states.disabled.typography.color};
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          color: ${states.disabled.typography.color};
+          cursor: not-allowed;
+
+          svg {
+            fill: ${states.disabled.typography.color};
+          }
         }
       }
     `}

--- a/libraries/core-react/src/components/Menu/MenuItem.tsx
+++ b/libraries/core-react/src/components/Menu/MenuItem.tsx
@@ -60,15 +60,19 @@ const ListItem = styled.li.attrs<StyleAttrsProps>(({ isFocused }) => ({
           &:focus {
             outline: none;
           }
+        @media (hover: hover) and (pointer: fine) {
           &:hover {
             cursor: not-allowed;
           }
+        }
         `
       : css`
-          &:hover {
-            z-index: 1;
-            cursor: pointer;
-            background: ${hover.background};
+          @media (hover: hover) and (pointer: fine) {
+            &:hover {
+              z-index: 1;
+              cursor: pointer;
+              background: ${hover.background};
+            }
           }
           &:focus {
             ${outlineTemplate(focus.outline)}

--- a/libraries/core-react/src/components/Search/Search.tsx
+++ b/libraries/core-react/src/components/Search/Search.tsx
@@ -69,9 +69,11 @@ const Container = styled.span<ContainerProps>`
           cursor: not-allowed;
         `
       : css`
-          &:hover {
-            ${bordersTemplate(states.focus.border)}
-            cursor: text;
+          @media (hover: hover) and (pointer: fine) {
+            &:hover {
+              ${bordersTemplate(states.focus.border)}
+              cursor: text;
+            }
           }
         `}
 
@@ -164,9 +166,11 @@ const InsideButton = styled.div<InsideButtonProps>`
     isActive &&
     css`
       visibility: visible;
-      &:hover {
-        cursor: pointer;
-        background: ${icon.states.hover.background};
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          cursor: pointer;
+          background: ${icon.states.hover.background};
+        }
       }
     `}
 `

--- a/libraries/core-react/src/components/Slider/Slider.tsx
+++ b/libraries/core-react/src/components/Slider/Slider.tsx
@@ -82,11 +82,13 @@ const RangeWrapper = styled.div<RangeWrapperProps>`
     );
     width: calc((var(--a) - var(--b)) / var(--dif) * var(--realWidth));
   }
-  &:hover:not([disabled]) {
-    ${fakeTrackBgHover}
-    &::before,
-    &::after {
-      background: ${track.entities.indicator.states.hover.background};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover:not([disabled]) {
+      ${fakeTrackBgHover}
+      &::before,
+      &::after {
+        background: ${track.entities.indicator.states.hover.background};
+      }
     }
   }
 `
@@ -115,10 +117,12 @@ const Wrapper = styled.div<WrapperProps>`
     /* Adjusting for start dot circle */
     margin-left: 3px;
   }
-  &:hover:not([disabled]) {
-    ${fakeTrackBgHover}
-    &::after {
-      background: ${track.entities.indicator.states.hover.background};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover:not([disabled]) {
+      ${fakeTrackBgHover}
+      &::after {
+        background: ${track.entities.indicator.states.hover.background};
+      }
     }
   }
 `

--- a/libraries/core-react/src/components/TableOfContents/LinkItem.tsx
+++ b/libraries/core-react/src/components/TableOfContents/LinkItem.tsx
@@ -41,13 +41,15 @@ const StyledLinkItem = styled.li`
       ${outlineTemplate(tokens.states.focus.outline)};
     }
 
-    &:hover {
-      ${typographyTemplate(tokens.states.hover.typography)}
-      background: ${tokens.states.hover.background};
-      ${bordersTemplate(tokens.states.hover.border)}
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        ${typographyTemplate(tokens.states.hover.typography)}
+        background: ${tokens.states.hover.background};
 
-      svg {
-        fill: ${tokens.states.hover.entities.icon.background};
+        ${bordersTemplate(tokens.states.hover.border)}
+        svg {
+          fill: ${tokens.states.hover.entities.icon.background};
+        }
       }
     }
 

--- a/libraries/core-react/src/components/Tabs/Tab.tsx
+++ b/libraries/core-react/src/components/Tabs/Tab.tsx
@@ -44,22 +44,24 @@ const StyledTab = styled.button.attrs<TabProps>(
   &::-moz-focus-inner {
     border: 0;
   }
-  &[data-hover],
-  &:hover {
-    color: ${({ active }) =>
-      active
-        ? tab.states.active.states.hover.typography.color
-        : tab.typography.color};
-    ${({ disabled }) =>
-      disabled
-        ? css`
-            background: ${tab.states.disabled.background};
-            cursor: not-allowed;
-          `
-        : css`
-            background: ${tab.states.hover.background};
-            cursor: pointer;
-          `}
+  @media (hover: hover) and (pointer: fine) {
+    &[data-hover],
+    &:hover {
+      color: ${({ active }) =>
+              active
+                      ? tab.states.active.states.hover.typography.color
+                      : tab.typography.color};
+      ${({ disabled }) =>
+              disabled
+                      ? css`
+                        background: ${tab.states.disabled.background};
+                        cursor: not-allowed;
+                      `
+                      : css`
+                        background: ${tab.states.hover.background};
+                        cursor: pointer;
+                      `}
+    }
   }
 
   ${({ disabled }) =>


### PR DESCRIPTION
Fixes #1589

Actions:
Wrap the focus selectors in the following component
 - [ ] Accordion
 - [x] Breadcrumbs
 - [x] Breadcrumb
 - [x] Button
 - [x] Chip
 - [x] MenuItem (Menu)
 - [x] Search
 - [x] Slider
 - [ ]  SliderInput
 - [ ]  Row (Table)
 - [x]  LinkItem (TableOfContents)
 - [x]  Tab (Tabs)