### PR TITLE
🐛 Fixed keyboard navigation when menuSection is present

### DIFF
--- a/libraries/core-react/src/components/Menu/MenuList.tsx
+++ b/libraries/core-react/src/components/Menu/MenuList.tsx
@@ -47,13 +47,14 @@ export const MenuList = forwardRef<HTMLUListElement, MenuListProps>(
             (grandChild: ReactNode) => {
               index++
               return cloneElement(grandChild as MenuChild, { index })
-            })
+            },
+          )
           return cloneElement(child as MenuChild, null, updatedGrandChildren)
         } else {
           index++
           return cloneElement(child as MenuChild, { index })
         }
-      }
+      },
     )
 
     const flattenedChildren = ReactChildren.map(
@@ -64,7 +65,8 @@ export const MenuList = forwardRef<HTMLUListElement, MenuListProps>(
         } else {
           return child
         }
-      })
+      },
+    )
 
     const focusableIndexs: number[] = ((flattenedChildren as MenuChild[]) || [])
       .filter((x) => !x.props.disabled)

--- a/libraries/core-react/src/components/Menu/MenuList.tsx
+++ b/libraries/core-react/src/components/Menu/MenuList.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useMemo,
   ReactElement,
   ReactNode,
   isValidElement,
@@ -44,27 +45,28 @@ export const MenuList = forwardRef<HTMLUListElement, MenuListProps>(
     const { focusedIndex, setFocusedIndex } = useMenu()
 
     let index = -1
-    const focusableIndexs: number[] = []
+    const focusableIndexs: number[] = useMemo<number[]>(() => [], [])
 
-    const updatedChildren: Array<MenuChild> = ReactChildren.map(
-      children,
-      (child: MenuChild) => {
-        if (child.type === MenuSection) {
-          const updatedGrandChildren = ReactChildren.map(
-            child.props.children,
-            (grandChild: MenuChild) => {
-              index++
-              if (isIndexable(grandChild)) focusableIndexs.push(index)
-              return cloneElement(grandChild, { index })
-            },
-          )
-          return cloneElement(child, null, updatedGrandChildren)
-        } else {
-          index++
-          if (isIndexable(child)) focusableIndexs.push(index)
-          return cloneElement(child, { index })
-        }
-      },
+    const updatedChildren: Array<MenuChild> = useMemo(
+      () =>
+        ReactChildren.map(children, (child: MenuChild) => {
+          if (child.type === MenuSection) {
+            const updatedGrandChildren = ReactChildren.map(
+              child.props.children,
+              (grandChild: MenuChild) => {
+                index++
+                if (isIndexable(grandChild)) focusableIndexs.push(index)
+                return cloneElement(grandChild, { index })
+              },
+            )
+            return cloneElement(child, null, updatedGrandChildren)
+          } else {
+            index++
+            if (isIndexable(child)) focusableIndexs.push(index)
+            return cloneElement(child, { index })
+          }
+        }),
+      [children, focusableIndexs, index],
     )
 
     const firstFocusIndex = focusableIndexs[0]


### PR DESCRIPTION
Resolves #1668 

The internal logic to add indexes to focusable children and then make them focusable with keyboard did not work at all with menuSections present. 
I have changed the code now to add index to menuItems inside sections, as well as menuItems that are not in sections. I then  made a separate flat array of children to build the focusableIndexs.

I also added event.preventDefault when pressing up/down arrows inside menu to stop scrolling the viewport.

On a sidenote it does not appear that memo works on menuItems, I guess because of the function props, so there are probably some more optimizations that can be done on this component