### PR TITLE
✨Menu: className and style props are put on outermost element

### DIFF
--- a/libraries/core-react/src/components/Menu/Menu.test.tsx
+++ b/libraries/core-react/src/components/Menu/Menu.test.tsx
@@ -31,15 +31,15 @@ describe('Menu', () => {
   })
 
   it('Can extend the css for the component', async () => {
-    render(
+    const { container } = render(
       <StyledMenu open>
         <div>some random content</div>
       </StyledMenu>,
     )
-    const menuContainer = screen.getByRole('menu', { hidden: true })
 
     await waitFor(() =>
-      expect(menuContainer).toHaveStyleRule('background', 'red'),
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(container.nextSibling).toHaveStyleRule('background', 'red'),
     )
   })
   it('is visible when open is true & anchorEl is set', async () => {

--- a/libraries/core-react/src/components/Menu/Menu.tsx
+++ b/libraries/core-react/src/components/Menu/Menu.tsx
@@ -105,11 +105,9 @@ export const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
     4,
   )
 
-  const combinedStyles = { ...styles.popper, ...style }
-
   const props = {
     open,
-    style: combinedStyles,
+    style: { ...styles.popper, ...style },
     className,
     ...attributes.popper,
   }

--- a/libraries/core-react/src/components/Menu/Menu.tsx
+++ b/libraries/core-react/src/components/Menu/Menu.tsx
@@ -89,7 +89,7 @@ export type MenuProps = {
 } & HTMLAttributes<HTMLUListElement>
 
 export const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
-  { anchorEl, open, placement = 'auto', ...rest },
+  { anchorEl, open, placement = 'auto', style, className, ...rest },
   ref,
 ) {
   const [containerEl, setContainerEl] = useState<HTMLElement>(null)
@@ -105,9 +105,12 @@ export const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
     4,
   )
 
+  const combinedStyles = { ...styles.popper, ...style }
+
   const props = {
     open,
-    style: styles.popper,
+    style: combinedStyles,
+    className,
     ...attributes.popper,
   }
 

--- a/libraries/core-react/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/libraries/core-react/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -15,12 +15,8 @@ exports[`Menu Matches snapshot 1`] = `
   z-index: 3;
 }
 
-.c1 {
-  background: red;
-}
-
 <ul
-  class="c0 c1"
+  class="c0"
   role="menu"
 >
   <div


### PR DESCRIPTION
resolves: #1672 

This will allow users to overwrite styles on an element that is also used by popper to set position via `position`, `inset (top, left, bottom, right)` and `transform`, but I think it's fine, users will quickly realize if they try that..