### PR TITLE
🐛♻️ Replacing ul>li with div>button fixes keyboard enter-as-click

### DIFF
--- a/libraries/core-react/src/components/Menu/Menu.tsx
+++ b/libraries/core-react/src/components/Menu/Menu.tsx
@@ -35,7 +35,7 @@ type MenuContainerProps = MenuProps & {
   containerEl: HTMLElement
 }
 
-const MenuContainer = forwardRef<HTMLUListElement, MenuContainerProps>(
+const MenuContainer = forwardRef<HTMLDivElement, MenuContainerProps>(
   function MenuContainer(
     {
       children,
@@ -86,9 +86,9 @@ export type MenuProps = {
   onClose?: () => void
   /** Menu placement relative to anchorEl */
   placement?: Placement
-} & HTMLAttributes<HTMLUListElement>
+} & HTMLAttributes<HTMLDivElement>
 
-export const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
+export const Menu = forwardRef<HTMLDivElement, MenuProps>(function Menu(
   { anchorEl, open, placement = 'auto', style, className, ...rest },
   ref,
 ) {

--- a/libraries/core-react/src/components/Menu/MenuItem.tsx
+++ b/libraries/core-react/src/components/Menu/MenuItem.tsx
@@ -28,7 +28,7 @@ type StyleAttrsProps = {
   isFocused: string
 }
 
-const ListItem = styled.button.attrs<StyleAttrsProps>(({ isFocused }) => ({
+const Item = styled.button.attrs<StyleAttrsProps>(({ isFocused }) => ({
   role: 'menuitem',
   tabIndex: isFocused ? -1 : 0,
 }))<StyleProps>`
@@ -125,7 +125,7 @@ export const MenuItem = memo(
     }
 
     return (
-      <ListItem
+      <Item
         {...props}
         ref={useCombinedRefs<HTMLButtonElement>(ref, (el) => {
           if (el !== null && isFocused) {
@@ -143,7 +143,7 @@ export const MenuItem = memo(
         }}
       >
         <Content>{children}</Content>
-      </ListItem>
+      </Item>
     )
   }),
 )

--- a/libraries/core-react/src/components/Menu/MenuItem.tsx
+++ b/libraries/core-react/src/components/Menu/MenuItem.tsx
@@ -134,7 +134,7 @@ export const MenuItem = memo(
         })}
         onFocus={() => toggleFocus(index)}
         onClick={(e) => {
-          if (!disabled && onClick) {
+          if (onClick) {
             onClick(e)
             if (onClose !== null) {
               onClose(e)

--- a/libraries/core-react/src/components/Menu/MenuItem.tsx
+++ b/libraries/core-react/src/components/Menu/MenuItem.tsx
@@ -28,10 +28,12 @@ type StyleAttrsProps = {
   isFocused: string
 }
 
-const ListItem = styled.li.attrs<StyleAttrsProps>(({ isFocused }) => ({
+const ListItem = styled.button.attrs<StyleAttrsProps>(({ isFocused }) => ({
   role: 'menuitem',
   tabIndex: isFocused ? -1 : 0,
 }))<StyleProps>`
+  border: 0;
+  background-color: transparent;
   width: auto;
   position: relative;
   z-index: 2;
@@ -75,6 +77,7 @@ const ListItem = styled.li.attrs<StyleAttrsProps>(({ isFocused }) => ({
             }
           }
           &:focus {
+            z-index: 3;
             ${outlineTemplate(focus.outline)}
           }
         `}
@@ -98,10 +101,10 @@ export type MenuItemProps = {
   disabled?: boolean
   /** onClick handler */
   onClick?: (e: React.MouseEvent) => void
-} & React.HTMLAttributes<HTMLLIElement>
+} & React.HTMLAttributes<HTMLButtonElement>
 
 export const MenuItem = memo(
-  forwardRef<HTMLLIElement, MenuItemProps>(function MenuItem(
+  forwardRef<HTMLButtonElement, MenuItemProps>(function MenuItem(
     { children, disabled, index = 0, onClick, ...rest },
     ref,
   ) {
@@ -124,7 +127,7 @@ export const MenuItem = memo(
     return (
       <ListItem
         {...props}
-        ref={useCombinedRefs<HTMLLIElement>(ref, (el) => {
+        ref={useCombinedRefs<HTMLButtonElement>(ref, (el) => {
           if (el !== null && isFocused) {
             el.focus()
           }

--- a/libraries/core-react/src/components/Menu/MenuList.tsx
+++ b/libraries/core-react/src/components/Menu/MenuList.tsx
@@ -16,9 +16,11 @@ import { MenuSectionProps, MenuSection } from './MenuSection'
 import { menu as tokens } from './Menu.tokens'
 import { spacingsTemplate } from '../../utils'
 
-const List = styled.ul`
+const List = styled.div`
   position: relative;
   list-style: none;
+  display: flex;
+  flex-direction: column;
   margin: 0;
   ${spacingsTemplate(tokens.spacings)}
   li:first-child {
@@ -40,7 +42,7 @@ function isIndexable(item: MenuChild) {
   return false
 }
 
-export const MenuList = forwardRef<HTMLUListElement, MenuListProps>(
+export const MenuList = forwardRef<HTMLDivElement, MenuListProps>(
   function MenuList({ children, focus, ...rest }, ref) {
     const { focusedIndex, setFocusedIndex } = useMenu()
 
@@ -95,7 +97,7 @@ export const MenuList = forwardRef<HTMLUListElement, MenuListProps>(
       setFocusedIndex(nextFocusedIndex)
     }
 
-    const handleKeyPress = (event: React.KeyboardEvent<HTMLUListElement>) => {
+    const handleKeyPress = (event: React.KeyboardEvent<HTMLDivElement>) => {
       const { key } = event
       event.stopPropagation()
 

--- a/libraries/core-react/src/components/Menu/MenuSection.tsx
+++ b/libraries/core-react/src/components/Menu/MenuSection.tsx
@@ -6,7 +6,7 @@ import { spacingsTemplate } from '../../utils'
 import { Divider } from '../Divider'
 import { Typography } from '../Typography'
 
-const ListItem = styled.div.attrs(() => ({
+const Header = styled.div.attrs(() => ({
   tabIndex: 0,
 }))`
   ${spacingsTemplate(tokens.entities.title.spacings)}
@@ -36,11 +36,11 @@ export const MenuSection = React.memo(function MenuSection(
         </div>
       )}
       {title && (
-        <ListItem>
+        <Header>
           <Typography group="navigation" variant="label">
             {title}
           </Typography>
-        </ListItem>
+        </Header>
       )}
       {children}
     </>

--- a/libraries/core-react/src/components/Menu/MenuSection.tsx
+++ b/libraries/core-react/src/components/Menu/MenuSection.tsx
@@ -6,7 +6,7 @@ import { spacingsTemplate } from '../../utils'
 import { Divider } from '../Divider'
 import { Typography } from '../Typography'
 
-const ListItem = styled.li.attrs(() => ({
+const ListItem = styled.div.attrs(() => ({
   tabIndex: 0,
 }))`
   ${spacingsTemplate(tokens.entities.title.spacings)}
@@ -31,9 +31,9 @@ export const MenuSection = React.memo(function MenuSection(
   return (
     <>
       {index !== 0 && (
-        <li>
+        <div>
           <Divider variant="small"></Divider>
-        </li>
+        </div>
       )}
       {title && (
         <ListItem>

--- a/libraries/core-react/src/components/Menu/MenuSection.tsx
+++ b/libraries/core-react/src/components/Menu/MenuSection.tsx
@@ -32,7 +32,7 @@ export const MenuSection = React.memo(function MenuSection(
     <>
       {index !== 0 && (
         <div>
-          <Divider variant="small"></Divider>
+          <Divider variant="small" />
         </div>
       )}
       {title && (

--- a/libraries/core-react/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/libraries/core-react/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -4,6 +4,13 @@ exports[`Menu Matches snapshot 1`] = `
 .c0 {
   position: relative;
   list-style: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   margin: 0;
   padding-left: 0px;
   padding-top: 8px;
@@ -15,7 +22,7 @@ exports[`Menu Matches snapshot 1`] = `
   z-index: 3;
 }
 
-<ul
+<div
   class="c0"
   role="menu"
 >
@@ -24,5 +31,5 @@ exports[`Menu Matches snapshot 1`] = `
   >
     some random content
   </div>
-</ul>
+</div>
 `;


### PR DESCRIPTION
resolves #1702 

In the menu, we want keyboard 'enter' to behave the same as clicking an item with the mouse. By replacing the `li` element with a `button` element we get this `onClick` behaviour with keyboard for free