### PR TITLE
🚸 Menu: Return focus to anchor after escape/enter keypress

### DIFF
--- a/libraries/core-react/src/components/Menu/Menu.tsx
+++ b/libraries/core-react/src/components/Menu/Menu.tsx
@@ -64,6 +64,13 @@ const MenuContainer = forwardRef<HTMLDivElement, MenuContainerProps>(
     useGlobalKeyPress('Escape', () => {
       if (open && onClose !== null) {
         onClose()
+        anchorEl.focus()
+      }
+    })
+
+    useGlobalKeyPress('Enter', () => {
+      if (open && onClose !== null) {
+        if (window.document.contains(anchorEl)) anchorEl.focus()
       }
     })
 


### PR DESCRIPTION
Resolves #1704 