### PR TITLE
🐛 Cell, DataCell: fix deprecated DOM intefrace

### DIFF
--- a/libraries/core-react/src/components/Table/Cell.tsx
+++ b/libraries/core-react/src/components/Table/Cell.tsx
@@ -12,11 +12,11 @@ export type CellProps = {
   /** Specifies cell sort direction */
   sort?: React.AriaAttributes['aria-sort']
 } & (
-  | TdHTMLAttributes<HTMLTableDataCellElement>
-  | ThHTMLAttributes<HTMLTableHeaderCellElement>
+  | TdHTMLAttributes<HTMLTableCellElement>
+  | ThHTMLAttributes<HTMLTableCellElement>
 )
 export const Cell = forwardRef<
-  HTMLTableDataCellElement | HTMLTableHeaderCellElement,
+  HTMLTableCellElement | HTMLTableCellElement,
   CellProps
 >(function Cell({ ...rest }, ref) {
   return (

--- a/libraries/core-react/src/components/Table/Cell.tsx
+++ b/libraries/core-react/src/components/Table/Cell.tsx
@@ -15,10 +15,10 @@ export type CellProps = {
   | TdHTMLAttributes<HTMLTableCellElement>
   | ThHTMLAttributes<HTMLTableCellElement>
 )
-export const Cell = forwardRef<
-  HTMLTableCellElement | HTMLTableCellElement,
-  CellProps
->(function Cell({ ...rest }, ref) {
+export const Cell = forwardRef<HTMLTableCellElement, CellProps>(function Cell(
+  { ...rest },
+  ref,
+) {
   return (
     <InnerContext.Consumer>
       {({ variant, sticky }) => {

--- a/libraries/core-react/src/components/Table/DataCell/DataCell.tsx
+++ b/libraries/core-react/src/components/Table/DataCell/DataCell.tsx
@@ -37,9 +37,9 @@ type CellProps = {
   variant?: Variants
   /** Specifies cell background color */
   color?: Colors
-} & TdHTMLAttributes<HTMLTableDataCellElement>
+} & TdHTMLAttributes<HTMLTableCellElement>
 
-export const TableDataCell = forwardRef<HTMLTableDataCellElement, CellProps>(
+export const TableDataCell = forwardRef<HTMLTableCellElement, CellProps>(
   function TableDataCell({ children, variant = 'text', ...rest }, ref) {
     const { density } = useEds()
     const token = useToken({ density }, applyVariant(variant, tableCell))

--- a/libraries/core-react/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/libraries/core-react/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -72,20 +72,19 @@ const CellInner = styled.div`
 type CellProps = {
   sort?: React.AriaAttributes['aria-sort']
   sticky?: boolean
-} & ThHTMLAttributes<HTMLTableHeaderCellElement>
+} & ThHTMLAttributes<HTMLTableCellElement>
 
-export const TableHeaderCell = forwardRef<
-  HTMLTableHeaderCellElement,
-  CellProps
->(function TableHeaderCell({ children, sort, ...rest }, ref) {
-  const { density } = useEds()
-  const token = useToken({ density }, tablehead)
+export const TableHeaderCell = forwardRef<HTMLTableCellElement, CellProps>(
+  function TableHeaderCell({ children, sort, ...rest }, ref) {
+    const { density } = useEds()
+    const token = useToken({ density }, tablehead)
 
-  return (
-    <ThemeProvider theme={token}>
-      <StyledTableCell aria-sort={sort} {...rest} ref={ref}>
-        <CellInner>{children}</CellInner>
-      </StyledTableCell>
-    </ThemeProvider>
-  )
-})
+    return (
+      <ThemeProvider theme={token}>
+        <StyledTableCell aria-sort={sort} {...rest} ref={ref}>
+          <CellInner>{children}</CellInner>
+        </StyledTableCell>
+      </ThemeProvider>
+    )
+  },
+)


### PR DESCRIPTION
resolves #1739 

`HTMLTableDataCellElement` and `HTMLTableHeaderCellElement` are deprecated.
According to MDN docs. the new DOM interface is `HTMLTableCellElement`, for manipulating the layout and presentation of table cells, either header or data cells, in an HTML document.