### PR TITLE
🔖 Release eds-icons@0.9.0

### DIFF
--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-New icons:
+New icons ([#1743](https://github.com/equinor/design-system/issues/1743)) ([#1581](https://github.com/equinor/design-system/issues/1581)) ([#1734](https://github.com/equinor/design-system/issues/1734))
 
 - `ducting`
 - `electrical`
@@ -40,10 +40,10 @@ New icons:
 
 ## Changed
 
-- `launch` (should no longer be confused with `external_link` icon)
-- Renamed `inspectrotation` to `inspect_rotation`
-- Renamed `inspect3d` to `inspect_3d`
-- Renamed `rotate3d` to `rotate_3d`
+- `launch` (should no longer be confused with `external_link` icon) ([#1742](https://github.com/equinor/design-system/issues/1742))
+- Renamed `inspectrotation` to `inspect_rotation` ([#1781](https://github.com/equinor/design-system/issues/1781))
+- Renamed `inspect3d` to `inspect_3d` ([#1781](https://github.com/equinor/design-system/issues/1781))
+- Renamed `rotate3d` to `rotate_3d` ([#1781](https://github.com/equinor/design-system/issues/1781))
 
 ## [0.8.0] - 2021-11-09
 

--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+New icons:
+
 - `ducting`
 - `electrical`
 - `fault`
@@ -39,7 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 - `launch` (should no longer be confused with `external_link` icon)
--
+- Renamed `inspectrotation` to `inspect_rotation`
+- Renamed `inspect3d` to `inspect_3d`
+- Renamed `rotate3d` to `rotate_3d`
 
 ## [0.8.0] - 2021-11-09
 

--- a/libraries/icons/package.json
+++ b/libraries/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Icons from the Equinor Design System",
   "main": "dist/icons.cjs.js",
   "module": "dist/icons.esm.js",


### PR DESCRIPTION
resolves #1789 

## [0.9.0] - 2021-12-09

## Added

New icons ([#1743](https://github.com/equinor/design-system/issues/1743)) ([#1581](https://github.com/equinor/design-system/issues/1581)) ([#1734](https://github.com/equinor/design-system/issues/1734))

- `ducting`
- `electrical`
- `fault`
- `formula`
- `go_to`
- `grid_layer`
- `grid_layers`
- `heat_trace`
- `hill_shading`
- `instrument`
- `junction_box`
- `line`
- `log_in`
- `log_out`
- `manual_valve`
- `miniplayer_fullscreen`
- `miniplayer`
- `pipe_support`
- `surface_layer`
- `tag_main_equipment`
- `tag_more`
- `tag_relations`
- `tag_special_equipment`
- `telecom`
- `thumb_pin`
- `well`

## Changed

- `launch` (should no longer be confused with `external_link` icon) ([#1742](https://github.com/equinor/design-system/issues/1742))
- Renamed `inspectrotation` to `inspect_rotation` ([#1781](https://github.com/equinor/design-system/issues/1781))
- Renamed `inspect3d` to `inspect_3d` ([#1781](https://github.com/equinor/design-system/issues/1781))
- Renamed `rotate3d` to `rotate_3d` ([#1781](https://github.com/equinor/design-system/issues/1781))
