### PR TITLE
🔖 Release eds-icons@0.9.1

### DIFF
--- a/libraries/icons/CHANGELOG.md
+++ b/libraries/icons/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2021-12-10
+
+## Fixed
+
+- Missing vector on `fault` icon ([#1793](https://github.com/equinor/design-system/issues/1793))
+
 ## [0.9.0] - 2021-12-09
 
 ## Added

--- a/libraries/icons/package.json
+++ b/libraries/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Icons from the Equinor Design System",
   "main": "dist/icons.cjs.js",
   "module": "dist/icons.esm.js",


### PR DESCRIPTION
## [0.9.1] - 2021-12-10

## Fixed

- Missing vector on `fault` icon ([#1793](https://github.com/equinor/design-system/issues/1793))