### PR TITLE
⚡️Improvement - Menu, Popover: deactivate popper when closed

### DIFF
--- a/libraries/core-react/src/components/Menu/Menu.tsx
+++ b/libraries/core-react/src/components/Menu/Menu.tsx
@@ -53,7 +53,7 @@ const MenuContainer = forwardRef<HTMLDivElement, MenuContainerProps>(
       if (onClose === null && onCloseCallback) {
         setOnClose(onCloseCallback)
       }
-    })
+    }, [onClose, onCloseCallback, setOnClose])
 
     useOutsideClick(containerEl, (e: MouseEvent) => {
       if (open && onClose !== null && !anchorEl.contains(e.target as Node)) {
@@ -100,12 +100,17 @@ export const Menu = forwardRef<HTMLDivElement, MenuProps>(function Menu(
   ref,
 ) {
   const [containerEl, setContainerEl] = useState<HTMLElement>(null)
+  const [storedAnchorEl, setStoredAnchorEl] = useState<HTMLElement>(null)
   const isMounted = useIsMounted()
   const { density } = useEds()
   const token = useToken({ density }, tokens)
 
+  useEffect(() => {
+    open ? setStoredAnchorEl(anchorEl) : setStoredAnchorEl(null)
+  }, [anchorEl, open])
+
   const { styles, attributes } = usePopper(
-    anchorEl,
+    storedAnchorEl,
     containerEl,
     null,
     placement,

--- a/libraries/core-react/src/components/Menu/MenuSection.tsx
+++ b/libraries/core-react/src/components/Menu/MenuSection.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react'
-import { ReactNode } from 'react'
+import { ReactNode, memo } from 'react'
 import styled from 'styled-components'
 import { menu as tokens } from './Menu.tokens'
 import { spacingsTemplate } from '../../utils'
@@ -24,9 +23,7 @@ export type MenuSectionProps = {
   title?: string
 }
 
-export const MenuSection = React.memo(function MenuSection(
-  props: MenuSectionProps,
-) {
+export const MenuSection = memo(function MenuSection(props: MenuSectionProps) {
   const { children, title, index } = props
   return (
     <>

--- a/libraries/core-react/src/components/Popover/Popover.tsx
+++ b/libraries/core-react/src/components/Popover/Popover.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, useState, HTMLAttributes, SVGProps } from 'react'
+import {
+  forwardRef,
+  useState,
+  HTMLAttributes,
+  SVGProps,
+  useEffect,
+} from 'react'
 import styled, { css, ThemeProvider } from 'styled-components'
 import { Icon } from '../Icon'
 import { Paper } from '../Paper'
@@ -132,6 +138,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     ref,
   ) {
     const [popperEl, setPopperEl] = useState<HTMLElement>(null)
+    const [storedAnchorEl, setStoredAnchorEl] = useState<HTMLElement>(null)
     const [arrowRef, setArrowRef] = useState<HTMLDivElement | null>(null)
     const popoverRef = useCombinedRefs<HTMLDivElement>(ref, setPopperEl)
 
@@ -152,8 +159,12 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       }
     })
 
+    useEffect(() => {
+      open ? setStoredAnchorEl(anchorEl) : setStoredAnchorEl(null)
+    }, [anchorEl, open])
+
     const { styles, attributes } = usePopper(
-      anchorEl,
+      storedAnchorEl,
       popperEl,
       arrowRef,
       placement,


### PR DESCRIPTION
resolves #1675 

There is room for improvement in menu still, as it does rerender on each frame while scrolling when menu is open. But it is tricky to figure out all the root causes of this and how to resolve them, so I will leave it for now. 