### PR TITLE
🩹 Don’t use density prop (cleaned up)

### DIFF
--- a/libraries/core-react/src/components/Accordion/Accordion.stories.tsx
+++ b/libraries/core-react/src/components/Accordion/Accordion.stories.tsx
@@ -171,6 +171,7 @@ export const Compact: Story<AccordionProps> = () => {
     // Simulate user change
     setDensity('compact')
   }, [density])
+
   return (
     <Wrapper>
       <EdsProvider density={density}>

--- a/libraries/core-react/src/components/Accordion/Accordion.stories.tsx
+++ b/libraries/core-react/src/components/Accordion/Accordion.stories.tsx
@@ -193,3 +193,11 @@ export const Compact: Story<AccordionProps> = () => {
     </Wrapper>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Accordion` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Banner/Banner.stories.tsx
+++ b/libraries/core-react/src/components/Banner/Banner.stories.tsx
@@ -160,3 +160,11 @@ export const Compact: Story<BannerProps> = () => {
     </EdsProvider>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Banner` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Button/Button.stories.tsx
+++ b/libraries/core-react/src/components/Button/Button.stories.tsx
@@ -1,4 +1,5 @@
-import { Button, Icon, ButtonProps, EdsProvider } from '../..'
+import { useState, useEffect } from 'react'
+import { Button, Icon, ButtonProps, EdsProvider, Density } from '../..'
 import styled from 'styled-components'
 import { Meta, Story } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
@@ -314,18 +315,27 @@ export const FullWidth: Story<ButtonProps> = () => (
   </FullWidthWrapper>
 )
 
-export const Compact: Story<ButtonProps> = () => (
-  <EdsProvider density="compact">
-    <Wrapper>
-      <Button>Contained</Button>
-      <Button variant="outlined">Outlined</Button>
-      <Button variant="ghost">Ghost</Button>
-      <Button variant="ghost_icon">
-        <Icon data={menu} title="Ghost icon menu"></Icon>
-      </Button>
-    </Wrapper>
-  </EdsProvider>
-)
+export const Compact: Story<ButtonProps> = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
+  return (
+    <EdsProvider density={density}>
+      <Wrapper>
+        <Button>Contained</Button>
+        <Button variant="outlined">Outlined</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="ghost_icon">
+          <Icon data={menu} title="Ghost icon menu"></Icon>
+        </Button>
+      </Wrapper>
+    </EdsProvider>
+  )
+}
 
 Compact.parameters = {
   docs: {

--- a/libraries/core-react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/libraries/core-react/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, ChangeEvent } from 'react'
+import { useState, useEffect, useRef, ChangeEvent } from 'react'
 import {
   Checkbox,
   Typography,
@@ -6,6 +6,7 @@ import {
   CheckboxProps,
   EdsProvider,
   Table,
+  Density,
 } from '../..'
 import styled from 'styled-components'
 import { action } from '@storybook/addon-actions'
@@ -226,16 +227,25 @@ export const WithFormsControl: Story<CheckboxProps> = () => {
 GroupedCheckbox.storyName = 'Multiple checkboxes in a group'
 WithFormsControl.storyName = 'Example with React Hook Form'
 
-export const Compact: Story<CheckboxProps> = () => (
-  <EdsProvider density="compact">
-    <Checkbox label="I am compact" />
-  </EdsProvider>
-)
+export const Compact: Story<CheckboxProps> = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
+  return (
+    <EdsProvider density={density}>
+      <Checkbox label="I am compact" />
+    </EdsProvider>
+  )
+}
 
 Compact.parameters = {
   docs: {
     description: {
-      story: 'Compact `Checkbox` using `EdsProvder` ',
+      story: 'Compact `Checkbox` using `EdsProvider` ',
     },
   },
 }

--- a/libraries/core-react/src/components/Dialog/Dialog.stories.tsx
+++ b/libraries/core-react/src/components/Dialog/Dialog.stories.tsx
@@ -214,3 +214,11 @@ export const Compact: Story<DialogProps> = () => {
     </EdsProvider>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Dialog` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Input/Input.stories.tsx
+++ b/libraries/core-react/src/components/Input/Input.stories.tsx
@@ -1,5 +1,6 @@
+import { useState, useEffect } from 'react'
 import styled from 'styled-components'
-import { Input, InputProps, Label, EdsProvider } from '../..'
+import { Input, InputProps, Label, EdsProvider, Density } from '../..'
 import { Story, Meta } from '@storybook/react/types-6-0'
 
 export default {
@@ -85,8 +86,15 @@ Accessiblity.parameters = {
 
 export const Compact: Story<InputProps> = () => {
   // To wrap the input component inside the label element is not yet supported
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
   return (
-    <EdsProvider density="compact">
+    <EdsProvider density={density}>
       <Label htmlFor="compact" label="Compact" />
       <Input type="text" id="compact" />
     </EdsProvider>
@@ -96,7 +104,7 @@ export const Compact: Story<InputProps> = () => {
 Compact.parameters = {
   docs: {
     description: {
-      story: 'Compact `Input` using `EdsProvder` ',
+      story: 'Compact `Input` using `EdsProvider` ',
     },
   },
 }

--- a/libraries/core-react/src/components/Menu/Menu.stories.tsx
+++ b/libraries/core-react/src/components/Menu/Menu.stories.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useState, useRef } from 'react'
 import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
-import { Menu, MenuProps, Typography, Button, Icon, EdsProvider } from '../..'
+import {
+  Menu,
+  MenuProps,
+  Typography,
+  Button,
+  Icon,
+  EdsProvider,
+  Density,
+} from '../..'
 import { Story, Meta } from '@storybook/react'
 
 import { tokens } from '@equinor/eds-tokens'
@@ -275,6 +283,7 @@ export const Complex: Story<MenuProps> = () => {
 }
 
 export const Compact: Story<MenuProps> = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [focus, setFocus] = useState<'first' | 'last'>(null)
   const anchorRef = useRef<HTMLButtonElement>(null)
@@ -283,10 +292,16 @@ export const Compact: Story<MenuProps> = () => {
     setIsOpen(true)
     setFocus(focus)
   }
+
   const closeMenu = () => {
     setIsOpen(false)
     setFocus(null)
   }
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
 
   const onKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     const { key } = e
@@ -308,32 +323,42 @@ export const Compact: Story<MenuProps> = () => {
   }
 
   return (
-    <StoryCenter>
-      <Button
-        ref={anchorRef}
-        id="anchor-compact"
-        aria-haspopup="true"
-        aria-expanded={isOpen}
-        aria-controls="menu-compact"
-        onClick={() => (isOpen ? closeMenu() : openMenu(null))}
-        onKeyDown={onKeyPress}
-      >
-        Click to open Menu!
-      </Button>
-      <EdsProvider density="compact">
-        <Menu
-          open={isOpen}
-          id="menu-compact"
-          focus={focus}
-          aria-labelledby="anchor-compact"
-          onClose={closeMenu}
-          anchorEl={anchorRef.current}
+    <EdsProvider density={density}>
+      <StoryCenter>
+        <Button
+          ref={anchorRef}
+          id="anchor-compact"
+          aria-haspopup="true"
+          aria-expanded={isOpen}
+          aria-controls="menu-compact"
+          onClick={() => (isOpen ? closeMenu() : openMenu(null))}
+          onKeyDown={onKeyPress}
         >
-          <Menu.Item onClick={onClick}>Pressure</Menu.Item>
-          <Menu.Item onClick={onClick}>Bearing</Menu.Item>
-          <Menu.Item onClick={onClick}>Cable</Menu.Item>
-        </Menu>
-      </EdsProvider>
-    </StoryCenter>
+          Click to open Menu!
+        </Button>
+        <EdsProvider density="compact">
+          <Menu
+            open={isOpen}
+            id="menu-compact"
+            focus={focus}
+            aria-labelledby="anchor-compact"
+            onClose={closeMenu}
+            anchorEl={anchorRef.current}
+          >
+            <Menu.Item onClick={onClick}>Pressure</Menu.Item>
+            <Menu.Item onClick={onClick}>Bearing</Menu.Item>
+            <Menu.Item onClick={onClick}>Cable</Menu.Item>
+          </Menu>
+        </EdsProvider>
+      </StoryCenter>
+    </EdsProvider>
   )
+}
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Menu` using `EdsProvider` ',
+    },
+  },
 }

--- a/libraries/core-react/src/components/Popover/Popover.stories.tsx
+++ b/libraries/core-react/src/components/Popover/Popover.stories.tsx
@@ -247,3 +247,11 @@ export const Compact: Story<PopoverProps> = () => {
     </EdsProvider>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Popover` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Radio/Radio.stories.tsx
+++ b/libraries/core-react/src/components/Radio/Radio.stories.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Radio, RadioProps, Table, EdsProvider } from '../..'
+import { useState, useEffect } from 'react'
+import { Radio, RadioProps, Table, EdsProvider, Density } from '../..'
 import styled from 'styled-components'
 import { Meta, Story } from '@storybook/react'
 import { data } from '../../stories/data'
@@ -94,16 +94,25 @@ export const GroupedRadio: Story<RadioProps> = () => {
 GroupedRadio.storyName = 'Multiple radio buttons in a group'
 SingleRadio.storyName = 'Single radio buttons'
 
-export const Compact: Story<RadioProps> = () => (
-  <EdsProvider density="compact">
-    <Radio label="I am compact" />
-  </EdsProvider>
-)
+export const Compact: Story<RadioProps> = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
+  return (
+    <EdsProvider density={density}>
+      <Radio label="I am compact" />
+    </EdsProvider>
+  )
+}
 
 Compact.parameters = {
   docs: {
     description: {
-      story: 'Compact `Radio` using `EdsProvder` ',
+      story: 'Compact `Radio` using `EdsProvider` ',
     },
   },
 }

--- a/libraries/core-react/src/components/Search/Search.stories.tsx
+++ b/libraries/core-react/src/components/Search/Search.stories.tsx
@@ -198,3 +198,11 @@ export const Compact: Story<SearchProps> = () => {
     </EdsProvider>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Search` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Select/MultiSelect/MultiSelect.stories.tsx
+++ b/libraries/core-react/src/components/Select/MultiSelect/MultiSelect.stories.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   MultiSelect,
   MultiSelectProps,
   Button,
   Typography,
   EdsProvider,
+  Density,
 } from '../../..'
 import { Story, Meta } from '@storybook/react/types-6-0'
 import { UseMultipleSelectionStateChange } from 'downshift'
@@ -204,8 +205,25 @@ export const WithReactHookForm: Story<MultiSelectProps> = () => {
   )
 }
 
-export const Compact: Story = () => (
-  <EdsProvider density="compact">
-    <MultiSelect label="This is compact" items={items} />
-  </EdsProvider>
-)
+export const Compact: Story = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
+  return (
+    <EdsProvider density={density}>
+      <MultiSelect label="This is compact" items={items} />
+    </EdsProvider>
+  )
+}
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `MultiSelect` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Select/NativeSelect/NativeSelect.stories.tsx
+++ b/libraries/core-react/src/components/Select/NativeSelect/NativeSelect.stories.tsx
@@ -1,4 +1,5 @@
-import { NativeSelect, NativeSelectProps, EdsProvider } from '../../..'
+import { useState, useEffect } from 'react'
+import { NativeSelect, NativeSelectProps, EdsProvider, Density } from '../../..'
 import { Story, Meta } from '@storybook/react/types-6-0'
 
 export default {
@@ -36,14 +37,31 @@ export const Disabled: Story<NativeSelectProps> = () => (
   </NativeSelect>
 )
 
-export const Compact: Story = () => (
-  <EdsProvider density="compact">
-    <NativeSelect label="This is compact" id="compact-select">
-      <option>First option with a really really long text</option>
-      <option>Second</option>
-      <option>Third</option>
-      <option>Another</option>
-      <option>Even another</option>
-    </NativeSelect>
-  </EdsProvider>
-)
+export const Compact: Story = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
+  return (
+    <EdsProvider density={density}>
+      <NativeSelect label="This is compact" id="compact-select">
+        <option>First option with a really really long text</option>
+        <option>Second</option>
+        <option>Third</option>
+        <option>Another</option>
+        <option>Even another</option>
+      </NativeSelect>
+    </EdsProvider>
+  )
+}
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `NativeSelect` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Select/SingleSelect/SingleSelect.stories.tsx
+++ b/libraries/core-react/src/components/Select/SingleSelect/SingleSelect.stories.tsx
@@ -35,10 +35,10 @@ const Container = styled.div`
 `
 
 export const Default: Story<SingleSelectProps> = (args) => (
-      <Container>
-        <SingleSelect label="Choose an element" {...args} items={items} />
-      </Container>
-  )
+  <Container>
+    <SingleSelect label="Choose an element" {...args} items={items} />
+  </Container>
+)
 
 export const Disabled: Story = () => (
   <SingleSelect label="Choose an element" meta="km/t" items={items} disabled />

--- a/libraries/core-react/src/components/Select/SingleSelect/SingleSelect.stories.tsx
+++ b/libraries/core-react/src/components/Select/SingleSelect/SingleSelect.stories.tsx
@@ -228,7 +228,7 @@ export const Compact: Story = () => {
 Compact.parameters = {
   docs: {
     description: {
-      story: 'Compact `SingleSelect` using `EdsProvder` ',
+      story: 'Compact `SingleSelect` using `EdsProvider` ',
     },
   },
 }

--- a/libraries/core-react/src/components/Select/SingleSelect/SingleSelect.stories.tsx
+++ b/libraries/core-react/src/components/Select/SingleSelect/SingleSelect.stories.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import { useState } from 'react'
-import { SingleSelect, SingleSelectProps, Button, Typography } from '../../..'
+import { useState, useEffect } from 'react'
+import {
+  SingleSelect,
+  SingleSelectProps,
+  Button,
+  Typography,
+  Density,
+} from '../../..'
 import { UseComboboxStateChange } from 'downshift'
 import { action } from '@storybook/addon-actions'
 import { Story, Meta } from '@storybook/react'
@@ -29,10 +35,10 @@ const Container = styled.div`
 `
 
 export const Default: Story<SingleSelectProps> = (args) => (
-  <Container>
-    <SingleSelect label="Choose an element" {...args} items={items} />
-  </Container>
-)
+      <Container>
+        <SingleSelect label="Choose an element" {...args} items={items} />
+      </Container>
+  )
 
 export const Disabled: Story = () => (
   <SingleSelect label="Choose an element" meta="km/t" items={items} disabled />
@@ -204,8 +210,25 @@ export const WithReactHookForm: Story<SingleSelectProps> = () => {
   )
 }
 
-export const Compact: Story = () => (
-  <EdsProvider density="compact">
-    <SingleSelect label="This is compact" items={items} />
-  </EdsProvider>
-)
+export const Compact: Story = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
+  return (
+    <EdsProvider density={density}>
+      <SingleSelect label="This is compact" items={items} />
+    </EdsProvider>
+  )
+}
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `SingleSelect` using `EdsProvder` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Snackbar/Snackbar.stories.tsx
+++ b/libraries/core-react/src/components/Snackbar/Snackbar.stories.tsx
@@ -93,3 +93,11 @@ export const Compact: Story<SnackbarProps> = () => {
     </EdsProvider>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Snackbar` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Switch/Switch.stories.tsx
+++ b/libraries/core-react/src/components/Switch/Switch.stories.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Switch, SwitchProps, EdsProvider, Table } from '../..'
+import { useState, useEffect } from 'react'
+import { Switch, SwitchProps, EdsProvider, Table, Density } from '../..'
 import styled from 'styled-components'
 import { Meta, Story } from '@storybook/react'
 import { data } from '../../stories/data'
@@ -64,6 +64,13 @@ export const DefaultStates: Story<SwitchProps> = () => {
 }
 
 export const Compact: Story<SwitchProps> = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
   const UnstyledList = styled.ul`
     list-style-type: none;
     li {
@@ -71,7 +78,7 @@ export const Compact: Story<SwitchProps> = () => {
     }
   `
   return (
-    <EdsProvider density="compact">
+    <EdsProvider density={density}>
       <Wrapper>
         <UnstyledList>
           <li>
@@ -95,6 +102,14 @@ export const Compact: Story<SwitchProps> = () => {
       </Wrapper>
     </EdsProvider>
   )
+}
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Switch` using `EdsProvider` ',
+    },
+  },
 }
 
 export const ControlledSwitchControl: Story<SwitchProps> = () => {

--- a/libraries/core-react/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/libraries/core-react/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -354,3 +354,11 @@ export const Compact: Story<TableOfContentsProps> = () => {
     </EdsProvider>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `TableOfContents` using `EdsProvider` ',
+    },
+  },
+}

--- a/libraries/core-react/src/components/Tabs/Tabs.stories.tsx
+++ b/libraries/core-react/src/components/Tabs/Tabs.stories.tsx
@@ -296,6 +296,14 @@ export const Compact: Story<TabsProps> = () => {
   )
 }
 
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `Tabs` using `EdsProvider` ',
+    },
+  },
+}
+
 WithSearch.storyName = 'With search'
 WithInputInPanel.storyName = 'With input in panel'
 WithStyledComponent.storyName = 'With styled component'

--- a/libraries/core-react/src/components/TextField/TextField.stories.tsx
+++ b/libraries/core-react/src/components/TextField/TextField.stories.tsx
@@ -1,4 +1,12 @@
-import { TextField, TextFieldProps, Icon, EdsProvider, Button } from '../..'
+import { useState, useEffect } from 'react'
+import {
+  TextField,
+  TextFieldProps,
+  Icon,
+  EdsProvider,
+  Button,
+  Density,
+} from '../..'
 import { Story, Meta } from '@storybook/react'
 import {
   thumbs_up,
@@ -450,32 +458,51 @@ Variants.parameters = {
   },
 }
 
-export const Compact: Story<TextFieldProps> = () => (
-  <Wrapper>
-    <EdsProvider density="compact">
-      <TextField
-        id="compact-textfield"
-        placeholder="Placeholder text"
-        label="Default"
-        inputIcon={<Icon name="thumbs_up" title="Success" />}
-        helperIcon={<Icon data={info_circle} title="info" />}
-        helperText="Helper information text over several lines so that it breaks"
-        style={{ width: '200px' }}
-      />
-      <TextField
-        id="compact-textfield-multiline"
-        placeholder="Placeholder text"
-        label="Multiline"
-        multiline
-        rowsMax={10}
-        inputIcon={<Icon name="thumbs_up" title="Success" />}
-        style={{ resize: 'none' }}
-        helperIcon={<Icon data={info_circle} title="info" />}
-        helperText="Helper information text thats very very very loooonooooooong"
-      />
+export const Compact: Story<TextFieldProps> = () => {
+  const [density, setDensity] = useState<Density>('comfortable')
+
+  useEffect(() => {
+    // Simulate user change
+    setDensity('compact')
+  }, [density])
+
+  return (
+    <EdsProvider density={density}>
+      <Wrapper>
+        <EdsProvider density="compact">
+          <TextField
+            id="compact-textfield"
+            placeholder="Placeholder text"
+            label="Default"
+            inputIcon={<Icon name="thumbs_up" title="Success" />}
+            helperIcon={<Icon data={info_circle} title="info" />}
+            helperText="Helper information text over several lines so that it breaks"
+            style={{ width: '200px' }}
+          />
+          <TextField
+            id="compact-textfield-multiline"
+            placeholder="Placeholder text"
+            label="Multiline"
+            multiline
+            rowsMax={10}
+            inputIcon={<Icon name="thumbs_up" title="Success" />}
+            style={{ resize: 'none' }}
+            helperIcon={<Icon data={info_circle} title="info" />}
+            helperText="Helper information text thats very very very loooonooooooong"
+          />
+        </EdsProvider>
+      </Wrapper>
     </EdsProvider>
-  </Wrapper>
-)
+  )
+}
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `TextField` using `EdsProvider` ',
+    },
+  },
+}
 
 export const ExampleWithReactHookForm: Story<TextFieldProps> = () => {
   const { handleSubmit, control } = useForm({

--- a/libraries/core-react/src/components/TopBar/TopBar.stories.tsx
+++ b/libraries/core-react/src/components/TopBar/TopBar.stories.tsx
@@ -148,3 +148,11 @@ export const Compact: Story<TopbarProps> = (): JSX.Element => {
     </EdsProvider>
   )
 }
+
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'Compact `TopBar` using `EdsProvider` ',
+    },
+  },
+}


### PR DESCRIPTION
Split things up a bit. This pr is just about fixing stories with direct usage of compact as density value. Also added missing descriptions to some of the stories and fixed some typos along the way.

Resolves #1707 