### PR TITLE
♿️ textfield a11y improvements

### DIFF
--- a/libraries/core-react/src/components/TextField/Field.tsx
+++ b/libraries/core-react/src/components/TextField/Field.tsx
@@ -180,6 +180,7 @@ export const Field = forwardRef<
   const iconSize = density === 'compact' ? 16 : 24
   const actualVariant = variant === 'default' ? 'textfield' : variant
   const inputVariant = tokens[actualVariant]
+  const isError = actualVariant === 'error' ? true : false
 
   const focusHandler = (
     e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -208,6 +209,7 @@ export const Field = forwardRef<
 
   const inputProps = {
     ref: ref as Ref<HTMLInputElement>,
+    'aria-invalid': isError,
     type,
     disabled,
     readOnly,

--- a/libraries/core-react/src/components/TextField/Field.tsx
+++ b/libraries/core-react/src/components/TextField/Field.tsx
@@ -180,7 +180,7 @@ export const Field = forwardRef<
   const iconSize = density === 'compact' ? 16 : 24
   const actualVariant = variant === 'default' ? 'textfield' : variant
   const inputVariant = tokens[actualVariant]
-  const isError = actualVariant === 'error' ? true : false
+  const isError = actualVariant === 'error'
 
   const focusHandler = (
     e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,

--- a/libraries/core-react/src/components/TextField/TextField.tsx
+++ b/libraries/core-react/src/components/TextField/TextField.tsx
@@ -12,7 +12,7 @@ import { HelperText } from './HelperText'
 import { TextFieldProvider } from './TextField.context'
 import type { Variants } from './types'
 import { textfield as tokens } from './TextField.tokens'
-import { useToken } from '../../hooks'
+import { useToken, useId } from '../../hooks'
 import { useEds } from '../EdsProvider'
 
 const Container = styled.div`
@@ -79,7 +79,9 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     },
     ref,
   ) {
+    const helperTextId = useId(null, 'helpertext')
     const inputProps = {
+      'aria-describedby': helperTextId,
       multiline,
       disabled,
       placeholder,
@@ -93,6 +95,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     }
 
     const helperProps = {
+      id: helperTextId,
       variant,
       helperText,
       icon: helperIcon,


### PR DESCRIPTION
resolves #1145 

Screenreader should now read the helpertext

I implemented aria-invalid when variant="error"