### PR TITLE
🐛 Make sure table header is on top of content when sticky

### DIFF
--- a/libraries/core-react/src/components/Table/HeaderCell/HeaderCell.tsx
+++ b/libraries/core-react/src/components/Table/HeaderCell/HeaderCell.tsx
@@ -59,6 +59,7 @@ const StyledTableCell = styled.th((props: BaseProps) => {
       ? css`
           position: sticky;
           top: 0;
+          z-index: 1;
         `
       : ''}
   `

--- a/libraries/core-react/src/components/Table/Table.stories.tsx
+++ b/libraries/core-react/src/components/Table/Table.stories.tsx
@@ -81,6 +81,7 @@ const FixedContainer = styled.div`
 
 export const FixedTableHeader: Story<TableProps> = () => {
   const cellValues = toCellValues(data, columns)
+  const buttonIndex = cellValues[0].length - 1
 
   return (
     <FixedContainer>
@@ -98,8 +99,14 @@ export const FixedTableHeader: Story<TableProps> = () => {
         <Table.Body>
           {cellValues?.map((row) => (
             <Table.Row key={row.toString()}>
-              {row.map((cellValue) => (
-                <Table.Cell key={cellValue}>{cellValue}</Table.Cell>
+              {row.map((cellValue, index) => (
+                <Table.Cell key={cellValue}>
+                  {index === buttonIndex ? (
+                    <Button variant="outlined">{cellValue}</Button>
+                  ) : (
+                    cellValue
+                  )}
+                </Table.Cell>
               ))}
             </Table.Row>
           ))}


### PR DESCRIPTION
resolves #1816

To test, replace content of Table.Cell  with  buttons in the FixedTableHeader story