### PR TITLE
💥Conform Scrim open logic

### DIFF
--- a/libraries/core-react/src/components/Scrim/Scrim.stories.tsx
+++ b/libraries/core-react/src/components/Scrim/Scrim.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Scrim, Button, Typography, ScrimProps } from '../..'
 import { Story, Meta } from '@storybook/react'
 
@@ -20,6 +20,7 @@ export default {
   component: Scrim,
   args: {
     isDismissable: true,
+    open: false,
   },
   parameters: {
     docs: {
@@ -33,28 +34,33 @@ export default {
 } as Meta
 
 export const Default: Story<ScrimProps> = (args) => {
-  const [visibleScrim, setVisibleScrim] = useState(false)
-  const handleClose = (event, closed) => {
-    if (closed) {
-      setVisibleScrim(closed)
-    } else {
-      setVisibleScrim(!visibleScrim)
-    }
+  const { open } = args
+  const [isOpen, setIsOpen] = useState(open)
+
+  const handleOpen = () => {
+    setIsOpen(true)
   }
+
+  const handleClose = () => {
+    setIsOpen(false)
+  }
+
+  // This is just for storybook and changes done via controls addon
+  useEffect(() => {
+    setIsOpen(open)
+  }, [open])
 
   return (
     <>
-      <Button onClick={() => setVisibleScrim(true)}>Trigger Scrim</Button>
-      {visibleScrim && (
-        <Scrim {...args} onClose={handleClose}>
-          <TestContent>
-            <Typography variant="body_short">
-              Press close or hit “ESC” to close scrim.
-            </Typography>
-            <Button onClick={() => setVisibleScrim(false)}>Close</Button>
-          </TestContent>
-        </Scrim>
-      )}
+      <Button onClick={handleOpen}>Trigger Scrim</Button>
+      <Scrim {...args} open={isOpen} onClose={handleClose}>
+        <TestContent>
+          <Typography variant="body_short">
+            Press close or hit “ESC” to close scrim.
+          </Typography>
+          <Button onClick={handleClose}>Close</Button>
+        </TestContent>
+      </Scrim>
     </>
   )
 }

--- a/libraries/core-react/src/components/Scrim/Scrim.test.tsx
+++ b/libraries/core-react/src/components/Scrim/Scrim.test.tsx
@@ -40,23 +40,23 @@ describe('Scrim', () => {
     render(<DismissableScrim data-testid="scrim" />)
     const scrim = screen.getByTestId('scrim')
 
-    expect(scrim).not.toBeEmptyDOMElement()
+    expect(scrim).toBeInTheDocument()
     expect(screen.queryByText('OK')).toBeVisible()
     const targetButton = screen.queryByText('OK')
     fireEvent.click(targetButton)
-    expect(scrim).toBeEmptyDOMElement()
+    expect(scrim).not.toBeInTheDocument()
   })
   it('Is dismissable with Esc', () => {
     render(<DismissableScrim data-testid="scrim" />)
     const scrim = screen.getByTestId('scrim')
 
-    expect(scrim).not.toBeEmptyDOMElement()
+    expect(scrim).toBeInTheDocument()
     expect(screen.queryByText('OK')).toBeVisible()
     fireEvent.keyDown(scrim, {
       key: 'Escape',
       keyCode: 27,
     })
-    expect(scrim).toBeEmptyDOMElement()
+    expect(scrim).not.toBeInTheDocument()
   })
 
   it('Has correct style rules when visible', () => {

--- a/libraries/core-react/src/components/Scrim/Scrim.test.tsx
+++ b/libraries/core-react/src/components/Scrim/Scrim.test.tsx
@@ -18,21 +18,17 @@ afterEach(cleanup)
 const DismissableScrim = (props) => {
   const [visibleScrim, setVisibleScrim] = useState(true)
 
-  const handleClose = (event, closed) => {
-    if (closed !== undefined) {
-      setVisibleScrim(closed)
-    } else {
-      setVisibleScrim(!visibleScrim)
-    }
+  const handleClose = () => {
+    setVisibleScrim(false)
   }
 
-  return visibleScrim ? (
-    <Scrim onClose={handleClose} isDismissable {...props}>
-      <button type="button" onClick={() => setVisibleScrim(false)}>
+  return (
+    <Scrim onClose={handleClose} open={visibleScrim} isDismissable {...props}>
+      <button type="button" onClick={handleClose}>
         OK
       </button>
     </Scrim>
-  ) : null
+  )
 }
 
 describe('Scrim', () => {
@@ -44,33 +40,33 @@ describe('Scrim', () => {
     render(<DismissableScrim data-testid="scrim" />)
     const scrim = screen.getByTestId('scrim')
 
-    expect(scrim).toBeInTheDocument()
+    expect(scrim).not.toBeEmptyDOMElement()
     expect(screen.queryByText('OK')).toBeVisible()
     const targetButton = screen.queryByText('OK')
     fireEvent.click(targetButton)
-    expect(scrim).not.toBeInTheDocument()
+    expect(scrim).toBeEmptyDOMElement()
   })
   it('Is dismissable with Esc', () => {
     render(<DismissableScrim data-testid="scrim" />)
     const scrim = screen.getByTestId('scrim')
 
-    expect(scrim).toBeInTheDocument()
+    expect(scrim).not.toBeEmptyDOMElement()
     expect(screen.queryByText('OK')).toBeVisible()
     fireEvent.keyDown(scrim, {
       key: 'Escape',
       keyCode: 27,
     })
-    expect(scrim).not.toBeInTheDocument()
+    expect(scrim).toBeEmptyDOMElement()
   })
 
   it('Has correct style rules when visible', () => {
-    render(<StyledScrim data-testid="scrim" />)
+    render(<StyledScrim open={true} data-testid="scrim" />)
     const scrim = screen.getByTestId('scrim')
 
     expect(scrim).toHaveStyleRule('display', 'flex')
   })
   it('Can extend the css for the component', () => {
-    render(<StyledScrim data-testid="scrim" />)
+    render(<StyledScrim open={true} data-testid="scrim" />)
     const scrim = screen.getByTestId('scrim')
 
     expect(scrim).toHaveStyleRule('background', 'red')

--- a/libraries/core-react/src/components/Scrim/Scrim.tsx
+++ b/libraries/core-react/src/components/Scrim/Scrim.tsx
@@ -32,7 +32,7 @@ export type ScrimProps = {
   /** programmatically toggle scrim */
   open: boolean
   /** function to handle closing scrim */
-  onClose?: (event: MouseEvent | KeyboardEvent) => void
+  onClose?: () => void
 } & HTMLAttributes<HTMLDivElement>
 
 export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
@@ -48,16 +48,16 @@ export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
 
   useHideBodyScroll(open)
 
-  useGlobalKeyPress('Escape', (e: KeyboardEvent) => {
+  useGlobalKeyPress('Escape', () => {
     if (isDismissable && onClose && open) {
-      onClose(e)
+      onClose()
     }
   })
 
   const handleMouseClose = (event: MouseEvent) => {
     if (event) {
       if (event.type === 'click' && isDismissable && open) {
-        onClose && onClose(event)
+        onClose && onClose()
       }
     }
   }

--- a/libraries/core-react/src/components/Scrim/Scrim.tsx
+++ b/libraries/core-react/src/components/Scrim/Scrim.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, MouseEvent, HTMLAttributes } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { scrim as tokens } from './Scrim.tokens'
 import { useGlobalKeyPress, useHideBodyScroll } from '../../hooks'
 

--- a/libraries/core-react/src/components/Scrim/Scrim.tsx
+++ b/libraries/core-react/src/components/Scrim/Scrim.tsx
@@ -5,7 +5,7 @@ import { useGlobalKeyPress, useHideBodyScroll } from '../../hooks'
 
 const { height, width, background } = tokens
 
-const StyledScrim = styled.div<StyledScrimProps>`
+const StyledScrim = styled.div`
   width: ${width};
   height: ${height};
   background: ${background};
@@ -15,15 +15,13 @@ const StyledScrim = styled.div<StyledScrimProps>`
   left: 0;
   align-items: center;
   justify-content: center;
-  ${({ open }) => css({ display: open ? 'flex' : 'none' })}
+  display: flex;
 `
 
 const ScrimContent = styled.div`
   width: auto;
   height: auto;
 `
-
-type StyledScrimProps = Pick<ScrimProps, 'open'>
 
 export type ScrimProps = {
   /** Whether scrim can be dismissed with esc key and outside click
@@ -67,11 +65,13 @@ export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
     event.stopPropagation()
   }
 
+  if (!open) {
+    return null
+  }
+
   return (
     <StyledScrim onClick={handleMouseClose} {...props}>
-      {open && (
-        <ScrimContent onClick={handleContentClick}>{children}</ScrimContent>
-      )}
+      <ScrimContent onClick={handleContentClick}>{children}</ScrimContent>
     </StyledScrim>
   )
 })

--- a/libraries/core-react/src/components/Scrim/__snapshots__/Scrim.test.tsx.snap
+++ b/libraries/core-react/src/components/Scrim/__snapshots__/Scrim.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`Scrim Matches snapshot 1`] = `
 
 <div
     class="c0"
+    open=""
   >
     <div
       class="c1"

--- a/libraries/core-react/src/hooks/useHideBodyScroll.ts
+++ b/libraries/core-react/src/hooks/useHideBodyScroll.ts
@@ -1,11 +1,17 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
-export const useHideBodyScroll = (overflowState: string): void => {
+export const useHideBodyScroll = (active: boolean): void => {
+  const overflowState = useRef<string | undefined>(document.body.style.overflow)
   useEffect(() => {
-    document.body.style.overflow = 'hidden'
+    const originalState = overflowState.current
+    if (active) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = originalState
+    }
 
     return () => {
-      document.body.style.overflow = overflowState
+      document.body.style.overflow = originalState
     }
-  }, [])
+  }, [active])
 }


### PR DESCRIPTION
resolves #1176 

This introduces breaking changes to scrim:
Use `open` prop to align Scrim open/close logic with other components. It now hides itself (with `display: none` and not rendering children)  (breaking)
Removed the second argument (`open`) in onClose (breaking)

The useHideBodyScroll hook is changed to take a boolean that is watched to determine when to hide scroll (since the Scrim is not neccessarily fully unmounted when closed now)