### PR TITLE
🔖 Release eds-core-react@0.17.0

### DIFF
--- a/libraries/core-react/CHANGELOG.md
+++ b/libraries/core-react/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2021-12-22
+
+### Added
+
+- `Scrim` is now controlled via an `open` property. ([#1176](https://github.com/equinor/design-system/issues/1176))
+
+### Changed
+
+- Improvements to `Menu` & `Popover` DOM imprint when closed and subsuquent opennings. ([#1675](https://github.com/equinor/design-system/issues/1675))
+
+### Removed
+
+- `event` & `open` was removed as parameters to the `onClose` callback for `Scrim`. ([#1176](https://github.com/equinor/design-system/issues/1176))
+
+### Fixed
+
+- `MultiSelect` should now clear properly on blur and clicking clear button. ([#1664](https://github.com/equinor/design-system/issues/1664))
+- Improved `TextField` a11y for when error messages are displayed as `helperText`. ([#1145](https://github.com/equinor/design-system/issues/1145))
+- `Button` in tables should now have proper stacking context for sticky table header. ([#1816](https://github.com/equinor/design-system/issues/1816))
+
 ## [0.16.1] - 2021-12-07
 
 ### Changed

--- a/libraries/core-react/package.json
+++ b/libraries/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"


### PR DESCRIPTION
resolves #1829 

## [0.17.0] - 2021-12-22

### Added

- `Scrim` is now controlled via an `open` property. ([#1176](https://github.com/equinor/design-system/issues/1176))

### Changed

- Improvements to `Menu` & `Popover` DOM imprint when closed and subsuquent opennings. ([#1675](https://github.com/equinor/design-system/issues/1675))

### Removed

- `event` & `open` was removed as parameters to the `onClose` callback for `Scrim`. ([#1176](https://github.com/equinor/design-system/issues/1176))

### Fixed

- `MultiSelect` should now clear properly on blur and clicking clear button. ([#1664](https://github.com/equinor/design-system/issues/1664))
- Improved `TextField` a11y for when error messages are displayed as `helperText`. ([#1145](https://github.com/equinor/design-system/issues/1145))
- `Button` in tables should now have proper stacking context for sticky table header. ([#1816](https://github.com/equinor/design-system/issues/1816))
