### PR TITLE
🐛 Fix Combobox dropdown layering

### DIFF
--- a/packages/eds-lab-react/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/eds-lab-react/src/components/Combobox/Combobox.stories.tsx
@@ -89,6 +89,7 @@ Introduction.args = {
   multiple: false,
   readOnly: false,
   disabled: false,
+  disablePortal: false,
 }
 
 export const Multiple: Story<ComboboxProps<MyOptionType>> = (args) => {

--- a/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
+++ b/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
@@ -399,14 +399,14 @@ function ComboboxInner<T>(
   } = useCombobox(comboBoxProps)
 
   useEffect(() => {
-    if (isMounted && anchorRef.current) {
+    if (anchorRef.current) {
       setAnchorEl(anchorRef.current)
     }
     return () => {
       setAnchorEl(null)
       setContainerEl(null)
     }
-  }, [anchorRef, isMounted, isOpen])
+  }, [anchorRef, isOpen])
 
   const { styles, attributes } = usePopper(
     anchorEl,

--- a/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
+++ b/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
@@ -20,7 +20,7 @@ import {
   multiSelect as multiSelectTokens,
   selectTokens as selectTokens,
 } from './Combobox.tokens'
-import { useToken, usePopper } from '../../hooks'
+import { useToken, usePopper, useIsMounted } from '../../hooks'
 import { bordersTemplate } from '../../utils'
 import { ComboboxOption } from './Option'
 
@@ -195,6 +195,7 @@ function ComboboxInner<T>(
   } = props
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>()
   const [containerEl, setContainerEl] = useState<HTMLElement>()
+  const isMounted = useIsMounted()
 
   const { styles, attributes } = usePopper(
     anchorEl,
@@ -465,28 +466,30 @@ function ComboboxInner<T>(
           </StyledButton>
         </Container>
 
-        {!isOpen
+        {!isMounted
           ? null
           : createPortal(
               <StyledList {...menuProps}>
-                {availableItems.map((item, index) => {
-                  const isDisabled = disabledItems.includes(item)
-                  return (
-                    <ComboboxOption
-                      key={item}
-                      value={item}
-                      multiple={multiple}
-                      highlighted={
-                        highlightedIndex === index && !isDisabled
-                          ? 'true'
-                          : 'false'
-                      }
-                      isSelected={selectedItems.includes(item)}
-                      isDisabled={isDisabled}
-                      {...getItemProps({ item, index, disabled })}
-                    />
-                  )
-                })}
+                {!isOpen
+                  ? null
+                  : availableItems.map((item, index) => {
+                      const isDisabled = disabledItems.includes(item)
+                      return (
+                        <ComboboxOption
+                          key={item}
+                          value={item}
+                          multiple={multiple}
+                          highlighted={
+                            highlightedIndex === index && !isDisabled
+                              ? 'true'
+                              : 'false'
+                          }
+                          isSelected={selectedItems.includes(item)}
+                          isDisabled={isDisabled}
+                          {...getItemProps({ item, index, disabled })}
+                        />
+                      )
+                    })}
               </StyledList>,
               document.body,
             )}

--- a/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
+++ b/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState, HTMLAttributes } from 'react'
+import { forwardRef, useState, HTMLAttributes, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import {
   useCombobox,
@@ -200,17 +200,11 @@ function ComboboxInner<T>(
     disablePortal,
     ...other
   } = props
+
+  const anchorRef = useRef()
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>()
   const [containerEl, setContainerEl] = useState<HTMLElement>()
   const isMounted = useIsMounted()
-
-  const { styles, attributes } = usePopper(
-    anchorEl,
-    containerEl,
-    null,
-    'bottom-start',
-    4,
-  )
 
   const isControlled = Boolean(selectedOptions)
   const labelItems = options.map(optionLabel)
@@ -404,6 +398,24 @@ function ComboboxInner<T>(
     reset: resetCombobox,
   } = useCombobox(comboBoxProps)
 
+  useEffect(() => {
+    if (isMounted && anchorRef.current) {
+      setAnchorEl(anchorRef.current)
+    }
+    return () => {
+      setAnchorEl(null)
+      setContainerEl(null)
+    }
+  }, [anchorRef, isMounted, isOpen])
+
+  const { styles, attributes } = usePopper(
+    anchorEl,
+    containerEl,
+    null,
+    'bottom-start',
+    4,
+  )
+
   const openSelect = () => {
     if (!isOpen && !(disabled || readOnly)) {
       openMenu()
@@ -464,7 +476,7 @@ function ComboboxInner<T>(
               getDropdownProps({
                 preventKeyAction: multiple ? isOpen : undefined,
                 disabled,
-                ref: setAnchorEl,
+                ref: anchorRef,
               }),
             )}
             placeholder={placeholderText}

--- a/packages/eds-lab-react/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/eds-lab-react/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`Combobox Matches snapshot 1`] = `
   overflow-y: scroll;
   max-height: 300px;
   padding: 0;
-  margin-top: 4px;
   position: absolute;
   right: 0;
   left: 0;
@@ -38,6 +37,7 @@ exports[`Combobox Matches snapshot 1`] = `
   class="c0 c1"
   id="downshift-0-menu"
   role="listbox"
+  style="position: absolute; left: 0px; top: 0px;"
 />
 `;
 


### PR DESCRIPTION
fixes #1913 

* Introduced use of react portal & popper for placement. 
* Due to using popper, options width now scales based on content.
  * ~~This can be fixed in #1004 after #1848, as changes in `usePopper` hook are needed~~
    * Edit: We decided that this will be the default behaviour now and if requested add feature for toggling this later. Decided on PR-review meet 01.02.2022
  