### PR TITLE
🐛 menu: fix unwanted viewport scroll when kb-navigation

### DIFF
--- a/packages/eds-core-react/src/components/Menu/MenuItem.tsx
+++ b/packages/eds-core-react/src/components/Menu/MenuItem.tsx
@@ -128,8 +128,10 @@ export const MenuItem = memo(
       <Item
         {...props}
         ref={useCombinedRefs<HTMLButtonElement>(ref, (el) => {
-          if (el !== null && isFocused) {
-            el.focus()
+          if (isFocused) {
+            requestAnimationFrame(() => {
+              if (el !== null) el.focus()
+            })
           }
         })}
         onFocus={() => toggleFocus(index)}


### PR DESCRIPTION
resolves #1932 

Use raf to delay focus by one frame so transform values from popper take hold 