### PR TITLE
✨ Enable Tabs horizontal overflow

### DIFF
--- a/packages/eds-core-react/src/components/Tabs/Tab.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tab.tsx
@@ -38,6 +38,9 @@ const StyledTab = styled.button.attrs<TabProps>(
     text-overflow: ellipsis;
     overflow-x: hidden;
 
+    scroll-snap-align: end;
+    scroll-snap-stop: always;
+
     &:focus {
       outline: none;
     }

--- a/packages/eds-core-react/src/components/Tabs/TabList.tsx
+++ b/packages/eds-core-react/src/components/Tabs/TabList.tsx
@@ -37,7 +37,7 @@ const StyledTabList = styled.div.attrs(
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: ${({ variant }) => variants[variant] as VariantsRecord};
-  overflow-x: hidden;
+  overflow-x: ${({ scrollable }) => (scrollable ? 'auto' : 'hidden')};
   scroll-snap-type: x mandatory;
   overscroll-behavior-x: contain;
 
@@ -58,6 +58,8 @@ const StyledTabList = styled.div.attrs(
 export type TabListProps = {
   /** Sets the width of the tabs */
   variant?: Variants
+  /** adds scrollbar if tabs overflow on non-touch devices */
+  scrollable?: boolean
 } & HTMLAttributes<HTMLDivElement>
 
 type TabChild = {
@@ -76,6 +78,7 @@ const TabList = forwardRef<HTMLDivElement, TabListProps>(function TabsList(
     handleChange,
     tabsId,
     variant = 'minWidth',
+    scrollable = false,
     tabsFocused,
   } = useContext(TabsContext)
 
@@ -153,6 +156,7 @@ const TabList = forwardRef<HTMLDivElement, TabListProps>(function TabsList(
       ref={ref}
       {...props}
       variant={variant}
+      scrollable={scrollable}
     >
       {Tabs}
     </StyledTabList>

--- a/packages/eds-core-react/src/components/Tabs/TabList.tsx
+++ b/packages/eds-core-react/src/components/Tabs/TabList.tsx
@@ -2,6 +2,7 @@ import {
   forwardRef,
   useContext,
   useRef,
+  useState,
   useCallback,
   useEffect,
   ReactElement,
@@ -80,13 +81,18 @@ const TabList = forwardRef<HTMLDivElement, TabListProps>(function TabsList(
 
   const currentTab = useRef(activeTab)
 
+  const [arrowNavigating, setArrowNavigating] = useState(false)
   const selectedTabRef = useCallback(
     (node: HTMLElement) => {
-      if (node !== null && tabsFocused) {
+      if (
+        (node !== null && tabsFocused) ||
+        (node !== null && arrowNavigating)
+      ) {
+        setArrowNavigating(false)
         node.focus()
       }
     },
-    [tabsFocused],
+    [arrowNavigating, tabsFocused],
   )
 
   useEffect(() => {
@@ -125,15 +131,18 @@ const TabList = forwardRef<HTMLDivElement, TabListProps>(function TabsList(
     const i = direction === 'left' ? 1 : -1
     const nextTab =
       focusableChildren[focusableChildren.indexOf(currentTab.current) - i]
+    setArrowNavigating(true)
     handleChange(nextTab === undefined ? fallbackTab : nextTab)
   }
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const { key } = event
     if (key === 'ArrowLeft') {
+      event.preventDefault()
       handleTabsChange('left', lastFocusableChild)
     }
     if (key === 'ArrowRight') {
+      event.preventDefault()
       handleTabsChange('right', firstFocusableChild)
     }
   }

--- a/packages/eds-core-react/src/components/Tabs/TabList.tsx
+++ b/packages/eds-core-react/src/components/Tabs/TabList.tsx
@@ -36,6 +36,22 @@ const StyledTabList = styled.div.attrs(
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: ${({ variant }) => variants[variant] as VariantsRecord};
+  overflow-x: hidden;
+  scroll-snap-type: x mandatory;
+  overscroll-behavior-x: contain;
+
+  @media (prefers-reduced-motion: no-preference) {
+    scroll-behavior: smooth;
+  }
+  @media (hover: none) {
+    overflow-x: scroll;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: 0;
+    & ::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
+  }
 `
 
 export type TabListProps = {

--- a/packages/eds-core-react/src/components/Tabs/Tabs.context.ts
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.context.ts
@@ -3,6 +3,7 @@ import { Variants } from './Tabs.types'
 
 type State = {
   variant: Variants
+  scrollable: boolean
   handleChange: (index: number) => void
   activeTab: number
   tabsId: string
@@ -11,6 +12,7 @@ type State = {
 
 const TabsContext = createContext<State>({
   variant: 'minWidth',
+  scrollable: false,
   handleChange: () => null,
   activeTab: 0,
   tabsId: '',

--- a/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
@@ -22,6 +22,27 @@ const TabsRow = styled.div`
 const NavButton = styled(Button)`
   flex-shrink: 0;
 `
+const StyledTabList = styled(Tabs.List)`
+  --track-color: #ffffff;
+  --thumb-color: #dcdcdc;
+  scrollbar-color: var(--track-color) var(--thumb-color);
+  scrollbar-width: thin;
+  padding-bottom: 8px;
+
+  // For Google Chrome/webkit
+  & ::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  & ::-webkit-scrollbar-thumb {
+    background: var(--thumb-color);
+    border-radius: 8px;
+  }
+
+  & ::-webkit-scrollbar-track {
+    background: var(--track-color);
+  }
+`
 
 export default {
   title: 'Navigation/Tabs',
@@ -206,27 +227,6 @@ OverflowScroll.parameters = {
 }
 
 export const OverflowScrollStyled: Story<TabsProps> = () => {
-  const StyledTabList = styled(Tabs.List)`
-    --track-color: #ffffff;
-    --thumb-color: #cacaca;
-    scrollbar-color: var(--track-color) var(--thumb-color);
-    scrollbar-width: thin;
-    padding-bottom: 8px;
-
-    // For Google Chrome/webkit
-    & ::-webkit-scrollbar {
-      height: 8px;
-    }
-
-    & ::-webkit-scrollbar-thumb {
-      background: var(--thumb-color);
-      border-radius: 8px;
-    }
-
-    & ::-webkit-scrollbar-track {
-      background: var(--track-color);
-    }
-  `
   const [activeTab, setActiveTab] = useState(0)
 
   const handleChange = (index: number) => {

--- a/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
@@ -103,9 +103,8 @@ export const Overflow: Story<TabsProps> = () => {
   const list = useRef<HTMLDivElement>(null)
   const [containerWidth, setContainerWidth] = useState(0)
   const [totalWidth, setTotalWidth] = useState(0)
-  const [scrollPos, setScrollPos] = useState(0)
+  const [prevDisabled, setPrevDisabled] = useState(true)
   const [nextDisabled, setNextDisabled] = useState(false)
-  const { setTimeout, clearTimeout } = window
 
   const handleChange = (index: number) => {
     setActiveTab(index)
@@ -113,18 +112,20 @@ export const Overflow: Story<TabsProps> = () => {
 
   useLayoutEffect(() => {
     const cachedList = list.current
-    let delayToScrollEnd = 0
+    let delayToScrollEnd: ReturnType<typeof setTimeout>
+
     const handleScroll = () => {
       if (delayToScrollEnd) clearTimeout(delayToScrollEnd)
       delayToScrollEnd = setTimeout(() => {
-        setScrollPos(cachedList.scrollLeft)
-        if (containerWidth + Math.ceil(cachedList.scrollLeft) === totalWidth) {
-          setNextDisabled(true)
-        } else {
-          setNextDisabled(false)
-        }
+        cachedList.scrollLeft === 0
+          ? setPrevDisabled(true)
+          : setPrevDisabled(false)
+        containerWidth + Math.ceil(cachedList.scrollLeft) === totalWidth
+          ? setNextDisabled(true)
+          : setNextDisabled(false)
       }, 20)
     }
+
     if (cachedList) {
       setContainerWidth(cachedList.clientWidth)
       setTotalWidth(cachedList.scrollWidth)
@@ -132,7 +133,7 @@ export const Overflow: Story<TabsProps> = () => {
     }
 
     return () => {
-      clearTimeout(delayToScrollEnd)
+      if (delayToScrollEnd) clearTimeout(delayToScrollEnd)
       cachedList.removeEventListener('scroll', handleScroll)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,7 +158,7 @@ export const Overflow: Story<TabsProps> = () => {
           onClick={() => scroll('left')}
           aria-hidden="true"
           tabIndex={-1}
-          disabled={scrollPos === 0}
+          disabled={prevDisabled}
         >
           <Icon name="chevron_left" />
         </NavButton>

--- a/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
@@ -98,166 +98,6 @@ export const States: Story<TabsProps> = () => {
   )
 }
 
-export const Overflow: Story<TabsProps> = () => {
-  const [activeTab, setActiveTab] = useState(0)
-  const list = useRef<HTMLDivElement>(null)
-  const [containerWidth, setContainerWidth] = useState(0)
-  const [totalWidth, setTotalWidth] = useState(0)
-  const [prevDisabled, setPrevDisabled] = useState(true)
-  const [nextDisabled, setNextDisabled] = useState(false)
-
-  const handleChange = (index: number) => {
-    setActiveTab(index)
-  }
-
-  useLayoutEffect(() => {
-    const cachedList = list.current
-    let delayToScrollEnd: ReturnType<typeof setTimeout>
-
-    const handleScroll = () => {
-      if (delayToScrollEnd) clearTimeout(delayToScrollEnd)
-      delayToScrollEnd = setTimeout(() => {
-        cachedList.scrollLeft === 0
-          ? setPrevDisabled(true)
-          : setPrevDisabled(false)
-        containerWidth + Math.ceil(cachedList.scrollLeft) === totalWidth
-          ? setNextDisabled(true)
-          : setNextDisabled(false)
-      }, 20)
-    }
-
-    if (cachedList) {
-      setContainerWidth(cachedList.clientWidth)
-      setTotalWidth(cachedList.scrollWidth)
-      cachedList.addEventListener('scroll', handleScroll, { passive: true })
-    }
-
-    return () => {
-      if (delayToScrollEnd) clearTimeout(delayToScrollEnd)
-      cachedList.removeEventListener('scroll', handleScroll)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [containerWidth, list, totalWidth])
-
-  const scroll = (direction: string) => {
-    //Tabs have "scroll-snap-align: end" so we need to scroll less than
-    //the full row to avoid skipping past tabs. Here we set it to 80%
-    const SCROLL_AMOUNT = 0.8
-    let target = 0
-    const signifier = direction === 'left' ? -1 : 1
-    target =
-      list.current.scrollLeft + signifier * containerWidth * SCROLL_AMOUNT
-    list.current.scrollTo(target, 0)
-  }
-
-  return (
-    <Tabs activeTab={activeTab} onChange={handleChange}>
-      <TabsRow>
-        <NavButton
-          variant="ghost_icon"
-          onClick={() => scroll('left')}
-          aria-hidden="true"
-          tabIndex={-1}
-          disabled={prevDisabled}
-        >
-          <Icon name="chevron_left" />
-        </NavButton>
-        <Tabs.List ref={list}>
-          {Array.from({ length: 20 }, (_, i) => (
-            <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
-          ))}
-        </Tabs.List>
-        <NavButton
-          variant="ghost_icon"
-          onClick={() => scroll('right')}
-          aria-hidden="true"
-          tabIndex={-1}
-          disabled={nextDisabled}
-        >
-          <Icon name="chevron_right" />
-        </NavButton>
-      </TabsRow>
-      <Tabs.Panels>
-        {Array.from({ length: 20 }, (_, i) => (
-          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
-        ))}
-      </Tabs.Panels>
-    </Tabs>
-  )
-}
-
-Overflow.parameters = {
-  docs: {
-    description: {
-      story:
-        'Tabs uses css `scroll-snap`, so in a case where there is overflow and the user wants to add next/previous buttons for scrolling, they can use `element.scrollTo` some amount and then css will take care of alignment',
-    },
-  },
-}
-
-export const OverflowScroll: Story<TabsProps> = () => {
-  const [activeTab, setActiveTab] = useState(0)
-
-  const handleChange = (index: number) => {
-    setActiveTab(index)
-  }
-
-  return (
-    <Tabs activeTab={activeTab} onChange={handleChange} scrollable>
-      <Tabs.List>
-        {Array.from({ length: 20 }, (_, i) => (
-          <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
-        ))}
-      </Tabs.List>
-      <Tabs.Panels>
-        {Array.from({ length: 20 }, (_, i) => (
-          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
-        ))}
-      </Tabs.Panels>
-    </Tabs>
-  )
-}
-
-OverflowScroll.parameters = {
-  docs: {
-    description: {
-      story:
-        'In the case of tabs overflowing, and where next/previous buttons are not desired, the `scrollable` prop adds `overflow-x: auto` to the tabs list. Tabs uses css `scroll-snap` which handles alignment and tabs snapping into place',
-    },
-  },
-}
-
-export const OverflowScrollStyled: Story<TabsProps> = () => {
-  const [activeTab, setActiveTab] = useState(0)
-
-  const handleChange = (index: number) => {
-    setActiveTab(index)
-  }
-
-  return (
-    <Tabs activeTab={activeTab} onChange={handleChange} scrollable>
-      <StyledTabList>
-        {Array.from({ length: 15 }, (_, i) => (
-          <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
-        ))}
-      </StyledTabList>
-      <Tabs.Panels>
-        {Array.from({ length: 15 }, (_, i) => (
-          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
-        ))}
-      </Tabs.Panels>
-    </Tabs>
-  )
-}
-
-OverflowScrollStyled.parameters = {
-  docs: {
-    description: {
-      story: '`scrollable` with custom styled scrollbar',
-    },
-  },
-}
-
 export const Widths: Story<TabsProps> = () => {
   return (
     <>
@@ -460,6 +300,192 @@ export const WithStyledComponent: Story<TabsProps> = () => {
   )
 }
 
+export const Overflow: Story<TabsProps> = () => {
+  const [activeTab, setActiveTab] = useState(0)
+  const list = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState(0)
+  const [totalWidth, setTotalWidth] = useState(0)
+  const [prevDisabled, setPrevDisabled] = useState(true)
+  const [nextDisabled, setNextDisabled] = useState(false)
+
+  const handleChange = (index: number) => {
+    setActiveTab(index)
+  }
+
+  useLayoutEffect(() => {
+    const cachedList = list.current
+    let delayToScrollEnd: ReturnType<typeof setTimeout>
+
+    const handleScroll = () => {
+      if (delayToScrollEnd) clearTimeout(delayToScrollEnd)
+      delayToScrollEnd = setTimeout(() => {
+        cachedList.scrollLeft === 0
+          ? setPrevDisabled(true)
+          : setPrevDisabled(false)
+        containerWidth + Math.ceil(cachedList.scrollLeft) === totalWidth
+          ? setNextDisabled(true)
+          : setNextDisabled(false)
+      }, 20)
+    }
+
+    if (cachedList) {
+      setContainerWidth(cachedList.clientWidth)
+      setTotalWidth(cachedList.scrollWidth)
+      cachedList.addEventListener('scroll', handleScroll, { passive: true })
+    }
+
+    return () => {
+      if (delayToScrollEnd) clearTimeout(delayToScrollEnd)
+      cachedList.removeEventListener('scroll', handleScroll)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerWidth, list, totalWidth])
+
+  const scroll = (direction: string) => {
+    //Tabs have "scroll-snap-align: end" so we need to scroll less than
+    //the full row to avoid skipping past tabs. Here we set it to 80%
+    const SCROLL_AMOUNT = 0.8
+    let target = 0
+    const signifier = direction === 'left' ? -1 : 1
+    target =
+      list.current.scrollLeft + signifier * containerWidth * SCROLL_AMOUNT
+    list.current.scrollTo(target, 0)
+  }
+
+  return (
+    <Tabs activeTab={activeTab} onChange={handleChange}>
+      <TabsRow>
+        <NavButton
+          variant="ghost_icon"
+          onClick={() => scroll('left')}
+          aria-hidden="true"
+          tabIndex={-1}
+          disabled={prevDisabled}
+        >
+          <Icon name="chevron_left" />
+        </NavButton>
+        <Tabs.List ref={list}>
+          {Array.from({ length: 20 }, (_, i) => (
+            <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
+          ))}
+        </Tabs.List>
+        <NavButton
+          variant="ghost_icon"
+          onClick={() => scroll('right')}
+          aria-hidden="true"
+          tabIndex={-1}
+          disabled={nextDisabled}
+        >
+          <Icon name="chevron_right" />
+        </NavButton>
+      </TabsRow>
+      <Tabs.Panels>
+        {Array.from({ length: 20 }, (_, i) => (
+          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
+        ))}
+      </Tabs.Panels>
+    </Tabs>
+  )
+}
+
+Overflow.parameters = {
+  docs: {
+    description: {
+      story:
+        'Tabs uses css `scroll-snap`, so in a case where there is overflow and the user wants to add next/previous buttons for scrolling, they can use `element.scrollTo` some amount and then css will take care of alignment',
+    },
+  },
+}
+
+export const OverflowScroll: Story<TabsProps> = () => {
+  const [activeTab, setActiveTab] = useState(0)
+
+  const handleChange = (index: number) => {
+    setActiveTab(index)
+  }
+
+  return (
+    <Tabs activeTab={activeTab} onChange={handleChange} scrollable>
+      <Tabs.List>
+        {Array.from({ length: 20 }, (_, i) => (
+          <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
+        ))}
+      </Tabs.List>
+      <Tabs.Panels>
+        {Array.from({ length: 20 }, (_, i) => (
+          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
+        ))}
+      </Tabs.Panels>
+    </Tabs>
+  )
+}
+
+OverflowScroll.parameters = {
+  docs: {
+    description: {
+      story:
+        'In the case of tabs overflowing, and where next/previous buttons are not desired, the `scrollable` prop adds `overflow-x: auto` to the tabs list. Tabs uses css `scroll-snap` which handles alignment and tabs snapping into place. Note that scrollbar had been disabled for touch devices since the tabs are swipeable',
+    },
+  },
+}
+
+export const OverflowScrollStyled: Story<TabsProps> = () => {
+  const [activeTab, setActiveTab] = useState(0)
+
+  const handleChange = (index: number) => {
+    setActiveTab(index)
+  }
+
+  /*
+  //An example of how to make custom styled scrollbar for the Tabs.List
+   const StyledTabList = styled(Tabs.List)`
+    --track-color: #ffffff;
+    --thumb-color: #dcdcdc;
+    scrollbar-color: var(--track-color) var(--thumb-color);
+
+    //For firefox
+    scrollbar-width: thin;
+    padding-bottom: 8px;
+
+    // For Google Chrome/Safari/Edge
+    & ::-webkit-scrollbar {
+      height: 8px;
+    }
+
+    & ::-webkit-scrollbar-thumb {
+      background: var(--thumb-color);
+      border-radius: 8px;
+    }
+
+    & ::-webkit-scrollbar-track {
+      background: var(--track-color);
+    }
+  ` */
+
+  return (
+    <Tabs activeTab={activeTab} onChange={handleChange} scrollable>
+      <StyledTabList>
+        {Array.from({ length: 15 }, (_, i) => (
+          <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
+        ))}
+      </StyledTabList>
+      <Tabs.Panels>
+        {Array.from({ length: 15 }, (_, i) => (
+          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
+        ))}
+      </Tabs.Panels>
+    </Tabs>
+  )
+}
+
+OverflowScrollStyled.parameters = {
+  docs: {
+    description: {
+      story: ' The scrollbar styles for Tabs.List can be overwritten',
+    },
+  },
+}
+
 export const Compact: Story<TabsProps> = () => {
   const focusedRef = useRef<HTMLButtonElement>(null)
   const [density, setDensity] = useState<Density>('comfortable')
@@ -498,5 +524,5 @@ WithSearch.storyName = 'With search'
 WithInputInPanel.storyName = 'With input in panel'
 WithStyledComponent.storyName = 'With styled component'
 Overflow.storyName = 'Overflow with next/previous buttons'
-OverflowScroll.storyName = 'Overflow with standard scrollbar'
+OverflowScroll.storyName = 'Overflow with default scrollbar'
 OverflowScrollStyled.storyName = 'Overflow with customized scrollbar'

--- a/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
@@ -173,6 +173,90 @@ Overflow.parameters = {
   },
 }
 
+export const OverflowScroll: Story<TabsProps> = () => {
+  const [activeTab, setActiveTab] = useState(0)
+
+  const handleChange = (index: number) => {
+    setActiveTab(index)
+  }
+
+  return (
+    <Tabs activeTab={activeTab} onChange={handleChange} scrollable>
+      <Tabs.List>
+        {Array.from({ length: 20 }, (_, i) => (
+          <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
+        ))}
+      </Tabs.List>
+      <Tabs.Panels>
+        {Array.from({ length: 20 }, (_, i) => (
+          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
+        ))}
+      </Tabs.Panels>
+    </Tabs>
+  )
+}
+
+OverflowScroll.parameters = {
+  docs: {
+    description: {
+      story:
+        'In the case of tabs overflowing, and where next/previous buttons are not desired, the `scrollable` prop adds `overflow-x: auto` to the tabs list. Tabs uses css `scroll-snap` which handles alignment and tabs snapping into place',
+    },
+  },
+}
+
+export const OverflowScrollStyled: Story<TabsProps> = () => {
+  const StyledTabList = styled(Tabs.List)`
+    --track-color: #ffffff;
+    --thumb-color: #cacaca;
+    scrollbar-color: var(--track-color) var(--thumb-color);
+    scrollbar-width: thin;
+    padding-bottom: 8px;
+
+    // For Google Chrome/webkit
+    & ::-webkit-scrollbar {
+      height: 8px;
+    }
+
+    & ::-webkit-scrollbar-thumb {
+      background: var(--thumb-color);
+      border-radius: 8px;
+    }
+
+    & ::-webkit-scrollbar-track {
+      background: var(--track-color);
+    }
+  `
+  const [activeTab, setActiveTab] = useState(0)
+
+  const handleChange = (index: number) => {
+    setActiveTab(index)
+  }
+
+  return (
+    <Tabs activeTab={activeTab} onChange={handleChange} scrollable>
+      <StyledTabList>
+        {Array.from({ length: 15 }, (_, i) => (
+          <Tabs.Tab key={i}>Tab Title {i + 1}</Tabs.Tab>
+        ))}
+      </StyledTabList>
+      <Tabs.Panels>
+        {Array.from({ length: 15 }, (_, i) => (
+          <Tabs.Panel key={i}>Panel {i + 1}</Tabs.Panel>
+        ))}
+      </Tabs.Panels>
+    </Tabs>
+  )
+}
+
+OverflowScrollStyled.parameters = {
+  docs: {
+    description: {
+      story: '`scrollable` with custom styled scrollbar',
+    },
+  },
+}
+
 export const Widths: Story<TabsProps> = () => {
   return (
     <>
@@ -413,3 +497,5 @@ WithSearch.storyName = 'With search'
 WithInputInPanel.storyName = 'With input in panel'
 WithStyledComponent.storyName = 'With styled component'
 Overflow.storyName = 'Overflow with next/previous buttons'
+OverflowScroll.storyName = 'Overflow with standard scrollbar'
+OverflowScrollStyled.storyName = 'Overflow with customized scrollbar'

--- a/packages/eds-core-react/src/components/Tabs/Tabs.tokens.ts
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.tokens.ts
@@ -81,6 +81,7 @@ export const token: ComponentToken = {
           outline: {
             type: 'outline',
             width: '1px',
+            offset: '-1px',
             style: 'dashed',
             color: focusOutlineColor,
           },

--- a/packages/eds-core-react/src/components/Tabs/Tabs.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.tsx
@@ -59,8 +59,8 @@ const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
 
     if (tabsFocused) return
     if (!listenerAttached) {
-      setListenerAttached(true)
       if (tabsRef.current) {
+        setListenerAttached(true)
         tabsRef.current.addEventListener('keyup', checkIfTabWasPressed, {
           once: true,
           capture: true,

--- a/packages/eds-core-react/src/components/Tabs/Tabs.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.tsx
@@ -47,9 +47,15 @@ const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
       return
     }
     clearTimeout(blurTimer)
-    if (!tabsFocused) {
-      setTabsFocused(true)
+
+    //Only force focus on active Tab if Tabs was navigated to with keyboard
+    const checkIfTabWasPressed = (event: KeyboardEvent) => {
+      document.removeEventListener('keyup', checkIfTabWasPressed, true)
+      if (event.key === 'Tab') setTabsFocused(true)
     }
+    if (!tabsFocused)
+      document.addEventListener('keyup', checkIfTabWasPressed, true)
+
     onFocus && onFocus(e)
   }
 

--- a/packages/eds-core-react/src/components/Tabs/Tabs.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.tsx
@@ -13,6 +13,8 @@ export type TabsProps = {
   onChange?: (index: number) => void
   /** Sets the width of the tabs. Tabs can have a maximum width of 360px */
   variant?: Variants
+  /** adds scrollbar if tabs overflow on non-touch devices */
+  scrollable?: boolean
 } & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
 
 const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
@@ -22,6 +24,7 @@ const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
     onBlur,
     onFocus,
     variant = 'minWidth',
+    scrollable,
     id,
     ...props
   },
@@ -92,6 +95,7 @@ const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs(
           handleChange: onChange,
           tabsId,
           variant,
+          scrollable,
           tabsFocused,
         }}
       >


### PR DESCRIPTION
resolves #1650 

- Added `scrollable` prop to add `overflow-x: auto` on Tabs.List (default its `overflow-x: hidden`
- added `scroll-snap` properties to Tabs.List and tabs.Tab, so that next/prev buttons can be more easily implemented by just using `element.scrollTo`.
- Fixed an internal focus issue that prevented clicking on tabs when active tab has been scrolled out of view (the event listener state juggling might be a bridge too far though,  hehe).
- Added a story showing how to add prev/next buttons on an overflowing Tabs list.
- Added a story with `scrollable` on an overflowing Tabs list.
- Added a story with scrollable on an overflowing Tabs list with custom styled scrollbar (for the sake of the pull request and discussion, I guess we might just go for one solution and delete the other.




Debatable decitions:

- I use  `scroll-behavior: smooth` on the tabslist (unless user have `prefers-reduced-motion`) so scrolling is animated. I think it makes it easier keep track of the context-change visually, but i realize there are no animations otherwise in eds.
- I hide scrollbar (even when `scrollable` is set) on touch devices, as i think it gets in the way of swipe gesture and reduces the user experience.


Issues with mac (not present on windows 10) that I am currently trying to fix:
chrome/firefox: 
- "Overflow with standard scrollbar" example, the scrollbar seems buggy and does not show on hover (the customized scrollbar example works fine)

Safari: 
- Arrow-navigation does not work, but doesnt work in current develop either. The keydown event is never triggered. Instead the container is scrolled since it is never preventDefaulted 
- same scollbar issue as chrome where default scrollbar doesn't appear on hover but custom scrollbar works
-  scroll-behavior: smooth is not supported (but can be enabled in experimental features so maybe it is coming)
