### PR TITLE
👷‍♂️ Working published core-react with eds-utils

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -162,7 +162,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-utils]
     steps:
-      - name: Get utils build
+      - uses: actions/cache@v2
+        name: Get base files
+        with:
+          path: |
+            ./*
+            ~/.pnpm-store
+          key: ${{ github.sha }}
+      - name: Get eds-utils build
         uses: actions/cache@v2
         with:
           path: ./packages/eds-utils

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -58,9 +58,9 @@ jobs:
             ~/.pnpm-store
           key: ${{ github.sha }}
   test:
-    name: Test
+    name: Test eds-core-react
     runs-on: ubuntu-latest
-    needs: setup
+    needs: [build-utils]
     steps:
       - name: Get base files
         uses: actions/cache@v2
@@ -68,13 +68,18 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-core
+      - name: Get eds-utils build
+        uses: actions/cache@v2
+        with:
+          path: ./packages/eds-utils
+          key: ${{ github.sha }}-build-utils
       - name: Test eds-core-react
         run: node_modules/.bin/pnpm --filter @equinor/eds-core-react run test
   lint:
-    name: Lint
+    name: Lint packages
     runs-on: ubuntu-latest
-    needs: setup
+    needs: [build-utils]
     steps:
       - name: Get base files
         uses: actions/cache@v2
@@ -82,13 +87,18 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-core
+      - name: Get eds-utils build
+        uses: actions/cache@v2
+        with:
+          path: ./packages/eds-utils
+          key: ${{ github.sha }}-build-utils
       - name: Lint all packages
         run: node_modules/.bin/pnpm run lint ./packages
   build-tokens:
     name: Build eds-tokens
     runs-on: ubuntu-latest
-    needs: [test, lint]
+    needs: setup
     steps:
       - name: Get base files
         uses: actions/cache@v2

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -155,9 +155,7 @@ jobs:
       - name: Save build to cache
         uses: actions/cache@v2
         with:
-          path: |
-            ./*
-            ~/.pnpm-store
+          path: ./packages/eds-utils
           key: ${{ github.sha }}-build-utils
   publish-utils:
     name: Publish eds-utils to npm

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -68,7 +68,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}-core
+          key: ${{ github.sha }}
       - name: Get eds-utils build
         uses: actions/cache@v2
         with:
@@ -87,7 +87,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}-core
+          key: ${{ github.sha }}
       - name: Get eds-utils build
         uses: actions/cache@v2
         with:
@@ -125,7 +125,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}-lab
+          key: ${{ github.sha }}
       - name: Get eds-tokens build
         uses: actions/cache@v2
         with:
@@ -144,7 +144,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}-lab
+          key: ${{ github.sha }}
       - name: Get eds-tokens build
         uses: actions/cache@v2
         with:

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -165,9 +165,7 @@ jobs:
       - name: Get utils build
         uses: actions/cache@v2
         with:
-          path: |
-            ./*
-            ~/.pnpm-store
+          path: ./packages/eds-utils
           key: ${{ github.sha }}-build-utils
       - name: Publish to npm
         run: node_modules/.bin/pnpm --filter @equinor/eds-utils publish --access public --tag ${{ github.event.inputs.npm-tag }} --no-git-checks
@@ -204,6 +202,11 @@ jobs:
             ./*
             ~/.pnpm-store
           key: ${{ github.sha }}
+      - name: Get utils build
+        uses: actions/cache@v2
+        with:
+          path: ./packages/eds-utils
+          key: ${{ github.sha }}-build-utils
       - name: Get eds-icons build
         uses: actions/cache@v2
         with:
@@ -251,6 +254,11 @@ jobs:
             ./*
             ~/.pnpm-store
           key: ${{ github.sha }}
+      - name: Get utils build
+        uses: actions/cache@v2
+        with:
+          path: ./packages/eds-utils
+          key: ${{ github.sha }}-build-utils
       - uses: actions/cache@v2
         name: Use storybook build cache
         with:

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.17.0-dev.20220209",
+  "version": "0.18.0-dev.20220210",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.17.0",
+  "version": "0.17.0-dev.20220209",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-utils/package.json
+++ b/packages/eds-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-utils",
-  "version": "0.1.0",
+  "version": "0.1.0-dev.20220210",
   "description": "Utility functions and hooks for the Equinor Design System",
   "sideEffects": false,
   "main": "dist/eds-utils.cjs.js",


### PR DESCRIPTION
resolves #1949 

Suggest keeping the -dev version names as its the latest versions that are published under the `next` tag which is what is in development