### PR TITLE
♻️ Change disabled option feature for Combobox

### DIFF
--- a/packages/eds-lab-react/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/eds-lab-react/src/components/Combobox/Combobox.stories.tsx
@@ -184,55 +184,28 @@ OptionLabel.args = {
 }
 
 export const DisabledOption: Story<ComboboxProps<MyOptionType>> = (args) => {
-  const options = [
-    {
-      label: 'Microsoft Corporation',
-      symbol: 'MSFT',
-      disabled: true,
-    },
-    {
-      label: 'Tesla, Inc',
-      symbol: 'TSLA',
-    },
-    {
-      label: 'Apple Inc.',
-      symbol: 'AAPL',
-    },
-    {
-      label: 'NVIDIA Corporation',
-      symbol: 'NVDA',
-    },
-    {
-      label: 'Alphabet Inc.',
-      symbol: 'GOOG',
-      disabled: true,
-    },
-    {
-      label: 'Amazon.com, Inc.',
-      symbol: 'AMZN',
-    },
-    {
-      label: 'Meta Platforms, Inc.',
-      symbol: 'FB',
-      disabled: true,
-    },
-    {
-      label: 'Berkshire Hathaway Inc.',
-      symbol: 'BRK',
-    },
-  ]
-
+  const { options } = args
+  const isOptionDisabled = (item: MyOptionType) =>
+    item === options[0] || item === options[options.length - 1]
   return (
     <Stack direction="column">
-      <Combobox label="Select a stock" options={options} {...args} />
+      <Combobox
+        label="Select a stock"
+        optionDisabled={isOptionDisabled}
+        {...args}
+      />
       <Combobox
         label="Select multiple stocks"
-        options={options}
+        optionDisabled={isOptionDisabled}
         {...args}
         multiple
       />
     </Stack>
   )
+}
+
+DisabledOption.args = {
+  options: stocks,
 }
 
 export const PreselectedOptions: Story<ComboboxProps<MyOptionType>> = (

--- a/packages/eds-lab-react/src/components/Combobox/Combobox.test.tsx
+++ b/packages/eds-lab-react/src/components/Combobox/Combobox.test.tsx
@@ -148,23 +148,13 @@ describe('Combobox', () => {
   })
 
   it('Second option is first when first option is disabled', async () => {
-    const optionsData = [
-      {
-        label: 'option1',
-        id: 1,
-        disabled: true,
-      },
-      {
-        label: 'option2',
-        id: 2,
-      },
-      {
-        label: 'option3',
-        id: 3,
-      },
-    ]
-
-    render(<Combobox options={optionsData} label={labelText} />)
+    render(
+      <Combobox
+        options={items}
+        label={labelText}
+        optionDisabled={(item) => item === items[0]}
+      />,
+    )
 
     const labeledNodes = await screen.findAllByLabelText(labelText)
     const input = labeledNodes[0]
@@ -173,9 +163,7 @@ describe('Combobox', () => {
     fireEvent.keyDown(input, { key: 'ArrowDown' })
     const options = await within(optionsList).findAllByRole('option')
     expect(options).toHaveLength(2) // since one option is disabled
-    expect(
-      await within(options[0]).findByText(optionsData[1].label),
-    ).toBeDefined()
+    expect(await within(options[0]).findByText(items[1].label)).toBeDefined()
 
     const withDisabledOptions = await within(optionsList).findAllByRole(
       'option',
@@ -185,7 +173,7 @@ describe('Combobox', () => {
     )
     expect(withDisabledOptions[0]).toHaveAttribute('aria-hidden')
     expect(
-      await within(withDisabledOptions[0]).findByText(optionsData[0].label),
+      await within(withDisabledOptions[0]).findByText(items[0].label),
     ).toBeDefined()
   })
 

--- a/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
+++ b/packages/eds-lab-react/src/components/Combobox/Combobox.tsx
@@ -183,6 +183,8 @@ export type ComboboxProps<T> = {
   optionLabel?: (option: ComboboxOption<T>) => string
   /** Disable use of react portal for dropdown */
   disablePortal?: boolean
+  /** Disable option */
+  optionDisabled?: (option: ComboboxOption<T>) => boolean
 } & HTMLAttributes<HTMLDivElement>
 
 function ComboboxInner<T>(
@@ -202,6 +204,7 @@ function ComboboxInner<T>(
     initialSelectedOptions = [],
     optionLabel = (item) => item.label,
     disablePortal,
+    optionDisabled = () => false,
     ...other
   } = props
   const anchorRef = useRef()
@@ -212,7 +215,7 @@ function ComboboxInner<T>(
   const isControlled = Boolean(selectedOptions)
   const labelItems = options.map(optionLabel)
   const [disabledItems] = useState<string[]>(
-    options.filter((x) => x.disabled).map(optionLabel),
+    options.filter(optionDisabled).map(optionLabel),
   )
   const [availableItems, setAvailableItems] = useState<string[]>(labelItems)
   const initialSelectedItems = initialSelectedOptions.map(optionLabel)


### PR DESCRIPTION
After started working on #1657 it would be better to use a option callback function instead of object prop for declaring an option as disabled. This will better tie in with upcoming feature #1657 and option labeling also being callback functions.