### PR TITLE
🐛 Adding all variants to quickvariants

### DIFF
--- a/packages/eds-core-react/src/components/Typography/Typography.tokens.ts
+++ b/packages/eds-core-react/src/components/Typography/Typography.tokens.ts
@@ -2,7 +2,7 @@ import { ComponentToken, tokens } from '@equinor/eds-tokens'
 import type { TypographyTokens } from '@equinor/eds-tokens'
 
 const { typography, colors: colorsToken } = tokens
-const { heading, paragraph } = typography
+const { heading, paragraph, ui, table, input, navigation } = typography
 
 const {
   interactive: {
@@ -28,10 +28,18 @@ const colors = {
 export type QuickTypographyVariants =
   | TypographyTokens['heading']
   | TypographyTokens['paragraph']
+  | TypographyTokens['ui']
+  | TypographyTokens['table']
+  | TypographyTokens['input']
+  | TypographyTokens['navigation']
 
 const quickVariants: QuickTypographyVariants = {
   ...heading,
   ...paragraph,
+  ...ui,
+  ...table,
+  ...input,
+  ...navigation,
 }
 
 type TypographyVariants =


### PR DESCRIPTION
resolves #2022 

Is this correct though? previously only heading and paragraph variants would work, but all variants would be listed as available with typescript/in storybook. Now I have added all variants as possible which then matches the exposed types 