### PR TITLE
🐛 Fixes in Menu.Item & Menu.Section

### DIFF
--- a/packages/eds-core-react/src/components/Menu/MenuList.tsx
+++ b/packages/eds-core-react/src/components/Menu/MenuList.tsx
@@ -54,6 +54,8 @@ export const MenuList = forwardRef<HTMLDivElement, MenuListProps>(
         ReactChildren.map(children, (child: MenuChild) => {
           if (!child) return child
           if (child.type === MenuSection) {
+            index++
+            const menuSectionIndex = index
             const updatedGrandChildren = ReactChildren.map(
               child.props.children,
               (grandChild: MenuChild) => {
@@ -62,7 +64,11 @@ export const MenuList = forwardRef<HTMLDivElement, MenuListProps>(
                 return cloneElement(grandChild, { index })
               },
             )
-            return cloneElement(child, null, updatedGrandChildren)
+            return cloneElement(
+              child,
+              { index: menuSectionIndex },
+              updatedGrandChildren,
+            )
           } else {
             index++
             if (isIndexable(child)) focusableIndexs.push(index)

--- a/packages/eds-core-react/src/components/Menu/MenuList.tsx
+++ b/packages/eds-core-react/src/components/Menu/MenuList.tsx
@@ -52,6 +52,7 @@ export const MenuList = forwardRef<HTMLDivElement, MenuListProps>(
     const updatedChildren: Array<MenuChild> = useMemo(
       () =>
         ReactChildren.map(children, (child: MenuChild) => {
+          if (!child) return child
           if (child.type === MenuSection) {
             const updatedGrandChildren = ReactChildren.map(
               child.props.children,


### PR DESCRIPTION
fixes #2015

* Fixed crash in `Menu` when using conditional rendering on `Menu.Item`
* Fixed divider not hiding in `Menu.Section` when first.