### PR TITLE
🧑‍💻Menu anchor handle keypress internal

### DIFF
--- a/packages/eds-core-react/src/components/Menu/Menu.context.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.context.tsx
@@ -5,19 +5,23 @@ import {
   MouseEvent,
   createContext,
 } from 'react'
+import type { FocusTarget } from './Menu.types'
 
 export type State = {
   focusedIndex: number
+  initialFocus: FocusTarget
   onClose: (e?: MouseEvent) => void
 }
 
 type UseMenu<T> = T & {
   setFocusedIndex: (index: number) => void
+  setInitialFocus: (initialFocus: FocusTarget) => void
   setOnClose: (onClose: (e?: MouseEvent) => void) => void
 }
 
 const initalState: State = {
   focusedIndex: -1,
+  initialFocus: null,
   onClose: null,
 }
 
@@ -28,15 +32,19 @@ type ProviderProps = { children: ReactNode }
 export const MenuProvider = ({ children }: ProviderProps): JSX.Element => {
   const [state, setState] = useState<State>(initalState)
 
-  const { focusedIndex, onClose } = state
+  const { focusedIndex, initialFocus, onClose } = state
 
   const setFocusedIndex: UseMenu<State>['setFocusedIndex'] = (i) => {
     setState((prevState) => ({ ...prevState, focusedIndex: i }))
+  }
+  const setInitialFocus: UseMenu<State>['setInitialFocus'] = (initialFocus) => {
+    setState((prevState) => ({ ...prevState, initialFocus: initialFocus }))
   }
 
   const setOnClose: UseMenu<State>['setOnClose'] = (onClose) => {
     const onCloseHelper = () => {
       setFocusedIndex(-1)
+      setInitialFocus(null)
       onClose()
     }
     setState((prevState) => ({ ...prevState, onClose: onCloseHelper }))
@@ -45,6 +53,8 @@ export const MenuProvider = ({ children }: ProviderProps): JSX.Element => {
   const value = {
     setFocusedIndex,
     focusedIndex,
+    setInitialFocus,
+    initialFocus,
     setOnClose,
     onClose,
   }

--- a/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
@@ -65,7 +65,7 @@ export const Default: Story<MenuProps> = (args) => {
     setIsOpen(args.open)
     // eslint-disable-next-line react/destructuring-assignment
   }, [args.open, args.focus])
-
+/*
   const onKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     const { key } = e
     if (key === 'Tab') return
@@ -84,7 +84,7 @@ export const Default: Story<MenuProps> = (args) => {
       default:
         break
     }
-  }
+  } */
 
   return (
     <StoryCenter>
@@ -95,7 +95,6 @@ export const Default: Story<MenuProps> = (args) => {
         aria-expanded={isOpen}
         aria-controls="menu-default"
         onClick={() => (isOpen ? closeMenu() : openMenu(null))}
-        onKeyDown={onKeyPress}
       >
         Click to open Menu!
       </Button>

--- a/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
@@ -47,54 +47,30 @@ const onClick = (event: React.MouseEvent) => {
 
 export const Default: Story<MenuProps> = (args) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [focus, setFocus] = useState<MenuProps['focus']>(null)
-  const anchorRef = useRef<HTMLButtonElement>(null)
+  const [anchorRef, setAnchorRef] = useState<HTMLButtonElement>(null)
 
-  const openMenu = (focus: MenuProps['focus']) => {
+  const openMenu = () => {
     setIsOpen(true)
-    setFocus(focus)
   }
   const closeMenu = () => {
     setIsOpen(false)
-    setFocus(null)
   }
 
   // This is just for storybook and changes done via controls addon
   useEffect(() => {
-    setFocus(args.focus)
     setIsOpen(args.open)
     // eslint-disable-next-line react/destructuring-assignment
-  }, [args.open, args.focus])
-/*
-  const onKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const { key } = e
-    if (key === 'Tab') return
-    e.preventDefault()
-    e.stopPropagation()
-    switch (key) {
-      case 'Enter':
-        isOpen ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowDown':
-        isOpen ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowUp':
-        isOpen ? closeMenu() : openMenu('last')
-        break
-      default:
-        break
-    }
-  } */
+  }, [args.open])
 
   return (
     <StoryCenter>
       <Button
-        ref={anchorRef}
+        ref={setAnchorRef}
         id="anchor-default"
         aria-haspopup="true"
         aria-expanded={isOpen}
         aria-controls="menu-default"
-        onClick={() => (isOpen ? closeMenu() : openMenu(null))}
+        onClick={() => (isOpen ? closeMenu() : openMenu())}
       >
         Click to open Menu!
       </Button>
@@ -102,10 +78,9 @@ export const Default: Story<MenuProps> = (args) => {
         open={isOpen}
         {...args}
         id="menu-default"
-        focus={focus}
         aria-labelledby="anchor-default"
         onClose={closeMenu}
-        anchorEl={anchorRef.current}
+        anchorEl={anchorRef}
       >
         <Menu.Item onClick={onClick}>Pressure</Menu.Item>
         <Menu.Item onClick={onClick}>Bearing</Menu.Item>
@@ -122,47 +97,24 @@ Default.args = {
 
 export const Complex: Story<MenuProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [focus, setFocus] = useState<'first' | 'last'>(null)
-  const anchorRef = useRef<HTMLButtonElement>(null)
+  const [anchorRef, setAnchorRef] = useState<HTMLButtonElement>(null)
 
-  const openMenu = (focus: 'first' | 'last') => {
+  const openMenu = () => {
     setIsOpen(true)
-    setFocus(focus)
   }
   const closeMenu = () => {
     setIsOpen(false)
-    setFocus(null)
   }
 
-  const onKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const { key } = e
-    if (key === 'Tab') return
-    e.preventDefault()
-    e.stopPropagation()
-    switch (key) {
-      case 'Enter':
-        isOpen ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowDown':
-        isOpen ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowUp':
-        isOpen ? closeMenu() : openMenu('last')
-        break
-      default:
-        break
-    }
-  }
   return (
     <StoryCenter>
       <Button
-        ref={anchorRef}
+        ref={setAnchorRef}
         id="anchor-complex"
         aria-controls="menu-complex"
         aria-haspopup="true"
         aria-expanded={isOpen}
-        onClick={() => (isOpen ? closeMenu() : openMenu(null))}
-        onKeyDown={onKeyPress}
+        onClick={() => (isOpen ? closeMenu() : openMenu())}
       >
         Click to open Menu!
       </Button>
@@ -171,9 +123,8 @@ export const Complex: Story<MenuProps> = () => {
         id="menu-complex"
         aria-labelledby="anchor-complex"
         open={isOpen}
-        anchorEl={anchorRef.current}
+        anchorEl={anchorRef}
         onClose={closeMenu}
-        focus={focus}
         placement="right"
       >
         <Menu.Item onClick={onClick}>
@@ -286,17 +237,14 @@ export const Complex: Story<MenuProps> = () => {
 export const Compact: Story<MenuProps> = () => {
   const [density, setDensity] = useState<Density>('comfortable')
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [focus, setFocus] = useState<'first' | 'last'>(null)
-  const anchorRef = useRef<HTMLButtonElement>(null)
+  const [anchorRef, setAnchorRef] = useState<HTMLButtonElement>(null)
 
-  const openMenu = (focus: 'first' | 'last') => {
+  const openMenu = () => {
     setIsOpen(true)
-    setFocus(focus)
   }
 
   const closeMenu = () => {
     setIsOpen(false)
-    setFocus(null)
   }
 
   useEffect(() => {
@@ -304,37 +252,16 @@ export const Compact: Story<MenuProps> = () => {
     setDensity('compact')
   }, [density])
 
-  const onKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const { key } = e
-    if (key === 'Tab') return
-    e.preventDefault()
-    e.stopPropagation()
-    switch (key) {
-      case 'Enter':
-        isOpen ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowDown':
-        isOpen ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowUp':
-        isOpen ? closeMenu() : openMenu('last')
-        break
-      default:
-        break
-    }
-  }
-
   return (
     <EdsProvider density={density}>
       <StoryCenter>
         <Button
-          ref={anchorRef}
+          ref={setAnchorRef}
           id="anchor-compact"
           aria-haspopup="true"
           aria-expanded={isOpen}
           aria-controls="menu-compact"
-          onClick={() => (isOpen ? closeMenu() : openMenu(null))}
-          onKeyDown={onKeyPress}
+          onClick={() => (isOpen ? closeMenu() : openMenu())}
         >
           Click to open Menu!
         </Button>
@@ -342,10 +269,9 @@ export const Compact: Story<MenuProps> = () => {
           <Menu
             open={isOpen}
             id="menu-compact"
-            focus={focus}
             aria-labelledby="anchor-compact"
             onClose={closeMenu}
-            anchorEl={anchorRef.current}
+            anchorEl={anchorRef}
           >
             <Menu.Item onClick={onClick}>Pressure</Menu.Item>
             <Menu.Item onClick={onClick}>Bearing</Menu.Item>

--- a/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
 import {
@@ -47,7 +47,7 @@ const onClick = (event: React.MouseEvent) => {
 
 export const Default: Story<MenuProps> = (args) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorRef, setAnchorRef] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
 
   const openMenu = () => {
     setIsOpen(true)
@@ -65,7 +65,7 @@ export const Default: Story<MenuProps> = (args) => {
   return (
     <StoryCenter>
       <Button
-        ref={setAnchorRef}
+        ref={setAnchorEl}
         id="anchor-default"
         aria-haspopup="true"
         aria-expanded={isOpen}
@@ -80,7 +80,7 @@ export const Default: Story<MenuProps> = (args) => {
         id="menu-default"
         aria-labelledby="anchor-default"
         onClose={closeMenu}
-        anchorEl={anchorRef}
+        anchorEl={anchorEl}
       >
         <Menu.Item onClick={onClick}>Pressure</Menu.Item>
         <Menu.Item onClick={onClick}>Bearing</Menu.Item>
@@ -97,7 +97,7 @@ Default.args = {
 
 export const Complex: Story<MenuProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorRef, setAnchorRef] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
 
   const openMenu = () => {
     setIsOpen(true)
@@ -109,7 +109,7 @@ export const Complex: Story<MenuProps> = () => {
   return (
     <StoryCenter>
       <Button
-        ref={setAnchorRef}
+        ref={setAnchorEl}
         id="anchor-complex"
         aria-controls="menu-complex"
         aria-haspopup="true"
@@ -123,7 +123,7 @@ export const Complex: Story<MenuProps> = () => {
         id="menu-complex"
         aria-labelledby="anchor-complex"
         open={isOpen}
-        anchorEl={anchorRef}
+        anchorEl={anchorEl}
         onClose={closeMenu}
         placement="right"
       >
@@ -237,7 +237,7 @@ export const Complex: Story<MenuProps> = () => {
 export const Compact: Story<MenuProps> = () => {
   const [density, setDensity] = useState<Density>('comfortable')
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorRef, setAnchorRef] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
 
   const openMenu = () => {
     setIsOpen(true)
@@ -256,7 +256,7 @@ export const Compact: Story<MenuProps> = () => {
     <EdsProvider density={density}>
       <StoryCenter>
         <Button
-          ref={setAnchorRef}
+          ref={setAnchorEl}
           id="anchor-compact"
           aria-haspopup="true"
           aria-expanded={isOpen}
@@ -271,7 +271,7 @@ export const Compact: Story<MenuProps> = () => {
             id="menu-compact"
             aria-labelledby="anchor-compact"
             onClose={closeMenu}
-            anchorEl={anchorRef}
+            anchorEl={anchorEl}
           >
             <Menu.Item onClick={onClick}>Pressure</Menu.Item>
             <Menu.Item onClick={onClick}>Bearing</Menu.Item>

--- a/packages/eds-core-react/src/components/Menu/Menu.test.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.test.tsx
@@ -138,32 +138,6 @@ describe('Menu', () => {
     await waitFor(() => expect(handleOnClick).toHaveBeenCalled())
     expect(handleOnClose).toHaveBeenCalled()
   })
-  it('has first menuItem focused when focus is set to first', async () => {
-    render(
-      <TestMenu open focus="first">
-        <Menu.Item>Item 1</Menu.Item>
-        <Menu.Item>Item 2</Menu.Item>
-        <Menu.Item>Item 3</Menu.Item>
-      </TestMenu>,
-    )
-    const menuItem = screen.getAllByRole('menuitem')[0]
-
-    // eslint-disable-next-line testing-library/no-node-access
-    await waitFor(() => expect(document.activeElement == menuItem).toBeTruthy())
-  })
-  it('has last menuItem focused when focus is set to last', async () => {
-    render(
-      <TestMenu open focus="last">
-        <Menu.Item>Item 1</Menu.Item>
-        <Menu.Item>Item 2</Menu.Item>
-        <Menu.Item>Item 3</Menu.Item>
-      </TestMenu>,
-    )
-    const menuItem = screen.getAllByRole('menuitem')[2]
-
-    // eslint-disable-next-line testing-library/no-node-access
-    await waitFor(() => expect(document.activeElement == menuItem).toBeTruthy())
-  })
   it('has called onClose when Menu.Item is clicked from inside a Menu.Section', async () => {
     const handleOnClose = jest.fn()
     const handleOnClick = jest.fn()

--- a/packages/eds-core-react/src/components/Menu/Menu.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.tsx
@@ -42,18 +42,36 @@ const MenuContainer = forwardRef<HTMLDivElement, MenuContainerProps>(
       anchorEl,
       onClose: onCloseCallback,
       open,
+      focus,
       containerEl,
       ...rest
     },
     ref,
   ) {
     const { setOnClose, onClose } = useMenu()
+    const [focused, setFocused] = useState<string | null>(focus)
 
     useEffect(() => {
       if (onClose === null && onCloseCallback) {
         setOnClose(onCloseCallback)
       }
     }, [onClose, onCloseCallback, setOnClose])
+
+    useEffect(() => {
+      console.log('useEffect')
+      const openWithEnter = (event: KeyboardEvent) => {
+        console.log('openWithEnter')
+        if (event.key === 'Enter') {
+          console.log('enter ')
+          setFocused('first')
+        }
+      }
+      if (anchorEl) anchorEl.addEventListener('keydown', openWithEnter)
+      return () => {
+        console.log('anchor deleted return')
+        if (anchorEl) anchorEl.removeEventListener('keydown', openWithEnter)
+      }
+    }, [anchorEl])
 
     useOutsideClick(containerEl, (e: MouseEvent) => {
       if (open && onClose !== null && !anchorEl.contains(e.target as Node)) {
@@ -78,8 +96,13 @@ const MenuContainer = forwardRef<HTMLDivElement, MenuContainerProps>(
       }
     })
 
+    const menuListProps = {
+      ...rest,
+      focused,
+    }
+
     return (
-      <MenuList {...rest} ref={ref}>
+      <MenuList {...menuListProps} ref={ref}>
         {children}
       </MenuList>
     )
@@ -100,7 +123,7 @@ export type MenuProps = {
 } & HTMLAttributes<HTMLDivElement>
 
 export const Menu = forwardRef<HTMLDivElement, MenuProps>(function Menu(
-  { anchorEl, open, placement = 'auto', style, className, ...rest },
+  { anchorEl, open, focus, placement = 'auto', style, className, ...rest },
   ref,
 ) {
   const [containerEl, setContainerEl] = useState<HTMLElement>(null)
@@ -132,6 +155,7 @@ export const Menu = forwardRef<HTMLDivElement, MenuProps>(function Menu(
     ...rest,
     anchorEl,
     open,
+    focus,
     containerEl,
   }
 

--- a/packages/eds-core-react/src/components/Menu/MenuList.tsx
+++ b/packages/eds-core-react/src/components/Menu/MenuList.tsx
@@ -82,6 +82,7 @@ export const MenuList = forwardRef<HTMLDivElement, MenuListProps>(
     const lastFocusIndex = focusableIndexs[focusableIndexs.length - 1]
 
     useEffect(() => {
+      console.log('focus: ', focus)
       if (focus === 'first') {
         setFocusedIndex(firstFocusIndex)
       }

--- a/packages/eds-core-react/src/components/Menu/MenuList.tsx
+++ b/packages/eds-core-react/src/components/Menu/MenuList.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react'
 import styled from 'styled-components'
 import { useMenu } from './Menu.context'
-import type { FocusTarget } from './Menu.types'
 import { MenuItemProps, MenuItem } from './MenuItem'
 import { MenuSectionProps, MenuSection } from './MenuSection'
 import { menu as tokens } from './Menu.tokens'
@@ -28,7 +27,6 @@ const List = styled.div`
   }
 `
 type MenuListProps = {
-  focus?: FocusTarget
   children: ReactNode
 }
 
@@ -43,8 +41,8 @@ function isIndexable(item: MenuChild) {
 }
 
 export const MenuList = forwardRef<HTMLDivElement, MenuListProps>(
-  function MenuList({ children, focus, ...rest }, ref) {
-    const { focusedIndex, setFocusedIndex } = useMenu()
+  function MenuList({ children, ...rest }, ref) {
+    const { focusedIndex, setFocusedIndex, initialFocus } = useMenu()
 
     let index = -1
     const focusableIndexs: number[] = useMemo<number[]>(() => [], [])
@@ -82,15 +80,14 @@ export const MenuList = forwardRef<HTMLDivElement, MenuListProps>(
     const lastFocusIndex = focusableIndexs[focusableIndexs.length - 1]
 
     useEffect(() => {
-      console.log('focus: ', focus)
-      if (focus === 'first') {
+      if (initialFocus === 'first') {
         setFocusedIndex(firstFocusIndex)
       }
-      if (focus === 'last') {
+      if (initialFocus === 'last') {
         setFocusedIndex(lastFocusIndex)
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [focus, firstFocusIndex, lastFocusIndex])
+    }, [initialFocus, firstFocusIndex, lastFocusIndex])
 
     const handleMenuItemChange = (
       direction: Direction,

--- a/packages/eds-core-react/stories/playground/DataTable.tsx
+++ b/packages/eds-core-react/stories/playground/DataTable.tsx
@@ -113,13 +113,13 @@ const toCellValues = (data: Data[], columns: Column[]) =>
 
 const MenuButton = ({ row }: { row: string[] }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>()
-  const isOpen = Boolean(anchorEl)
+  const [isOpen, setIsOpen] = useState<boolean>(false)
 
-  const openMenu = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    setAnchorEl(e.currentTarget)
+  const openMenu = () => {
+    setIsOpen(true)
   }
   const closeMenu = () => {
-    setAnchorEl(null)
+    setIsOpen(false)
   }
 
   return (
@@ -130,49 +130,48 @@ const MenuButton = ({ row }: { row: string[] }) => {
         aria-controls={`menu-${row.toString()}`}
         aria-haspopup="true"
         aria-expanded={isOpen}
-        onClick={(e) => setAnchorEl(e.currentTarget)}
+        ref={setAnchorEl}
+        onClick={() => (isOpen ? closeMenu() : openMenu())}
       >
         <Icon name="more_vertical" title="more"></Icon>
       </Button>
-      {isOpen && (
-        <Menu
-          id={`menu-${row.toString()}`}
-          aria-labelledby={`menu-button-${row.toString()}`}
-          open={isOpen}
-          anchorEl={anchorEl}
-          onClose={closeMenu}
-        >
-          <Menu.Item onClick={closeMenu}>
-            <Icon name="folder" size={16} />
-            <Typography group="navigation" variant="menu_title">
-              Open
-            </Typography>
-            <Typography
-              color={colors.text.static_icons__tertiary.hex}
-              group="navigation"
-              variant="label"
-              style={{ height: 12 }}
-            >
-              CTRL+O
-            </Typography>
-          </Menu.Item>
-          <Menu.Item onClick={closeMenu}>
-            <Icon name="copy" size={16} />
-            <Typography group="navigation" variant="menu_title">
-              Copy
-            </Typography>
-            <Typography
-              color={colors.text.static_icons__tertiary.hex}
-              group="navigation"
-              variant="label"
-              as="span"
-              style={{ height: 12 }}
-            >
-              CTRL+C
-            </Typography>
-          </Menu.Item>
-        </Menu>
-      )}
+      <Menu
+        id={`menu-${row.toString()}`}
+        aria-labelledby={`menu-button-${row.toString()}`}
+        open={isOpen}
+        anchorEl={anchorEl}
+        onClose={closeMenu}
+      >
+        <Menu.Item onClick={closeMenu}>
+          <Icon name="folder" size={16} />
+          <Typography group="navigation" variant="menu_title">
+            Open
+          </Typography>
+          <Typography
+            color={colors.text.static_icons__tertiary.hex}
+            group="navigation"
+            variant="label"
+            style={{ height: 12 }}
+          >
+            CTRL+O
+          </Typography>
+        </Menu.Item>
+        <Menu.Item onClick={closeMenu}>
+          <Icon name="copy" size={16} />
+          <Typography group="navigation" variant="menu_title">
+            Copy
+          </Typography>
+          <Typography
+            color={colors.text.static_icons__tertiary.hex}
+            group="navigation"
+            variant="label"
+            as="span"
+            style={{ height: 12 }}
+          >
+            CTRL+C
+          </Typography>
+        </Menu.Item>
+      </Menu>
     </>
   )
 }

--- a/packages/eds-core-react/stories/playground/DataTable.tsx
+++ b/packages/eds-core-react/stories/playground/DataTable.tsx
@@ -113,42 +113,13 @@ const toCellValues = (data: Data[], columns: Column[]) =>
 
 const MenuButton = ({ row }: { row: string[] }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>()
-  const [focus, setFocus] = useState<MenuProps['focus']>(null)
   const isOpen = Boolean(anchorEl)
 
-  const openMenu = (
-    focus: MenuProps['focus'],
-    e: React.KeyboardEvent<HTMLButtonElement>,
-  ) => {
-    setFocus(focus)
+  const openMenu = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     setAnchorEl(e.currentTarget)
   }
   const closeMenu = () => {
-    setFocus(null)
     setAnchorEl(null)
-  }
-
-  const onKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const { key } = e
-    if (key === 'Tab') {
-      return
-    }
-    e.preventDefault()
-    e.stopPropagation()
-
-    switch (key) {
-      case 'Enter':
-        isOpen ? closeMenu() : openMenu('first', e)
-        break
-      case 'ArrowDown':
-        isOpen ? closeMenu() : openMenu('first', e)
-        break
-      case 'ArrowUp':
-        isOpen ? closeMenu() : openMenu('last', e)
-        break
-      default:
-        break
-    }
   }
 
   return (
@@ -160,7 +131,6 @@ const MenuButton = ({ row }: { row: string[] }) => {
         aria-haspopup="true"
         aria-expanded={isOpen}
         onClick={(e) => setAnchorEl(e.currentTarget)}
-        onKeyDown={onKeyPress}
       >
         <Icon name="more_vertical" title="more"></Icon>
       </Button>
@@ -170,7 +140,6 @@ const MenuButton = ({ row }: { row: string[] }) => {
           aria-labelledby={`menu-button-${row.toString()}`}
           open={isOpen}
           anchorEl={anchorEl}
-          focus={focus}
           onClose={closeMenu}
         >
           <Menu.Item onClick={closeMenu}>

--- a/packages/eds-core-react/stories/playground/Examples.stories.tsx
+++ b/packages/eds-core-react/stories/playground/Examples.stories.tsx
@@ -65,46 +65,23 @@ export const TestPage: Story = (args) => {
   const [isOpenMenu, setOpenMenu] = useState<boolean>(false)
   const [isOpenSnackbar, setOpenSnackbar] = useState<boolean>(false)
   const [isPopoverOpen, setPopoverOpen] = useState<boolean>(false)
-  const [focus, setFocus] = useState<MenuProps['focus']>(null)
   const [density, setDensity] =
     useState<EdsProviderProps['density']>('comfortable')
-  const menuAnchorRef = useRef<HTMLButtonElement>(null)
+  const [menuAnchorRef, setMenuAnchorRef] = useState<HTMLButtonElement>(null)
   const popverAnchorRef = useRef<HTMLButtonElement>(null)
 
-  const openMenu = (focus: MenuProps['focus']) => {
+  const openMenu = () => {
     setOpenMenu(true)
-    setFocus(focus)
   }
   const closeMenu = () => {
     setOpenMenu(false)
-    setFocus(null)
   }
 
   // This is just for storybook and changes done via controls addon
   useEffect(() => {
-    setFocus(args.focus)
     setOpenMenu(args.open)
     // eslint-disable-next-line react/destructuring-assignment
-  }, [args.open, args.focus])
-
-  const onKeyPress = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const { key } = e
-    e.preventDefault()
-    e.stopPropagation()
-    switch (key) {
-      case 'Enter':
-        isOpenMenu ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowDown':
-        isOpenMenu ? closeMenu() : openMenu('first')
-        break
-      case 'ArrowUp':
-        isOpenMenu ? closeMenu() : openMenu('last')
-        break
-      default:
-        break
-    }
-  }
+  }, [args.open])
 
   return (
     <Container>
@@ -117,13 +94,12 @@ export const TestPage: Story = (args) => {
         <TopBar.Actions>
           <Button
             variant="ghost_icon"
-            ref={menuAnchorRef}
+            ref={setMenuAnchorRef}
             id="anchor-menu"
             aria-haspopup="true"
             aria-expanded={isOpenMenu}
             aria-controls="menu"
-            onClick={() => (isOpenMenu ? closeMenu() : openMenu(null))}
-            onKeyDown={onKeyPress}
+            onClick={() => (isOpenMenu ? closeMenu() : openMenu())}
           >
             <Icon data={accessible} title="Choose density" />
           </Button>
@@ -131,10 +107,9 @@ export const TestPage: Story = (args) => {
             open={isOpenMenu}
             {...args}
             id="menu"
-            focus={focus}
             aria-labelledby="anchor-menu"
             onClose={closeMenu}
-            anchorEl={menuAnchorRef.current}
+            anchorEl={menuAnchorRef}
           >
             <Menu.Item onClick={() => setDensity('comfortable')}>
               Comfortable


### PR DESCRIPTION
Resolves #1936 

Make keyhandling of anchor internal (open and move focus to menu after pressing `enter`/`keyUp`/`keyDown`).
Adds eventlistener to the anchor for the keypresses, so a new requirement for developers now is to use `useState` to set the `anchorEl` ref. Previously in our examples we used useRef, but this will not trigger rerender to add listener when ref switches from null to the actual element