### PR TITLE
Fixes useOutsideClick type

### DIFF
--- a/packages/eds-utils/src/hooks/useOutsideClick.ts
+++ b/packages/eds-utils/src/hooks/useOutsideClick.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 
 export const useOutsideClick = (
-  el: HTMLElement,
+  el: HTMLElement | null,
   callback: (e: MouseEvent) => void,
 ): void => {
   useEffect(() => {


### PR DESCRIPTION
this is not a bug, not a feature, but typescript type mismatch. 
eslint complains about wrong type