### PR TITLE
♿️ Slider a11y improvements

### DIFF
--- a/packages/eds-core-react/src/components/Slider/Slider.test.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.test.tsx
@@ -30,7 +30,7 @@ const DateSlider = ({
     <Slider
       min={getUnixTime('2020-01-01')}
       max={getUnixTime('2020-01-31')}
-      ariaLabelledby={ariaLabelledby}
+      aria-labelledby={ariaLabelledby}
       step={60 * 60 * 24 * 1000}
       value={value}
       outputFunction={outputFunction}
@@ -41,7 +41,7 @@ const DateSlider = ({
 describe('Simple slider', () => {
   it('Matches snapshot', () => {
     const { asFragment } = render(
-      <Slider value={0} ariaLabelledby="test-one" />,
+      <Slider value={0} aria-labelledby="test-one" id="test" />,
     )
     expect(asFragment()).toMatchSnapshot()
   })
@@ -49,19 +49,19 @@ describe('Simple slider', () => {
     const { container } = render(
       <>
         <span id="a11y-test">Text</span>
-        <Slider value={40} ariaLabelledby="a11y-test" />
+        <Slider value={40} aria-labelledby="a11y-test" />
       </>,
     )
     expect(await axe(container)).toHaveNoViolations()
   })
   it('Creates a simple slider when providing a number as value', () => {
-    render(<Slider value={0} ariaLabelledby="test-one" />)
+    render(<Slider value={0} aria-labelledby="test-one" />)
     const input = screen.getByRole('slider')
 
     expect(input).toBeDefined()
   })
   it('Sets the aria label', () => {
-    render(<Slider value={5} ariaLabelledby="test-label" />)
+    render(<Slider value={5} aria-labelledby="test-label" />)
     const input = screen.getByRole('slider')
     expect(input).toHaveAttribute('aria-labelledby', 'test-label')
   })
@@ -72,7 +72,7 @@ describe('Simple slider', () => {
         min={4}
         max={10}
         step={2}
-        ariaLabelledby="test-minmax"
+        aria-labelledby="test-minmax"
       />,
     )
     const input = screen.getByRole('slider')
@@ -83,7 +83,7 @@ describe('Simple slider', () => {
   it('Updates output according to value change', () => {
     const handleChange = jest.fn()
     render(
-      <Slider value={5} ariaLabelledby="test-value" onChange={handleChange} />,
+      <Slider value={5} aria-labelledby="test-value" onChange={handleChange} />,
     )
     const input = screen.getByRole('slider')
     const outputValue = screen.getByRole('status')
@@ -96,7 +96,7 @@ describe('Simple slider', () => {
     render(
       <DateSlider
         value={getUnixTime('2020-01-01')}
-        ariaLabelledby="date-test"
+        aria-labelledby="date-test"
       />,
     )
     const input = screen.getByRole('slider')
@@ -107,7 +107,7 @@ describe('Simple slider', () => {
   })
   it('Has minimum and maximum values as default', () => {
     const { container } = render(
-      <Slider value={5} ariaLabelledby="test-default" min={0} max={100} />,
+      <Slider value={5} aria-labelledby="test-default" min={0} max={100} />,
     )
     expect(container).toHaveTextContent('0')
     expect(container).toHaveTextContent('100')
@@ -116,7 +116,7 @@ describe('Simple slider', () => {
     const { container } = render(
       <Slider
         value={5}
-        ariaLabelledby="test-default-off"
+        aria-labelledby="test-default-off"
         min={0}
         max={100}
         minMaxValues={false}
@@ -129,7 +129,7 @@ describe('Simple slider', () => {
 
 describe('Range slider', () => {
   it('Creates a range slider when providing an array as value', () => {
-    render(<Slider value={[0, 20]} ariaLabelledby="test-array" />)
+    render(<Slider value={[0, 20]} aria-labelledby="test-array" />)
     const inputs = screen.queryAllByRole('slider')
     expect(inputs).toHaveLength(2)
   })
@@ -140,7 +140,7 @@ describe('Range slider', () => {
         min={4}
         max={10}
         step={2}
-        ariaLabelledby="test-range-minmax"
+        aria-labelledby="test-range-minmax"
       />,
     )
     const input = screen.getAllByRole('slider')[1]
@@ -152,7 +152,11 @@ describe('Range slider', () => {
     const handleChange = jest.fn()
     const ariaId = 'test-rangechange'
     render(
-      <Slider value={[3, 6]} ariaLabelledby={ariaId} onChange={handleChange} />,
+      <Slider
+        value={[3, 6]}
+        aria-labelledby={ariaId}
+        onChange={handleChange}
+      />,
     )
 
     const inputA = screen.getAllByRole('slider')[0]
@@ -174,7 +178,7 @@ describe('Range slider', () => {
     render(
       <DateSlider
         value={[getUnixTime('2020-01-01'), getUnixTime('2020-01-31')]}
-        ariaLabelledby={ariaId}
+        aria-labelledby={ariaId}
       />,
     )
     const inputA = screen.getAllByRole('slider')[0]
@@ -191,7 +195,7 @@ describe('Range slider', () => {
   })
 
   it('Sets the aria label', () => {
-    render(<Slider value={[2, 4]} ariaLabelledby="test-rangelabel" />)
+    render(<Slider value={[2, 4]} aria-labelledby="test-rangelabel" />)
     const wrapper = screen.getByRole('group')
     expect(wrapper).toHaveAttribute('aria-labelledby', 'test-rangelabel')
   })
@@ -199,7 +203,7 @@ describe('Range slider', () => {
     const { container } = render(
       <Slider
         value={[2, 4]}
-        ariaLabelledby="test-rangedefault"
+        aria-labelledby="test-rangedefault"
         min={0}
         max={100}
       />,
@@ -211,7 +215,7 @@ describe('Range slider', () => {
     const { container } = render(
       <Slider
         value={[2, 4]}
-        ariaLabelledby="test-range-minmaxoff"
+        aria-labelledby="test-range-minmaxoff"
         min={0}
         max={100}
         minMaxValues={false}

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -13,7 +13,7 @@ import { slider as tokens } from './Slider.tokens'
 import { MinMax } from './MinMax'
 import { Output } from './Output'
 import { SliderInput } from './SliderInput'
-import { bordersTemplate } from '@equinor/eds-utils'
+import { bordersTemplate, useId } from '@equinor/eds-utils'
 
 const {
   entities: { track, handle, dot },
@@ -296,15 +296,14 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     }
   }
 
-  const inputIdA = `${ariaLabelledby}-thumb-a`
-  const inputIdB = `${ariaLabelledby}-thumb-b`
-  const inputId = `${ariaLabelledby}-thumb`
+  const inputIdA = useId(null, 'inputA')
+  const inputIdB = useId(null, 'inputB')
+  const inputId = useId(null, 'thumb')
 
   return (
     <>
       {isRangeSlider ? (
         <RangeWrapper
-          {...rest}
           ref={ref}
           role="group"
           aria-labelledby={ariaLabelledby}
@@ -318,11 +317,15 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           {minMaxDots && <WrapperGroupLabelDots />}
           <SrOnlyLabel htmlFor={inputIdA}>Value A</SrOnlyLabel>
           <SliderInput
+            {...rest}
             type="range"
             ref={minRange}
             value={sliderValue[0]}
             max={max}
             min={min}
+            aria-valuemax={max}
+            aria-valuemin={min}
+            aria-valuenow={sliderValue[0]}
             id={inputIdA}
             step={step}
             onChange={(event) => {
@@ -338,10 +341,14 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           {minMaxValues && <MinMax>{getFormattedText(min)}</MinMax>}
           <SrOnlyLabel htmlFor={inputIdB}>Value B</SrOnlyLabel>
           <SliderInput
+            {...rest}
             type="range"
             value={sliderValue[1]}
             min={min}
             max={max}
+            aria-valuemax={max}
+            aria-valuemin={min}
+            aria-valuenow={sliderValue[1]}
             id={inputIdB}
             step={step}
             ref={maxRange}
@@ -359,7 +366,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
         </RangeWrapper>
       ) : (
         <Wrapper
-          {...rest}
           ref={ref}
           max={max}
           min={min}
@@ -367,10 +373,14 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           disabled={disabled}
         >
           <SliderInput
+            {...rest}
             type="range"
             value={sliderValue[0]}
             min={min}
             max={max}
+            aria-valuemax={max}
+            aria-valuemin={min}
+            aria-valuenow={sliderValue[0]}
             step={step}
             id={inputId}
             onChange={(event) => {

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -300,8 +300,8 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
   let inputIdA = useId(null, 'inputA')
   let inputIdB = useId(null, 'inputB')
   let inputId = useId(null, 'thumb')
-  const overrideId = rest['id'] ? rest['id'] : null
-  if (overrideId) {
+  if (rest['id']) {
+    const overrideId = rest['id']
     inputIdA = `${overrideId}-thumb-a`
     inputIdB = `${overrideId}-thumb-b`
     inputId = `${overrideId}-thumb`

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -326,6 +326,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
             aria-valuemax={max}
             aria-valuemin={min}
             aria-valuenow={sliderValue[0]}
+            aria-valuetext={getFormattedText(sliderValue[0]).toString()}
             id={inputIdA}
             step={step}
             onChange={(event) => {
@@ -349,6 +350,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
             aria-valuemax={max}
             aria-valuemin={min}
             aria-valuenow={sliderValue[1]}
+            aria-valuetext={getFormattedText(sliderValue[1]).toString()}
             id={inputIdB}
             step={step}
             ref={maxRange}
@@ -381,6 +383,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
             aria-valuemax={max}
             aria-valuemin={min}
             aria-valuenow={sliderValue[0]}
+            aria-valuetext={getFormattedText(sliderValue[0]).toString()}
             step={step}
             id={inputId}
             onChange={(event) => {

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -164,8 +164,8 @@ const SrOnlyLabel = styled.label`
 `
 
 export type SliderProps = {
-  /** Id for the elements that labels this slider */
-  ariaLabelledby: string
+  /** Id for the elements that labels this slider (NOTE: will be deprecated and removed in a future version of EDS, please use the native aria-labelledby instead) */
+  ariaLabelledby?: string
   /** Components value, range of numbers */
   value: number[] | number
   /** Function to be called when value change */
@@ -207,6 +207,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     step = 1,
     disabled,
     ariaLabelledby,
+    'aria-labelledby': ariaLabelledbyNative,
     ...rest
   },
   ref,
@@ -300,13 +301,25 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
   const inputIdB = useId(null, 'inputB')
   const inputId = useId(null, 'thumb')
 
+  const getAriaLabelledby = () => {
+    if (ariaLabelledbyNative) return ariaLabelledbyNative
+    if (ariaLabelledby) {
+      console.warn(
+        'Slider: The "ariaLabelledby" prop is deprecated and will be removed in a future version of EDS, please use the native "aria-labelledby" instead',
+      )
+      return ariaLabelledby
+    }
+    return null
+  }
+
   return (
     <>
       {isRangeSlider ? (
         <RangeWrapper
+          {...rest}
           ref={ref}
           role="group"
-          aria-labelledby={ariaLabelledby}
+          aria-labelledby={getAriaLabelledby()}
           valA={sliderValue[0]}
           valB={sliderValue[1]}
           max={max}
@@ -317,7 +330,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           {minMaxDots && <WrapperGroupLabelDots />}
           <SrOnlyLabel htmlFor={inputIdA}>Value A</SrOnlyLabel>
           <SliderInput
-            {...rest}
             type="range"
             ref={minRange}
             value={sliderValue[0]}
@@ -342,7 +354,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           {minMaxValues && <MinMax>{getFormattedText(min)}</MinMax>}
           <SrOnlyLabel htmlFor={inputIdB}>Value B</SrOnlyLabel>
           <SliderInput
-            {...rest}
             type="range"
             value={sliderValue[1]}
             min={min}
@@ -368,6 +379,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
         </RangeWrapper>
       ) : (
         <Wrapper
+          {...rest}
           ref={ref}
           max={max}
           min={min}
@@ -375,7 +387,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
           disabled={disabled}
         >
           <SliderInput
-            {...rest}
             type="range"
             value={sliderValue[0]}
             min={min}
@@ -390,7 +401,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
               onValueChange(event)
             }}
             disabled={disabled}
-            aria-labelledby={ariaLabelledby}
+            aria-labelledby={getAriaLabelledby()}
             onMouseUp={(event) => handleCommitedValue(event)}
             onKeyUp={(event) => handleKeyUp(event)}
           />

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -297,9 +297,15 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     }
   }
 
-  const inputIdA = useId(null, 'inputA')
-  const inputIdB = useId(null, 'inputB')
-  const inputId = useId(null, 'thumb')
+  let inputIdA = useId(null, 'inputA')
+  let inputIdB = useId(null, 'inputB')
+  let inputId = useId(null, 'thumb')
+  const overrideId = rest['id'] ? rest['id'] : null
+  if (overrideId) {
+    inputIdA = `${overrideId}-thumb-a`
+    inputIdB = `${overrideId}-thumb-b`
+    inputId = `${overrideId}-thumb`
+  }
 
   const getAriaLabelledby = () => {
     if (ariaLabelledbyNative) return ariaLabelledbyNative

--- a/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -4,14 +4,19 @@ exports[`Simple slider Matches snapshot 1`] = `
 <DocumentFragment>
   <div
     class="Slider__Wrapper-sc-n1grrg-1 jxDwAm"
+    id="test"
     max="100"
     min="0"
     value="0"
   >
     <input
       aria-labelledby="test-one"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="0"
+      aria-valuetext="0"
       class="SliderInput__StyledSliderInput-sc-17orw4f-0 hPHsSm"
-      id="test-one-thumb"
+      id="test-thumb"
       max="100"
       min="0"
       step="1"
@@ -20,7 +25,7 @@ exports[`Simple slider Matches snapshot 1`] = `
     />
     <output
       class="Output__StyledOutput-sc-1dy945x-0 ebnTLx"
-      for="test-one-thumb"
+      for="test-thumb"
       value="0"
     >
       0


### PR DESCRIPTION
resolves #2167 

- Added` aria-valuemin/max/now` (handled internally since these should be same as min/max/value anyway)
- Internally  set `aria-valuetext` with `getFormattedText`, which returns the return of `outputFunction`-prop, or raw value
- use `useId` instead of `ariaLabelledby` to construct internal ids
- Made `ariaLabelledby` optional with a deprecation warning log if used, and added support for native `aria-labelledby`
