### PR TITLE
💄Card: changed to flex column, removed height, actions pushed down

### DIFF
--- a/packages/eds-core-react/src/components/Card/Card.stories.tsx
+++ b/packages/eds-core-react/src/components/Card/Card.stories.tsx
@@ -31,6 +31,7 @@ const Wrapper = styled.div`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: repeat(2, 320px);
+  align-items: start;
   grid-gap: 32px 32px;
   background: #ebebeb;
 `
@@ -361,37 +362,44 @@ export const WithActions: Story<CardProps> = () => (
 )
 WithActions.storyName = 'With actions'
 
-export const WithDivider: Story<CardProps> = () => (
-  <Wrapper>
-    <Card>
-      <Card.Header>
-        <Card.HeaderTitle>
-          <Typography variant="h4">TICKET</Typography>
-        </Card.HeaderTitle>
-        <Typography variant="h6">20.02.2020</Typography>
-      </Card.Header>
-      <Card.Content>
-        <Typography variant="h5">Title</Typography>
-        <Typography variant="body_short">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </Typography>
-        <Divider style={{ width: '100%' }} />
-      </Card.Content>
-      <Card.Content>
-        <Typography variant="caption">Choose option</Typography>
-      </Card.Content>
-      <Card.Actions>
-        <Chip>active</Chip>
-        <Chip variant="active">pause</Chip>
-        <Chip>disable</Chip>
-        <Chip variant="error">stop</Chip>
-      </Card.Actions>
-      <Card.Actions>
-        <Button style={{ marginTop: '16px' }} variant="outlined">
-          SUBMIT TICKET
-        </Button>
-      </Card.Actions>
-    </Card>
-  </Wrapper>
-)
+export const WithDivider: Story<CardProps> = () => {
+  const Row = styled.div`
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+  `
+  return (
+    <Wrapper>
+      <Card>
+        <Card.Header>
+          <Card.HeaderTitle>
+            <Typography variant="h4">TICKET</Typography>
+          </Card.HeaderTitle>
+          <Typography variant="h6">20.02.2020</Typography>
+        </Card.Header>
+        <Card.Content>
+          <Typography variant="h5">Title</Typography>
+          <Typography variant="body_short">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </Typography>
+          <Divider style={{ width: '100%' }} />
+        </Card.Content>
+        <Card.Content>
+          <Typography variant="caption">Choose option</Typography>
+          <Row>
+            <Chip>active</Chip>
+            <Chip variant="active">pause</Chip>
+            <Chip>disable</Chip>
+            <Chip variant="error">stop</Chip>
+          </Row>
+        </Card.Content>
+        <Card.Actions>
+          <Button style={{ marginTop: '16px' }} variant="outlined">
+            SUBMIT TICKET
+          </Button>
+        </Card.Actions>
+      </Card>
+    </Wrapper>
+  )
+}
 WithDivider.storyName = 'With divider'

--- a/packages/eds-core-react/src/components/Card/Card.tsx
+++ b/packages/eds-core-react/src/components/Card/Card.tsx
@@ -16,16 +16,13 @@ export type CardProps = {
 } & HTMLAttributes<HTMLDivElement>
 
 const StyledCard = styled.div<StyledCardProps>`
-  height: fit-content;
   width: 100%;
   position: relative;
   background-color: ${({ background }) => background};
   box-sizing: border-box;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   grid-gap: 16px;
-  grid-auto-columns: auto;
-  align-items: center;
-  align-content: start;
   cursor: ${({ cursor }) => cursor};
   ${bordersTemplate(primary.border)};
 `

--- a/packages/eds-core-react/src/components/Card/CardActions.tsx
+++ b/packages/eds-core-react/src/components/Card/CardActions.tsx
@@ -20,6 +20,7 @@ const StyledCardActions = styled.div<Pick<CSSObject, 'justifyContent'>>`
   align-items: center;
   justify-content: ${({ justifyContent }) => justifyContent};
   padding: 0 ${spacings.right} 0 ${spacings.left};
+  margin-top: auto;
   :first-child {
     padding-top: ${spacings.top};
   }

--- a/packages/eds-core-react/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -27,23 +27,18 @@ exports[`Card Matches snapshot 1`] = `
 }
 
 .c0 {
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   width: 100%;
   position: relative;
   background-color: var(--eds_ui_background__default,rgba(255,255,255,1));
   box-sizing: border-box;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   grid-gap: 16px;
-  grid-auto-columns: auto;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-align-content: start;
-  -ms-flex-line-pack: start;
-  align-content: start;
   cursor: default;
   border-radius: 4px;
 }


### PR DESCRIPTION
resolves #2248 

Card can now be stretched when in a grid, this was not possible before due to height: fit-content. 
Card is now a flex column, with margin-top: auto on card.actions to push it down in the case where card is stretched. This means having multiple actions will kind of break the layout by evenly spacing the actions though, so users should have only one actions at the bottom (and just make a new styled div for rows inside content)