### PR TITLE
🔖 Release eds-core-react@0.20.0 & eds-utils@0.2.2

### DIFF
--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -11,10 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New component! 🎉 `Autocomplete` has been moved from our labs to core! ([#2201](https://github.com/equinor/design-system/pull/2201))
 
+### Changed
+
+- Improved `Progress` legibility ([#2182](https://github.com/equinor/design-system/pull/2182))
+- `Card` is now less opinonated making it easier to use inside flex/grid containers ([#2273](https://github.com/equinor/design-system/pull/2273))
+
 ### Deprecated
 
 - `MultiSelect` has been deprecated in favour of `<Autocomplete multiple />`. ([#1537](https://github.com/equinor/design-system/pull/1537))
 - `SingleSelect` has been deprecated in favour of `<Autocomplete />`. ([#1537](https://github.com/equinor/design-system/pull/1537))
+
+### Fixed
+
+- `Table.Cell` height should now be correct in `Table.Head` ([#2197](https://github.com/equinor/design-system/pull/2197))
+- `Tabs` should no longer throw error if `onChange` is not defined ([#2196](https://github.com/equinor/design-system/pull/2196))
+- `Popover` should now have correct typings for `onClose` ([#2264](https://github.com/equinor/design-system/pull/2264))
+- `Search` should no longer display blue background on Chrome when `autocomplete` is defined ([#2160](https://github.com/equinor/design-system/pull/2160))
 
 ## [0.19.0] - 2022-04-06
 

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New component! 🎉 `Autocomplete` has been moved from our labs to core! ([#2201](https://github.com/equinor/design-system/pull/2201))
+  - This is a new component based on feedback from `MultiSelect` & `SingleSelect` aimed resolving their shortcomings, complexity and improve further development
 
 ### Changed
 
 - Improved `Progress` legibility ([#2182](https://github.com/equinor/design-system/pull/2182))
 - `Card` is now less opinonated making it easier to use inside flex/grid containers ([#2273](https://github.com/equinor/design-system/pull/2273))
+- Upgraded dev dependencies, fixed missing types in Slider & removed `Menu.Item` memo as it was not working as intended ([#2183](https://github.com/equinor/design-system/pull/2183))
 
 ### Deprecated
 

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2022-06-08
+
+### Added
+
+- New component! 🎉 `Autocomplete` has been moved from our labs to core! ([#2201](https://github.com/equinor/design-system/pull/2201))
+
+### Deprecated
+
+- `MultiSelect` has been deprecated in favour of `<Autocomplete multiple />`. ([#1537](https://github.com/equinor/design-system/pull/1537))
+- `SingleSelect` has been deprecated in favour of `<Autocomplete />`. ([#1537](https://github.com/equinor/design-system/pull/1537))
+
 ## [0.19.0] - 2022-04-06
 
 ### Added

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.19.0-dev.202205096",
+  "version": "0.20.0",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-core-react/src/components/Select/MultiSelect/MultiSelect.tsx
+++ b/packages/eds-core-react/src/components/Select/MultiSelect/MultiSelect.tsx
@@ -54,6 +54,7 @@ export type MultiSelectProps = {
   ) => void
 } & SelectHTMLAttributes<HTMLSelectElement>
 
+/** @deprecated Use `<Autocomplete multiple />` instead. */
 export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
   function MultiSelect(
     {

--- a/packages/eds-core-react/src/components/Select/SingleSelect/SingleSelect.tsx
+++ b/packages/eds-core-react/src/components/Select/SingleSelect/SingleSelect.tsx
@@ -47,6 +47,7 @@ export type SingleSelectProps = {
 const PaddedStyledListItem = styled(StyledListItem)`
   ${({ theme }) => spacingsTemplate(theme.spacings)}
 `
+/** @deprecated Use `<Autocomplete />` instead */
 
 export const SingleSelect = forwardRef<HTMLDivElement, SingleSelectProps>(
   function SingleSelect(

--- a/packages/eds-utils/CHANGELOG.md
+++ b/packages/eds-utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2022-06-08
+
+### Changed
+
+- Upgraded dev dependencies & fixed missing types([#2183](https://github.com/equinor/design-system/pull/2183))
+
 ## [0.2.1] - 2022-04-06
 
 ### Changed

--- a/packages/eds-utils/package.json
+++ b/packages/eds-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-utils",
-  "version": "0.2.1-dev.202205096",
+  "version": "0.2.2",
   "description": "Utility functions and hooks for the Equinor Design System",
   "sideEffects": false,
   "main": "dist/eds-utils.cjs.js",


### PR DESCRIPTION
#2238

IDE preview of deprecated components 

![image](https://user-images.githubusercontent.com/1070981/172579190-6835e127-d2bc-41be-84e9-194d2cf0821e.png)


# eds-core-react

## [0.20.0] - 2022-06-08

### Added

- New component! 🎉 `Autocomplete` has been moved from our labs to core! ([#2201](https://github.com/equinor/design-system/pull/2201))
  - This is a new component based on feedback from `MultiSelect` & `SingleSelect` aimed resolving their shortcomings, complexity and improve further development

### Changed

- Improved `Progress` legibility ([#2182](https://github.com/equinor/design-system/pull/2182))
- `Card` is now less opinonated making it easier to use inside flex/grid containers ([#2273](https://github.com/equinor/design-system/pull/2273))
- Upgraded dev dependencies, fixed missing types in Slider & removed `Menu.Item` memo as it was not working as intended ([#2183](https://github.com/equinor/design-system/pull/2183))

### Deprecated

- `MultiSelect` has been deprecated in favour of `<Autocomplete multiple />`. ([#1537](https://github.com/equinor/design-system/pull/1537))
- `SingleSelect` has been deprecated in favour of `<Autocomplete />`. ([#1537](https://github.com/equinor/design-system/pull/1537))

### Fixed

- `Table.Cell` height should now be correct in `Table.Head` ([#2197](https://github.com/equinor/design-system/pull/2197))
- `Tabs` should no longer throw error if `onChange` is not defined ([#2196](https://github.com/equinor/design-system/pull/2196))
- `Popover` should now have correct typings for `onClose` ([#2264](https://github.com/equinor/design-system/pull/2264))
- `Search` should no longer display blue background on Chrome when `autocomplete` is defined ([#2160](https://github.com/equinor/design-system/pull/2160))

# eds-utils


## [0.2.2] - 2022-06-08

### Changed

- Upgraded dev dependencies & fixed missing types([#2183](https://github.com/equinor/design-system/pull/2183))