### PR TITLE
🔖  Release eds-tokens@0.7.1

### DIFF
--- a/packages/eds-tokens/CHANGELOG.md
+++ b/packages/eds-tokens/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2022-06-09
+
+### Changed
+
+- Upgraded dev dependencies([#2183](https://github.com/equinor/design-system/pull/2183))
+
 ## [0.7.0] - 2021-09-30
 
 ### Added

--- a/packages/eds-tokens/package.json
+++ b/packages/eds-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-tokens",
-  "version": "0.7.0-dev.202205096",
+  "version": "0.7.1",
   "description": "Design tokens for the Equinor Design System",
   "main": "dist/tokens.cjs.js",
   "module": "dist/tokens.esm.js",


### PR DESCRIPTION
resolves #2238 

## [0.7.1] - 2022-06-09

### Changed

- Upgraded dev dependencies([#2183](https://github.com/equinor/design-system/pull/2183))