### PR TITLE
Fix three issues with the lab DatePicker component

### DIFF
--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tokens.ts
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tokens.ts
@@ -10,6 +10,9 @@ const {
     navigation: { menu_title, button },
   },
   colors: {
+    text: {
+      static_icons__tertiary: { rgba: iconTertiary },
+    },
     interactive: {
       primary__resting: { rgba: focusColor },
     },
@@ -30,6 +33,7 @@ export interface DatePickerToken extends ComponentToken {
   colors: {
     green13: string
     green100: string
+    iconGray: string
   }
 }
 
@@ -39,6 +43,7 @@ export const datePicker: DatePickerToken = {
   colors: {
     green13: primary13,
     green100: primary100,
+    iconGray: iconTertiary,
   },
   border: {
     type: 'border',

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -3,6 +3,8 @@ import {
   useCallback,
   forwardRef,
   InputHTMLAttributes,
+  useRef,
+  useImperativeHandle,
   useEffect,
 } from 'react'
 import DatePicker, { registerLocale } from 'react-datepicker'
@@ -86,13 +88,16 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
       onDateValueChange(dateValue)
     }, [dateValue])
 
+    const localRef = useRef<any>()
+    useImperativeHandle(ref, () => localRef.current)
+
     return (
       <ThemeProvider theme={tokens}>
         <Container className={`date-picker ${className}`}>
           <DateLabel htmlFor={id} className={`date-label`}>
             <span>{label}</span>
             <StyledDatepicker
-              ref={ref}
+              ref={localRef}
               locale={locale}
               selected={date}
               className="eds-datepicker"
@@ -101,6 +106,17 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
               dateFormat={dateFormat}
               placeholderText={placeholder}
               id={id}
+              onKeyDown={(event) => {
+                // If you shift-tab while focusing the input-element, it should close the pop-over.
+                // Not currently supported by react-datepicker.
+                if (
+                  event.code === 'Tab' &&
+                  event.shiftKey &&
+                  (event.target as HTMLElement).nodeName == 'INPUT'
+                ) {
+                  localRef?.current?.setOpen(false)
+                }
+              }}
               filterDate={(date: Date): boolean => {
                 if (disableFuture) {
                   return new Date() > date

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -229,6 +229,7 @@ const DateLabel = styled.label`
 
     span {
       padding-left: 8px;
+      color: ${tokens.colors.iconGray};
     }
   `}
 `

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,10 @@
-import { useState, useCallback, forwardRef, InputHTMLAttributes } from 'react'
+import {
+  useState,
+  useCallback,
+  forwardRef,
+  InputHTMLAttributes,
+  useEffect,
+} from 'react'
 import DatePicker, { registerLocale } from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import enGb from 'date-fns/locale/en-GB'
@@ -75,6 +81,10 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
       },
       [onChanged],
     )
+
+    useEffect(() => {
+      onDateValueChange(dateValue)
+    }, [dateValue])
 
     return (
       <ThemeProvider theme={tokens}>

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -120,6 +120,7 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
             <CalendarIcon
               name="calendar"
               className="calendar-icon"
+              color={tokens.colors.iconGray}
               data={calendar}
               size={24}
             />
@@ -229,17 +230,11 @@ const StyledDatepicker = styled(DatePicker)`
 `
 
 const CalendarIcon = styled(Icon)`
-  ${({ theme }) =>
-    css`
-      position: absolute;
-      z-index: 1;
-      width: 24px;
-      height: 24px;
-      top: 21px;
-      right: 6px;
-      color: ${theme.entities.title.typography.color};
-      cursor: pointer;
-    `}
+  position: absolute;
+  z-index: 1;
+  top: 21px;
+  right: 6px;
+  cursor: pointer;
 `
 
 export { ReactDatePicker as DatePicker }


### PR DESCRIPTION
This PR solves/addresses three issues found in the DatePicker component in eds-lab-react. 

1. It is currently not possible to close the pop-over of the DatePicker by shift-tabbing away. Focus is moved away from the input field, but the pop-over stays. In forms with multiple DatePickers in a row, this might lead to multiple DatePickers being open at the same time. Fixed by using a ref to the 3rd-party-component, and running its `setOpen(false)`-function. Commit: ccacbf2
2. It is currently not possible to update the component's value from the outside of the component, as the component's value is currently initialized from the prop's value, then the prop is never read from again. This PR addresses this by adding a `useEffect` which updates the internal value whenever the external value is updated. Commit: c70a44d.
3. The color of the label and the calendar icon were too dark, compared to how they are designed in [EDS - Date/time picker](https://eds.equinor.com/0b0c666ab/p/07b531-datetime-picker/b/86826a). This is now updated, and passed directly to the component instead of unnecessarily overriding CSS (for the icon). Commits: 7f38785, 661ef2f, 2992a3d.