### PR TITLE
🔧 Dedicated tsconfig for build w exclude paths

### DIFF
--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -29,7 +29,7 @@
     "dist/*"
   ],
   "scripts": {
-    "build": "rollup -c && tsc -p tsconfig.json",
+    "build": "rollup -c && tsc -p tsconfig.build.json",
     "test": "tsc -p tsconfig.test.json && jest",
     "test:watch": "tsc-watch -p tsconfig.test.json --onFirstSuccess  \"jest --watch\"",
     "test:update-snapshots": "jest --updateSnapshot",

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -35,7 +35,7 @@
     "test:update-snapshots": "jest --updateSnapshot",
     "storybook": "start-storybook -p 9000 --ci",
     "build:storybook": "build-storybook -o storybook-build",
-    "types": "tsc"
+    "types": "tsc -p tsconfig.build.json"
   },
   "keywords": [
     "eds",

--- a/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { action } from '@storybook/addon-actions'
-import styled from 'styled-components'
 import {
   Menu,
   MenuProps,

--- a/packages/eds-core-react/tsconfig.build.json
+++ b/packages/eds-core-react/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/**/*.stories.ts*",
+    "src/**/*.test.ts*",
+    "src/stories",
+  ]
+}

--- a/packages/eds-core-react/tsconfig.json
+++ b/packages/eds-core-react/tsconfig.json
@@ -12,9 +12,6 @@
   "include": ["./src/**/*"],
   "exclude": [
     "node_modules",
-    "src/**/*.stories.ts*",
-    "src/**/*.test.ts*",
-    "src/stories",
     "src/test"
   ]
 }

--- a/packages/eds-core-react/tsconfig.json
+++ b/packages/eds-core-react/tsconfig.json
@@ -10,8 +10,5 @@
     "baseUrl": "."
   },
   "include": ["./src/**/*"],
-  "exclude": [
-    "node_modules",
-    "src/test"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/packages/eds-lab-react/package.json
+++ b/packages/eds-lab-react/package.json
@@ -29,13 +29,13 @@
     "dist/*"
   ],
   "scripts": {
-    "build": "rollup -c && tsc -p tsconfig.json",
+    "build": "rollup -c && tsc -p tsconfig.build.json",
     "test": "tsc -p tsconfig.test.json && jest",
     "test:watch": "tsc-watch -p tsconfig.test.json --onFirstSuccess  \"jest --watch\"",
     "test:update-snapshots": "jest --updateSnapshot",
     "storybook": "start-storybook -p 9000 --ci",
     "build:storybook": "build-storybook -o storybook-build",
-    "types": "tsc"
+    "types": "tsc -p tsconfig.build.json"
   },
   "keywords": [
     "eds",

--- a/packages/eds-lab-react/tsconfig.build.json
+++ b/packages/eds-lab-react/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/**/*.stories.ts*",
+    "src/**/*.test.ts*",
+    "src/stories",
+  ]
+}

--- a/packages/eds-lab-react/tsconfig.json
+++ b/packages/eds-lab-react/tsconfig.json
@@ -10,11 +10,5 @@
     "baseUrl": "."
   },
   "include": ["./src/**/*"],
-  "exclude": [
-    "node_modules",
-    "src/**/*.stories.ts*",
-    "src/**/*.test.ts*",
-    "src/stories",
-    "src/test"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/packages/eds-utils/package.json
+++ b/packages/eds-utils/package.json
@@ -27,10 +27,10 @@
     "dist/*"
   ],
   "scripts": {
-    "build": "rollup -c && tsc -p tsconfig.json",
+    "build": "rollup -c && tsc -p tsconfig.build.json",
     "test": "tsc -p tsconfig.test.json && jest",
     "test:watch": "tsc-watch -p tsconfig.test.json --onFirstSuccess  \"jest --watch\"",
-    "types": "tsc"
+    "types": "tsc -p tsconfig.build.json"
   },
   "keywords": [
     "eds",

--- a/packages/eds-utils/tsconfig.build.json
+++ b/packages/eds-utils/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/**/*.test.ts*",
+    "src/stories",
+    "src/test"
+  ]
+}

--- a/packages/eds-utils/tsconfig.json
+++ b/packages/eds-utils/tsconfig.json
@@ -10,5 +10,5 @@
     "baseUrl": "."
   },
   "include": ["./src/**/*"],
-  "exclude": ["node_modules", "src/**/*.test.ts*", "src/test"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
resolves #2318 

Seems like this also finally fixed the mdx import problem in stories.
Build output is identical to before with these changes, but now vscode uses tsconfig when evaluation stories and test files 