### PR TITLE
✨ Added `contained_icon` variant to Button

### DIFF
--- a/packages/eds-core-react/src/components/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/Button/Button.docs.mdx
@@ -35,8 +35,9 @@ The `Button` come with four variants; `contained`, `outlined`, `ghost` and `ghos
 
 ### Icon button
 
-The `ghost_icon` variant is meant for standalone icon buttons using the `<Icon>` component.
-<Story id="inputs-button--ghost-icon" />
+The `ghost_icon` & `contained_icon`variant is meant for standalone icon buttons using the `<Icon>` component.  
+Make sure to defined `aria-label` with descriptive text of `Button` interaction.
+<Story id="inputs-button--icon-button" />
 
 ### Color
 <Story id="inputs-button--color"/>

--- a/packages/eds-core-react/src/components/Button/Button.stories.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '../..'
 import styled from 'styled-components'
 import { Story, ComponentMeta } from '@storybook/react'
-import { menu } from '@equinor/eds-icons'
+import { menu, add, save } from '@equinor/eds-icons'
 import { Stack as SBStack } from './../../../.storybook/components'
 // import { Group } from '../Group'
 import page from './Button.docs.mdx'
@@ -58,31 +58,46 @@ Introduction.args = {
 export const Basic: Story<ButtonProps> = () => (
   <Stack>
     <Button>Contained</Button>
+    <Button variant="contained_icon" aria-label="add action">
+      <Icon data={add}></Icon>
+    </Button>
     <Button variant="outlined">Outlined</Button>
     <Button variant="ghost">Ghost</Button>
-    <Button variant="ghost_icon">
-      <Icon name="save" title="save action"></Icon>
+    <Button variant="ghost_icon" aria-label="save action">
+      <Icon data={save}></Icon>
     </Button>
   </Stack>
 )
 
-export const GhostIcon: Story<ButtonProps> = () => (
+export const IconButton: Story<ButtonProps> = () => (
   <Stack>
-    <Button variant="ghost_icon">
-      <Icon name="save" title="save action"></Icon>
+    <Button variant="ghost_icon" aria-label="save action">
+      <Icon data={save}></Icon>
     </Button>
-    <Button variant="ghost_icon" color="secondary">
-      <Icon name="save" title="save"></Icon>
+    <Button variant="ghost_icon" color="secondary" aria-label="save action">
+      <Icon data={save}></Icon>
     </Button>
-    <Button variant="ghost_icon" color="danger">
-      <Icon name="save" title="save"></Icon>
+    <Button variant="ghost_icon" color="danger" aria-label="save action">
+      <Icon data={save}></Icon>
     </Button>
-    <Button variant="ghost_icon" disabled>
-      <Icon name="save" title="save"></Icon>
+    <Button variant="ghost_icon" disabled aria-label="save action">
+      <Icon data={save}></Icon>
+    </Button>
+    <Button variant="contained_icon" aria-label="add action">
+      <Icon data={add}></Icon>
+    </Button>
+    <Button variant="contained_icon" color="secondary" aria-label="add action">
+      <Icon data={add}></Icon>
+    </Button>
+    <Button variant="contained_icon" color="danger" aria-label="add action">
+      <Icon data={add}></Icon>
+    </Button>
+    <Button variant="contained_icon" disabled aria-label="add action">
+      <Icon data={add}></Icon>
     </Button>
   </Stack>
 )
-GhostIcon.storyName = 'Ghost icon'
+IconButton.storyName = 'Ghost icon'
 
 export const Color: Story<ButtonProps> = () => (
   <Stack>
@@ -159,17 +174,29 @@ export const All: Story<ButtonProps> = () => (
     <Button variant="ghost" disabled>
       Disabled
     </Button>
-    <Button variant="ghost_icon">
+    <Button variant="ghost_icon" aria-label="save action">
       <Icon name="save" title="save action"></Icon>
     </Button>
-    <Button variant="ghost_icon" color="secondary">
-      <Icon name="save" title="save"></Icon>
+    <Button variant="ghost_icon" color="secondary" aria-label="save action">
+      <Icon data={save}></Icon>
     </Button>
-    <Button variant="ghost_icon" color="danger">
-      <Icon name="save" title="save"></Icon>
+    <Button variant="ghost_icon" color="danger" aria-label="save action">
+      <Icon data={save}></Icon>
     </Button>
-    <Button variant="ghost_icon" disabled>
-      <Icon name="save" title="save"></Icon>
+    <Button variant="ghost_icon" disabled aria-label="save action">
+      <Icon data={save}></Icon>
+    </Button>
+    <Button variant="contained_icon" aria-label="add action">
+      <Icon data={add}></Icon>
+    </Button>
+    <Button variant="contained_icon" color="secondary" aria-label="add action">
+      <Icon data={add}></Icon>
+    </Button>
+    <Button variant="contained_icon" color="danger" aria-label="add action">
+      <Icon data={add}></Icon>
+    </Button>
+    <Button variant="contained_icon" disabled aria-label="add action">
+      <Icon data={add}></Icon>
     </Button>
   </Stack>
 )
@@ -187,31 +214,31 @@ export const FullWidth: Story<ButtonProps> = () => (
       Disabled
     </Button>
     <Button fullWidth>
-      <Icon name="save" title="save"></Icon>Primary
+      <Icon data={save}></Icon>Primary
     </Button>
     <Button color="secondary" fullWidth>
-      <Icon name="save" title="save"></Icon>Secondary
+      <Icon data={save}></Icon>Secondary
     </Button>
     <Button color="danger" fullWidth>
-      <Icon name="save" title="save"></Icon>Danger
+      <Icon data={save}></Icon>Danger
     </Button>
     <Button disabled fullWidth>
-      <Icon name="save" title="save"></Icon>Disabled
+      <Icon data={save}></Icon>Disabled
     </Button>
     <Button fullWidth>
-      Primary <Icon name="save" title="save"></Icon>
+      Primary <Icon data={save}></Icon>
     </Button>
     <Button color="secondary" fullWidth>
       Secondary
-      <Icon name="save" title="save"></Icon>
+      <Icon data={save}></Icon>
     </Button>
     <Button color="danger" fullWidth>
       Danger
-      <Icon name="save" title="save"></Icon>
+      <Icon data={save}></Icon>
     </Button>
     <Button disabled fullWidth>
       Disabled
-      <Icon name="save" title="save"></Icon>
+      <Icon data={save}></Icon>
     </Button>
   </FullWidthStack>
 )

--- a/packages/eds-core-react/src/components/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.tsx
@@ -13,7 +13,12 @@ import { InnerFullWidth } from './InnerFullWidth'
 import { useEds } from '../EdsProvider'
 
 type Colors = 'primary' | 'secondary' | 'danger'
-type Variants = 'contained' | 'outlined' | 'ghost' | 'ghost_icon'
+type Variants =
+  | 'contained'
+  | 'contained_icon'
+  | 'outlined'
+  | 'ghost'
+  | 'ghost_icon'
 
 const getVariant = (
   tokenSet: ButtonTokenSet,
@@ -26,6 +31,8 @@ const getVariant = (
       return tokenSet.ghost_icon
     case 'outlined':
       return tokenSet.outlined
+    case 'contained_icon':
+      return tokenSet.contained_icon
     case 'contained':
     default:
       return tokenSet.contained
@@ -139,9 +146,9 @@ const ButtonBase = styled.button(({ theme }: { theme: ButtonToken }) => {
 
 export type ButtonProps = {
   /**  Specifies color */
-  color?: 'primary' | 'secondary' | 'danger'
+  color?: Colors
   /** Specifies which variant to use */
-  variant?: 'contained' | 'outlined' | 'ghost' | 'ghost_icon'
+  variant?: Variants
   /**
    * URL link destination
    * If defined, an 'a' element is used as root instead of 'button'

--- a/packages/eds-core-react/src/components/Button/Button.types.ts
+++ b/packages/eds-core-react/src/components/Button/Button.types.ts
@@ -8,6 +8,7 @@ export type ButtonToken = ComponentToken & {
 
 export type ButtonTokenSet = {
   contained: ButtonToken
+  contained_icon: ButtonToken
   outlined: ButtonToken
   ghost: ButtonToken
   ghost_icon: ButtonToken

--- a/packages/eds-core-react/src/components/Button/tokens/contained_icon.ts
+++ b/packages/eds-core-react/src/components/Button/tokens/contained_icon.ts
@@ -1,0 +1,73 @@
+import { tokens } from '@equinor/eds-tokens'
+import { mergeDeepRight } from 'ramda'
+
+import {
+  primary as primaryContained,
+  secondary as secondaryContained,
+  danger as dangerContained,
+} from './contained'
+import { ButtonToken } from '../Button.types'
+
+const {
+  clickbounds: {
+    default__base: clicboundHeight,
+    compact__standard: compactClickboundHeight,
+  },
+  shape,
+} = tokens
+
+const contained_icon = {
+  height: shape.icon_button.minHeight,
+  width: shape.icon_button.minWidth,
+  border: {
+    width: '0px',
+    radius: '50%',
+  },
+  spacings: { left: '0', right: '0' },
+  clickbound: {
+    width: clicboundHeight,
+    offset: {
+      top: '0',
+      left: `${(parseInt(clicboundHeight) - parseInt('40px')) / 2}px`,
+    },
+  },
+  states: {
+    hover: {
+      border: {
+        width: '0px',
+        radius: '50%',
+      },
+    },
+  },
+  modes: {
+    compact: {
+      height: shape._modes.compact.icon_button.minHeight,
+      width: shape._modes.compact.icon_button.minWidth,
+      clickbound: {
+        width: compactClickboundHeight,
+        offset: {
+          top: '0',
+          left: `${
+            (parseInt(compactClickboundHeight) -
+              parseInt(shape._modes.compact.icon_button.minWidth)) /
+            2
+          }px`,
+        },
+      },
+    },
+  },
+}
+
+export const primary: ButtonToken = mergeDeepRight(
+  primaryContained,
+  contained_icon,
+)
+
+export const secondary: Partial<ButtonToken> = mergeDeepRight(
+  secondaryContained,
+  contained_icon,
+)
+export const danger: Partial<ButtonToken> = mergeDeepRight(
+  dangerContained,
+  contained_icon,
+)

--- a/packages/eds-core-react/src/components/Button/tokens/index.ts
+++ b/packages/eds-core-react/src/components/Button/tokens/index.ts
@@ -4,6 +4,7 @@ import * as contained from './contained'
 import * as outlined from './outlined'
 import * as ghost from './ghost'
 import * as icon from './icon'
+import * as contained_icon from './contained_icon'
 
 type ButtonTokens = {
   primary: ButtonTokenSet
@@ -17,17 +18,20 @@ export const token: ButtonTokens = {
     outlined: outlined.primary,
     ghost: ghost.primary,
     ghost_icon: icon.primary,
+    contained_icon: contained_icon.primary,
   },
   secondary: {
     contained: contained.secondary,
     outlined: outlined.secondary,
     ghost: ghost.secondary,
     ghost_icon: icon.secondary,
+    contained_icon: contained_icon.secondary,
   },
   danger: {
     contained: contained.danger,
     outlined: outlined.danger,
     ghost: ghost.danger,
     ghost_icon: icon.danger,
+    contained_icon: contained_icon.danger,
   },
 }


### PR DESCRIPTION
resolves #2340 

- Updated docs to reflect new `Button` icon variant
- Updated docs to streamline `a11y` to use `aria-label` for icon buttons instead of title on icon

The size for icon buttons ghost & contained are to big (48px vs 40px), this is due to wrong value in shape token. This will be fixed from Figma and new tokens will need to be exported to fix this.