### PR TITLE
🔖  Release eds-core-react@0.20.4

### DIFF
--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.4] - 2022-06-24
+
+### Added
+
+- 📝 App launcher documentation by @martalalik in https://github.com/equinor/design-system/pull/2303
+
+### Changed
+
+- ⬆️ Upgrade popperjs dependencies by @mimarz in https://github.com/equinor/design-system/pull/2347
+
+### Fixed
+
+- 🐛 Using Icon data should work properly if `size` is not defined by @mimarz in https://github.com/equinor/design-system/pull/2327
+- 🐛 Fixed TextField `style` prop being sent container and inner input by @mimarz in https://github.com/equinor/design-system/pull/2337
+
 ## [0.20.3] - 2022-06-20
 
 ### Added

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- 🐛 Using Icon data should work properly if `size` is not defined by @mimarz in https://github.com/equinor/design-system/pull/2327
-- 🐛 Fixed TextField `style` prop being sent container and inner input by @mimarz in https://github.com/equinor/design-system/pull/2337
+- 🐛 Using `Icon` `data` should work properly if `size` is not defined by @mimarz in https://github.com/equinor/design-system/pull/2327
+- 🐛 Fixed `TextField` `style` prop being sent container and inner input by @mimarz in https://github.com/equinor/design-system/pull/2337
+- 🐛 Fixed `Autocomplete` `onOptionsChange` when not controlled & cleaned up react hooks form example by @mimarz in https://github.com/equinor/design-system/pull/2335
 
 ## [0.20.3] - 2022-06-20
 

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 📝 App launcher documentation by @martalalik in https://github.com/equinor/design-system/pull/2303
 
-### Changed
-
-- ⬆️ Upgrade popperjs dependencies by @mimarz in https://github.com/equinor/design-system/pull/2347
-
 ### Fixed
 
 - 🐛 Using `Icon` `data` should work properly if `size` is not defined by @mimarz in https://github.com/equinor/design-system/pull/2327

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-utils/CHANGELOG.md
+++ b/packages/eds-utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2022-06-24
+
+### Changed
+
+- ⬆️ Upgrade popperjs dependencies by @mimarz in https://github.com/equinor/design-system/pull/2347
+
 ## [0.2.2] - 2022-06-08
 
 ### Changed

--- a/packages/eds-utils/package.json
+++ b/packages/eds-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-utils",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Utility functions and hooks for the Equinor Design System",
   "sideEffects": false,
   "main": "dist/eds-utils.cjs.js",


### PR DESCRIPTION
## [0.20.4] - 2022-06-24

### Added

- 📝 App launcher documentation by @martalalik in https://github.com/equinor/design-system/pull/2303

### Changed

- ⬆️ Upgrade popperjs dependencies by @mimarz in https://github.com/equinor/design-system/pull/2347

### Fixed

- 🐛 Using `Icon` `data` should work properly if `size` is not defined by @mimarz in https://github.com/equinor/design-system/pull/2327
- 🐛 Fixed `TextField` `style` prop being sent container and inner input by @mimarz in https://github.com/equinor/design-system/pull/2337
- 🐛 Fixed `Autocomplete` `onOptionsChange` when not controlled & cleaned up react hooks form example by @mimarz in https://github.com/equinor/design-system/pull/2335
