### PR TITLE
feat(autocomplete): add disable clear button prop

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -167,6 +167,8 @@ export type AutocompleteProps<T> = {
   disabled?: boolean
   /** Read Only */
   readOnly?: boolean
+  /** Hide clear button even when items are selected */
+  hideClearButton?: boolean
   /** If this prop is used, the select will become a controlled component. Use an empty
    * array [] if there will be no initial selected items
    * Note that this prop replaces the need for ```initialSelectedItems```
@@ -204,6 +206,7 @@ function AutocompleteInner<T>(
     style,
     disabled = false,
     readOnly = false,
+    hideClearButton = false,
     onOptionsChange,
     selectedOptions,
     multiple,
@@ -521,7 +524,8 @@ function AutocompleteInner<T>(
     resetCombobox()
     resetSelection()
   }
-  const showClearButton = (selectedItems.length > 0 || inputValue) && !readOnly
+  const showClearButton =
+    (selectedItems.length > 0 || inputValue) && !readOnly && !hideClearButton
 
   const selectedItemsLabels = useMemo(
     () => selectedItems.map(getLabel),


### PR DESCRIPTION
In some situations it would be preferable to hide the clear button, e.g. when a field has a default and can never be null.
This PR adds a simple hideClearButton prop that is added onto the "showClearButton" computed bool.

Resolves #2383
