### PR TITLE
♻️ menu: replace popper with floating-UI

### DIFF
--- a/packages/eds-core-react/src/components/Menu/Menu.test.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.test.tsx
@@ -73,15 +73,16 @@ describe('Menu', () => {
     })
   })
   it('Can extend the css for the component', async () => {
-    const { container } = render(
-      <StyledMenu open>
+    render(
+      <StyledMenu open data-testid="menu">
         <div>some random content</div>
       </StyledMenu>,
     )
+    const container = screen.getByTestId('menu')
 
     await waitFor(() =>
       // eslint-disable-next-line testing-library/no-node-access
-      expect(container.nextSibling).toHaveStyleRule('background', 'red'),
+      expect(container.parentElement).toHaveStyleRule('background', 'red'),
     )
   })
   it('is visible when open is true & anchorEl is set', async () => {
@@ -97,7 +98,7 @@ describe('Menu', () => {
       expect(menuPaper).toBeDefined()
     })
     await waitFor(() => {
-      expect(menuPaper).toHaveAttribute('data-popper-placement', 'right-start')
+      expect(menuPaper).not.toHaveStyleRule('visibility', 'hidden')
     })
   })
   it('has rendered Menu.Item', async () => {


### PR DESCRIPTION
resolves #2343 

further improvements can be done by letting floating-ui handle keyboard navigation and add support for nested menus with `FloatingTree` but this is a larger undertaking to be handled by separate tickets 

Like with popover, it is unclear to me why the menu is hidden with visibility, but i am leaving it be