### PR TITLE
✨Overrideable component spike

### DIFF
--- a/packages/eds-core-react/src/components/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/Button/Button.docs.mdx
@@ -75,3 +75,15 @@ Example All button combinations.
 
 Compact `Button` using `EdsProvider`.
 <Story id="inputs-button--compact" />
+
+### Using the 'as' prop to render as another component
+
+The `as` prop allows you to render the button as another html element or even react component. 
+This is useful if you want to use the button as as a navigation component for a third party routing library such as rect-router.
+
+```tsx
+import { Link } from "react-router-dom"
+import { Button } from '@equinor/eds-core-react'
+
+<Button as={Link} to="/about">About</Button>
+```

--- a/packages/eds-core-react/src/components/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/Button/Button.docs.mdx
@@ -79,7 +79,11 @@ Compact `Button` using `EdsProvider`.
 ### Using the 'as' prop to render as another component
 
 The `as` prop allows you to render the `Button` as another html element or even react component. 
-This is useful if you want to use the `Button` as as a navigation component for a third party routing library such as react-router.
+
+```tsx
+<Button as="a" href="/about" target="_blank" rel="noreferrer">About</Button>
+```
+This is especially useful if you want to use the `Button` as as a navigation component for a third party routing library such as react-router.
 
 ```tsx
 import { Link } from "react-router-dom"

--- a/packages/eds-core-react/src/components/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/Button/Button.docs.mdx
@@ -78,7 +78,7 @@ Compact `Button` using `EdsProvider`.
 
 ### Using the 'as' prop to render as another component
 
-The `as` prop allows you to render the button as another html element or even react component. 
+The `as` prop allows you to render the `Button` as another html element or even react component. 
 This is useful if you want to use the `Button` as as a navigation component for a third party routing library such as react-router.
 
 ```tsx

--- a/packages/eds-core-react/src/components/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/Button/Button.docs.mdx
@@ -79,7 +79,7 @@ Compact `Button` using `EdsProvider`.
 ### Using the 'as' prop to render as another component
 
 The `as` prop allows you to render the button as another html element or even react component. 
-This is useful if you want to use the button as as a navigation component for a third party routing library such as rect-router.
+This is useful if you want to use the `Button` as as a navigation component for a third party routing library such as react-router.
 
 ```tsx
 import { Link } from "react-router-dom"

--- a/packages/eds-core-react/src/components/Button/Button.stories.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.stories.tsx
@@ -40,9 +40,6 @@ export default {
 export const Introduction: Story<ButtonProps> = (args) => {
   return <Button {...args}>You can control me</Button>
 }
-Introduction.args = {
-  as: undefined,
-}
 Introduction.decorators = [
   (Story) => (
     <Stack>

--- a/packages/eds-core-react/src/components/Button/Button.test.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.test.tsx
@@ -19,6 +19,13 @@ const StyledButton = styled(Button)`
 const MarginButton = styled(Button)`
   margin: 12px;
 `
+const LinkButton = ({ to }: { to: string }) => {
+  return (
+    <a href={to} target="_blank" rel="noreferrer">
+      click
+    </a>
+  )
+}
 
 afterEach(cleanup)
 
@@ -134,6 +141,13 @@ describe('Button', () => {
     const button = screen.getByRole('link')
 
     expect(button).toBeInTheDocument()
+  })
+  it('Can be cast as another component', () => {
+    render(<Button as={LinkButton} to="/" />)
+    const button = screen.getByRole('link')
+
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('target', '_blank')
   })
   it('Can change margins', () => {
     render(<MarginButton>Test me!</MarginButton>)

--- a/packages/eds-core-react/src/components/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ElementType, ButtonHTMLAttributes } from 'react'
+import { forwardRef, ButtonHTMLAttributes } from 'react'
 import styled, { css, ThemeProvider } from 'styled-components'
 import { token as buttonToken } from './tokens'
 import { ButtonTokenSet, ButtonToken } from './Button.types'
@@ -8,6 +8,7 @@ import {
   outlineTemplate,
   spacingsTemplate,
   useToken,
+  OverridableComponent,
 } from '@equinor/eds-utils'
 import { InnerFullWidth } from './InnerFullWidth'
 import { useEds } from '../EdsProvider'
@@ -156,8 +157,6 @@ export type ButtonProps = {
   href?: string
   /** Is the button disabled */
   disabled?: boolean
-  /** Change html element. */
-  as?: ElementType
   /** Type of button
    * @default 'button'
    */
@@ -166,8 +165,8 @@ export type ButtonProps = {
   fullWidth?: boolean
 } & ButtonHTMLAttributes<HTMLButtonElement>
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button(
+export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
+  forwardRef(function Button(
     {
       color = 'primary',
       variant = 'contained',
@@ -183,8 +182,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const { density } = useEds()
     const token = useToken({ density }, getToken(variant, color))
 
-    const as: ElementType =
-      href && !disabled ? 'a' : other.as ? other.as : 'button'
+    const as = href && !disabled ? 'a' : other.as ? other.as : 'button'
+
     const type = href || other.as ? undefined : 'button'
 
     tabIndex = disabled ? -1 : tabIndex
@@ -210,5 +209,4 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         </ButtonBase>
       </ThemeProvider>
     )
-  },
-)
+  })

--- a/packages/eds-core-react/src/components/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.tsx
@@ -71,6 +71,7 @@ const ButtonBase = styled.button(({ theme }: { theme: ButtonToken }) => {
   const { focus, hover, disabled } = states
 
   return css`
+    box-sizing: border-box;
     margin: 0;
     padding: 0;
     text-decoration: none;

--- a/packages/eds-core-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Button Matches snapshot 1`] = `
 }
 
 .c0 {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   -webkit-text-decoration: none;

--- a/packages/eds-core-react/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Pagination Matches snapshot 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   -webkit-text-decoration: none;

--- a/packages/eds-core-react/src/components/Search/__snapshots__/Search.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Search/__snapshots__/Search.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Search Matches snapshot 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   -webkit-text-decoration: none;

--- a/packages/eds-core-react/src/components/Select/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Select/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`MultiSelect Matches snapshot 2`] = `
 }
 
 .c0 {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   -webkit-text-decoration: none;

--- a/packages/eds-core-react/src/components/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -130,6 +130,7 @@ exports[`SingleSelect Matches snapshot 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   -webkit-text-decoration: none;

--- a/packages/eds-core-react/src/components/SideSheet/__snapshots__/SideSheet.test.tsx.snap
+++ b/packages/eds-core-react/src/components/SideSheet/__snapshots__/SideSheet.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`SideSheet Matches snapshot 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   -webkit-text-decoration: none;

--- a/packages/eds-utils/src/utils/index.ts
+++ b/packages/eds-utils/src/utils/index.ts
@@ -2,5 +2,6 @@ export * from './templates'
 export { joinHandlers } from './joinHandlers'
 export { mergeRefs } from './mergeRefs'
 export { setReactInputValue } from './setReactInputValue'
+export type { OverridableComponent } from './overridableComponent'
 
 export const trimSpaces = (text: string): string => text.replace(/ /g, '')

--- a/packages/eds-utils/src/utils/overridableComponent.ts
+++ b/packages/eds-utils/src/utils/overridableComponent.ts
@@ -1,0 +1,10 @@
+export type OverridableComponent<Component, Element extends HTMLElement> = {
+  (props: Component & React.RefAttributes<Element>): ReturnType<React.FC>
+
+  <As extends React.ElementType>(
+    props: {
+      as: As
+    } & Component &
+      Omit<React.ComponentPropsWithRef<As>, keyof Component>,
+  ): ReturnType<React.FC>
+}

--- a/packages/eds-utils/src/utils/overridableComponent.ts
+++ b/packages/eds-utils/src/utils/overridableComponent.ts
@@ -1,10 +1,12 @@
-export type OverridableComponent<Component, Element extends HTMLElement> = {
-  (props: Component & React.RefAttributes<Element>): ReturnType<React.FC>
+import { RefAttributes, FC, ElementType, ComponentPropsWithRef } from 'react'
 
-  <As extends React.ElementType>(
+export type OverridableComponent<Component, Element extends HTMLElement> = {
+  (props: Component & RefAttributes<Element>): ReturnType<FC>
+
+  <As extends ElementType>(
     props: {
       as: As
     } & Component &
-      Omit<React.ComponentPropsWithRef<As>, keyof Component>,
-  ): ReturnType<React.FC>
+      Omit<ComponentPropsWithRef<As>, keyof Component>,
+  ): ReturnType<FC>
 }


### PR DESCRIPTION
resolves #2338 (perhaps)

This solution does seem to work with button, although you need to set `as="a"` explicitly, as just setting `href`, which converts it to an `a` internally, is not picked up by typescript so adding `target` attribute gets an error in that case.

This pr also fixes a bug i came across where height of button is 36px when as=button, 38px when other things due to different default box-sizing. So i added explicit box-sizing: border-box to force always 36px