### PR TITLE
🐛 hide closed menu with display: none

### DIFF
--- a/packages/eds-core-react/src/components/Menu/Menu.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.tsx
@@ -41,7 +41,7 @@ const MenuPaper = styled(Paper)<MenuPaperProps>`
   width: fit-content;
   min-width: fit-content;
   ${bordersTemplate(border)};
-  ${({ open }) => css({ visibility: open ? null : 'hidden' })}
+  ${({ open }) => css({ display: open ? 'block' : 'none' })};
 `
 
 const MenuContainer = forwardRef<HTMLDivElement, MenuProps>(

--- a/packages/eds-core-react/src/components/Popover/Popover.tsx
+++ b/packages/eds-core-react/src/components/Popover/Popover.tsx
@@ -33,9 +33,8 @@ type StyledPopoverProps = Pick<PopoverProps, 'open'>
 
 const PopoverPaper = styled(Paper)<StyledPopoverProps>(({ theme, open }) => {
   return css`
-    ${{ visibility: open ? null : 'hidden' }}
+    ${{ display: open ? 'grid' : 'none' }}
     ${typographyTemplate(theme.typography)}
-    display: grid;
     grid-auto-columns: auto;
     align-items: center;
     align-content: start;

--- a/packages/eds-core-react/src/components/Popover/__snapshots__/Popover.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Popover/__snapshots__/Popover.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Popover Matches snapshot 1`] = `
 }
 
 .c1 {
+  display: grid;
   margin: 0;
   color: rgba(61,61,61,1);
   font-family: Equinor;
@@ -14,7 +15,6 @@ exports[`Popover Matches snapshot 1`] = `
   font-weight: 500;
   line-height: 1.500em;
   text-align: left;
-  display: grid;
   grid-auto-columns: auto;
   -webkit-align-items: center;
   -webkit-box-align: center;


### PR DESCRIPTION
resolves #2493 
Is this solution ok? I don't know why it was hidden with visibility. I'm guessing perhaps a concern for lag with conditional rendering large menus? Otherwise we can do that also instead of display none

Edit: fixed the same issue with popover although here overflow happens on the container element since popover is not portalized