### PR TITLE
🐛autocomplete: same zindex as tooltip

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -542,7 +542,7 @@ function AutocompleteInner<T>(
           position: strategy,
           top: y ?? 0,
           left: x ?? 0,
-          zIndex: 1500,
+          zIndex: 1400,
         },
       })}
     >

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -542,6 +542,7 @@ function AutocompleteInner<T>(
           position: strategy,
           top: y ?? 0,
           left: x ?? 0,
+          zIndex: 1500,
         },
       })}
     >


### PR DESCRIPTION
resolves #2502 

Also tested menu inside popover but it works fine (they have same z-index)