### PR TITLE
🐛Sidebar link active warning

### DIFF
--- a/packages/eds-lab-react/src/components/SideBar/SidebarLink/index.tsx
+++ b/packages/eds-lab-react/src/components/SideBar/SidebarLink/index.tsx
@@ -1,9 +1,4 @@
-import {
-  ButtonHTMLAttributes,
-  forwardRef,
-  AnchorHTMLAttributes,
-  ElementType,
-} from 'react'
+import { forwardRef, AnchorHTMLAttributes, ElementType } from 'react'
 import { sidebar as tokens } from '../SideBar.tokens'
 import {
   bordersTemplate,
@@ -11,8 +6,6 @@ import {
   OverridableComponent,
 } from '@equinor/eds-utils'
 import {
-  Button,
-  ButtonProps,
   Icon,
   Tooltip as EDSTooltip,
   Typography,
@@ -36,14 +29,9 @@ const {
 
 type ContainerProps = {
   $active?: boolean
-} & StrippedButton
+}
 
-type StrippedButton = Omit<
-  ButtonProps,
-  keyof ButtonHTMLAttributes<HTMLButtonElement>
->
-
-const Container = styled(Button)<ContainerProps>(({ theme, $active }) => {
+const Container = styled.a<ContainerProps>(({ theme, $active }) => {
   const {
     minWidth,
     entities: {
@@ -85,10 +73,10 @@ const Container = styled(Button)<ContainerProps>(({ theme, $active }) => {
 })
 
 type ItemTextProps = {
-  active?: boolean
+  $active?: boolean
 }
 
-const ItemText = styled(Typography)<ItemTextProps>(({ theme, active }) => {
+const ItemText = styled(Typography)<ItemTextProps>(({ theme, $active }) => {
   const {
     entities: {
       sidebarItem: {
@@ -103,7 +91,7 @@ const ItemText = styled(Typography)<ItemTextProps>(({ theme, active }) => {
   } = theme
   return css`
     justify-self: start;
-    color: ${active ? itemActiveTextColor : itemTextColor};
+    color: ${$active ? itemActiveTextColor : itemTextColor};
     &::first-letter {
       text-transform: capitalize;
     }
@@ -152,12 +140,11 @@ export const SidebarLink: OverridableSubComponent = forwardRef<
         tabIndex={0}
         $active={active}
         onClick={onClick}
-        variant="ghost"
         ref={ref}
         {...rest}
       >
         {icon && <Icon data={icon} color={getIconColor()} />}
-        <ItemText variant="cell_text" group="table" active={active}>
+        <ItemText variant="cell_text" group="table" $active={active}>
           {label}
         </ItemText>
       </Container>
@@ -171,7 +158,6 @@ export const SidebarLink: OverridableSubComponent = forwardRef<
         as={as}
         $active={active}
         onClick={onClick}
-        variant="ghost"
         ref={ref}
         {...rest}
       >

--- a/packages/eds-lab-react/src/components/SideBar/SidebarLink/index.tsx
+++ b/packages/eds-lab-react/src/components/SideBar/SidebarLink/index.tsx
@@ -35,7 +35,7 @@ const {
 } = tokens
 
 type ContainerProps = {
-  active?: boolean
+  $active?: boolean
 } & StrippedButton
 
 type StrippedButton = Omit<
@@ -43,7 +43,7 @@ type StrippedButton = Omit<
   keyof ButtonHTMLAttributes<HTMLButtonElement>
 >
 
-const Container = styled(Button)<ContainerProps>(({ theme, active }) => {
+const Container = styled(Button)<ContainerProps>(({ theme, $active }) => {
   const {
     minWidth,
     entities: {
@@ -63,7 +63,7 @@ const Container = styled(Button)<ContainerProps>(({ theme, active }) => {
     },
   } = theme
   return css`
-    background-color: ${active ? menuActiveBackground : 'none'};
+    background-color: ${$active ? menuActiveBackground : 'none'};
     display: grid;
     grid-template-columns: ${minWidth} 1fr;
     place-items: center;
@@ -72,7 +72,7 @@ const Container = styled(Button)<ContainerProps>(({ theme, active }) => {
     min-height: ${minHeight};
     &:hover {
       cursor: pointer;
-      background-color: ${active ? menuActiveBackground : menuHoverBackground};
+      background-color: ${$active ? menuActiveBackground : menuHoverBackground};
     }
     &:disabled {
       background-color: ${menuDisabledBackground};
@@ -150,7 +150,7 @@ export const SidebarLink: OverridableSubComponent = forwardRef<
       <Container
         as={as}
         tabIndex={0}
-        active={active}
+        $active={active}
         onClick={onClick}
         variant="ghost"
         ref={ref}
@@ -169,7 +169,7 @@ export const SidebarLink: OverridableSubComponent = forwardRef<
       <Container
         tabIndex={0}
         as={as}
-        active={active}
+        $active={active}
         onClick={onClick}
         variant="ghost"
         ref={ref}


### PR DESCRIPTION
resolves #2529 
Turns out extending an overridable component (Button) inside another overridable component (SideBar.Link) does not work very well when overriding, and adds the props as html attrs onto the final component. But I realized it is pointless to extend Button here anyway, so I removed it and just use an `a` element as base.