### PR TITLE
🐛 Breadcrumb/Typography: use transient props

### DIFF
--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -5,7 +5,7 @@ import { Typography } from '../Typography'
 import { Tooltip } from '../Tooltip'
 import { breadcrumbs as tokens } from './Breadcrumbs.tokens'
 
-type StyledProps = Pick<BreadcrumbProps, 'maxWidth'>
+type StyledProps = { $maxWidth?: number }
 
 const { states, typography } = tokens
 
@@ -23,7 +23,7 @@ const StyledTypography = styled(Typography)<StyledProps>`
   display: inline-block;
   text-decoration: none;
   color: ${typography.color};
-  ${({ maxWidth }) => css({ maxWidth })}
+  ${({ $maxWidth }) => css({ maxWidth: $maxWidth })}
 `
 type OverridableSubComponent = OverridableComponent<
   BreadcrumbProps,
@@ -48,7 +48,6 @@ export const Breadcrumb: OverridableSubComponent = forwardRef(
       ...other,
       href,
       ref,
-      maxWidth,
     }
 
     const showTooltip = maxWidth > 0
@@ -64,6 +63,7 @@ export const Breadcrumb: OverridableSubComponent = forwardRef(
         link={isHrefDefined}
         forwardedAs={forwardedAs}
         variant="body_short"
+        $maxWidth={maxWidth}
         {...props}
       >
         {children}

--- a/packages/eds-core-react/src/components/Typography/Typography.tsx
+++ b/packages/eds-core-react/src/components/Typography/Typography.tsx
@@ -74,13 +74,13 @@ const toVariantName = (
 
 type StyledProps = {
   typography: Partial<TypographyType>
-  link: boolean
+  $link: boolean
   color: ColorVariants
   lines: number
 }
 
 const StyledTypography = styled.p<StyledProps>`
-  ${({ typography, link }) => typographyTemplate(typography, link)}
+  ${({ typography, $link }) => typographyTemplate(typography, $link)}
   ${({ color }) => css({ color: findColor(color) })}
   ${({ lines }) =>
     //https://caniuse.com/#feat=css-line-clamp
@@ -94,8 +94,8 @@ const StyledTypography = styled.p<StyledProps>`
         text-overflow: ellipsis;
       }
     `}
-  ${({ link }) =>
-    link &&
+  ${({ $link }) =>
+    $link &&
     css`
       &:focus {
         outline: none;
@@ -168,7 +168,7 @@ export const Typography: OverridableComponent<TypographyProps, HTMLElement> =
       <StyledTypography
         as={as}
         typography={{ ...typography, ...token }}
-        link={link}
+        $link={link}
         ref={ref}
         {...other}
       >


### PR DESCRIPTION
resolves #2538 

Now casting breadcrumb `as={Link}` from react router will not throw warnings about maxWidth being applied to a dom element