### PR TITLE
🔖 Release core@0.23.0, lab@0.5.0 & utils@0.4.0

### DIFF
--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.23.0] - 2022-10-03
+## [0.23.0] - 2022-10-05
 
 ### Fixed
 

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.23.0] - 2022-10-03
 
+### Fixed
+
+- 🐛 Accordion: fixed shrinking icon by @oddvernes in https://github.com/equinor/design-system/pull/2540
+
+### Changed
+
+- ⬆️ Upgrade to React 18 by @mimarz in https://github.com/equinor/design-system/pull/2510
+- 🐛 Breadcrumb/Typography: use transient props by @oddvernes in https://github.com/equinor/design-system/pull/2542
+
 ## [0.22.0] - 2022-09-29
 
 ### Fixed

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.23.0-dev.20221003",
+  "version": "0.23.0",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-lab-react/CHANGELOG.md
+++ b/packages/eds-lab-react/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2022-10-03
+## [0.5.0] - 2022-10-05
+
+### Changed
+
+- ⬆️ Upgrade to React 18 by @mimarz in https://github.com/equinor/design-system/pull/2510
+- 🐛Sidebar link active warning by @oddvernes in https://github.com/equinor/design-system/pull/2531
 
 ## [0.4.2] - 2022-06-20
 

--- a/packages/eds-lab-react/package.json
+++ b/packages/eds-lab-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-lab-react",
-  "version": "0.5.0-dev.20221003",
+  "version": "0.5.0",
   "description": "The lab for the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-utils/CHANGELOG.md
+++ b/packages/eds-utils/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - 2022-10-03
+## [0.4.0] - 2022-10-05
+
+### Changed
+
+- ⬆️ Upgrade to React 18 by @mimarz in https://github.com/equinor/design-system/pull/2510
 
 ## [0.3.0] - 2022-09-08
 

--- a/packages/eds-utils/package.json
+++ b/packages/eds-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-utils",
-  "version": "0.4.0-dev.20221003",
+  "version": "0.4.0",
   "description": "Utility functions and hooks for the Equinor Design System",
   "sideEffects": false,
   "main": "dist/eds-utils.cjs.js",


### PR DESCRIPTION
resolves #2534 

# core
## [0.23.0] - 2022-10-03

### Fixed

- 🐛 Accordion: fixed shrinking icon by @oddvernes in https://github.com/equinor/design-system/pull/2540

### Changed

- ⬆️ Upgrade to React 18 by @mimarz in https://github.com/equinor/design-system/pull/2510
- 🐛 Breadcrumb/Typography: use transient props by @oddvernes in https://github.com/equinor/design-system/pull/2542


# lab
## [0.5.0] - 2022-10-05

### Changed

- ⬆️ Upgrade to React 18 by @mimarz in https://github.com/equinor/design-system/pull/2510
- 🐛Sidebar link active warning by @oddvernes in https://github.com/equinor/design-system/pull/2531

# utils
## [0.4.0] - 2022-10-05

### Changed

- ⬆️ Upgrade to React 18 by @mimarz in https://github.com/equinor/design-system/pull/2510
