### PR TITLE
🐛 Accordion: prevent toggle from submitting form

### DIFF
--- a/packages/eds-core-react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/eds-core-react/src/components/Accordion/AccordionHeader.tsx
@@ -1,5 +1,6 @@
 import {
   KeyboardEvent,
+  MouseEvent,
   Children as ReactChildren,
   cloneElement,
   forwardRef,
@@ -165,7 +166,9 @@ const AccordionHeader = forwardRef<HTMLButtonElement, AccordionHeaderProps>(
     },
     ref,
   ) {
-    const handleClick = () => {
+    const handleClick = (e: MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
       if (!disabled) {
         toggleExpanded()
         if (props.onToggle) {
@@ -173,14 +176,15 @@ const AccordionHeader = forwardRef<HTMLButtonElement, AccordionHeaderProps>(
         }
       }
     }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const { key } = event
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const { key } = e
       if (key === 'Enter' || key === ' ') {
         toggleExpanded()
         if (props.onToggle) {
           props.onToggle()
         }
-        event.preventDefault()
+        e.preventDefault()
+        e.stopPropagation()
       }
     }
 
@@ -253,6 +257,7 @@ const AccordionHeader = forwardRef<HTMLButtonElement, AccordionHeaderProps>(
           onClick={handleClick}
           onKeyDown={handleKeyDown}
           ref={ref}
+          type="button"
           {...props}
         >
           {chevronPosition === 'left' ? newChildren : newChildren.reverse()}

--- a/packages/eds-core-react/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -126,6 +126,7 @@ exports[`Accordion Matches snapshot 1`] = `
           class="c1"
           data-testid="header1"
           tabindex="0"
+          type="button"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
resolves #2566 

tested by wrapping a form around one of the stories. Before: it submitted which reloads page. After: it does not submit