### PR TITLE
🔥 Remove commonjs path for in eds-icons & eds-tokens

### DIFF
--- a/packages/eds-icons/commonjs/package.json
+++ b/packages/eds-icons/commonjs/package.json
@@ -1,4 +1,0 @@
-{
-  "type": "commonjs",
-  "main": "../dist/icons.cjs.js"
-}

--- a/packages/eds-tokens/commonjs/package.json
+++ b/packages/eds-tokens/commonjs/package.json
@@ -1,4 +1,0 @@
-{
-  "type": "commonjs",
-  "main": "../dist/tokens.cjs.js"
-}


### PR DESCRIPTION
resolves #2559 

Remove the last of fallback support for commonjs when node had problems figuring out esm vs commonjs modules.