### PR TITLE
🔖 Release eds-core-react@0.24.0, eds-icons@0.15.0, eds-lab-react@0.5.0, eds-tokens@0.8.0, eds-utils@0.5.0 

### DIFF
--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.24.0] - 2022-10-06
 
+### Added
+
+- ✨ Autocomplete: Support for toggling if input is cleared on selection by @mimarz in https://github.com/equinor/design-system/pull/2545
+- ✨Polymorphic tabs by @oddvernes in https://github.com/equinor/design-system/pull/2556
+
+### Changed
+
+- ♻️ Autocomplete: Always show all options on re-open after selection by @mimarz in https://github.com/equinor/design-system/pull/2562
+- ⬆️ upgraded floating-ui to v0.10.1 by @oddvernes in https://github.com/equinor/design-system/pull/2554
+- 🔧 Conform packages build, test & linting by @mimarz in https://github.com/equinor/design-system/pull/2555
+
+### Fixed
+
+- 🐛 Accordion: prevent toggle from submitting form by @oddvernes in https://github.com/equinor/design-system/pull/2567
+
+**Full Changelog**: https://github.com/equinor/design-system/compare/eds-core-react@0.23.0...eds-core-react@0.24.0
+
 ## [0.23.0] - 2022-10-05
 
 ### Fixed

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.0] - 2022-10-06
+## [0.24.0] - 2022-10-11
 
 ### Added
 

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.0] - 2022-10-11
+## [0.24.0] - 2022-10-12
 
 ### Added
 

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.24.0-dev.20221007",
+  "version": "0.24.0",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-icons/CHANGELOG.md
+++ b/packages/eds-icons/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.0] - 2022-10-11
+## [0.15.0] - 2022-10-12
 
 ### Added
 

--- a/packages/eds-icons/CHANGELOG.md
+++ b/packages/eds-icons/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.0] - 2022-10-10
+## [0.15.0] - 2022-10-11
 
 ### Added
 

--- a/packages/eds-icons/CHANGELOG.md
+++ b/packages/eds-icons/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `in_progress`
 
+### Removed
+
+- 🔥 Remove commonjs path for in eds-icons & eds-tokens by @mimarz in https://github.com/equinor/design-system/pull/2571
+
+### Changed
+
+- 🔧 Conform packages build, test & linting by @mimarz in https://github.com/equinor/design-system/pull/2555
+
 ## [0.14.0] - 2022-09-19
 
 ### Added

--- a/packages/eds-icons/package.json
+++ b/packages/eds-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.15.0-dev.20221005",
+  "version": "0.15.0",
   "description": "Icons from the Equinor Design System",
   "main": "dist/icons.cjs.js",
   "module": "dist/esm/index.js",

--- a/packages/eds-lab-react/CHANGELOG.md
+++ b/packages/eds-lab-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ⬆️ Upgrade to React 18 by @mimarz in https://github.com/equinor/design-system/pull/2510
 - 🐛Sidebar link active warning by @oddvernes in https://github.com/equinor/design-system/pull/2531
+- 💄 Sidebar spacing by @oddvernes in https://github.com/equinor/design-system/pull/2543
 
 ## [0.4.2] - 2022-06-20
 

--- a/packages/eds-lab-react/CHANGELOG.md
+++ b/packages/eds-lab-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2022-10-05
+## [0.5.0] - 2022-10-11
 
 ### Changed
 

--- a/packages/eds-lab-react/CHANGELOG.md
+++ b/packages/eds-lab-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2022-10-11
+## [0.5.0] - 2022-10-12
 
 ### Changed
 

--- a/packages/eds-lab-react/CHANGELOG.md
+++ b/packages/eds-lab-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2022-10-12
+## [0.5.1] - 2022-10-12
 
 ### Changed
 

--- a/packages/eds-lab-react/package.json
+++ b/packages/eds-lab-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-lab-react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The lab for the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-tokens/CHANGELOG.md
+++ b/packages/eds-tokens/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] - 2022-10-05
+## [0.8.0] - 2022-10-11
 
 ### Removed
 

--- a/packages/eds-tokens/CHANGELOG.md
+++ b/packages/eds-tokens/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0] - 2022-10-05
 
+### Removed
+
+- 🔥 Remove commonjs path for in eds-icons & eds-tokens by @mimarz in https://github.com/equinor/design-system/pull/2571
+
+### Changed
+
+- 🔧 Conform packages build, test & linting by @mimarz in https://github.com/equinor/design-system/pull/2555
+
 ## [0.7.1] - 2022-06-09
 
 ### Changed

--- a/packages/eds-tokens/CHANGELOG.md
+++ b/packages/eds-tokens/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] - 2022-10-11
+## [0.8.0] - 2022-10-12
 
 ### Removed
 

--- a/packages/eds-tokens/package.json
+++ b/packages/eds-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-tokens",
-  "version": "0.8.0-dev.20221005",
+  "version": "0.8.0",
   "description": "Design tokens for the Equinor Design System",
   "main": "dist/tokens.cjs.js",
   "module": "dist/esm/index.js",

--- a/packages/eds-utils/CHANGELOG.md
+++ b/packages/eds-utils/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2022-10-06
+## [0.5.0] - 2022-10-11
 
 ### Changed
 

--- a/packages/eds-utils/CHANGELOG.md
+++ b/packages/eds-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2022-10-06
 
+### Changed
+
+- 🔧 Conform packages build, test & linting by @mimarz in https://github.com/equinor/design-system/pull/2555
+
 ## [0.4.0] - 2022-10-05
 
 ### Changed

--- a/packages/eds-utils/CHANGELOG.md
+++ b/packages/eds-utils/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2022-10-11
+## [0.5.0] - 2022-10-12
 
 ### Changed
 

--- a/packages/eds-utils/package.json
+++ b/packages/eds-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-utils",
-  "version": "0.5.0-dev.20221006",
+  "version": "0.5.0",
   "description": "Utility functions and hooks for the Equinor Design System",
   "sideEffects": false,
   "main": "dist/eds-utils.cjs.js",


### PR DESCRIPTION
resolves #2535 

Need to release all packages as they need to be updated with new dependencies for tokens & icons.

Publish order:
- tokens
- icons
- utils
- core-react
- lab-react