### PR TITLE
🐛Datepicker: fix calendar icon position

### DIFF
--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -230,6 +230,9 @@ const DateLabel = styled.label`
     span {
       padding-left: 8px;
       color: ${tokens.colors.iconGray};
+      &:empty {
+        display: none;
+      }
     }
   `}
 `
@@ -259,7 +262,7 @@ const StyledDatepicker = styled(DatePicker)`
 const CalendarIcon = styled(Icon)`
   position: absolute;
   z-index: 1;
-  top: 21px;
+  bottom: 7px;
   right: 6px;
   cursor: pointer;
 `


### PR DESCRIPTION
resolves #2366 

If a user leaves an empty string as label, the empty span element was positioned differently in firefox vs chrome. This changed the height of the wrapper that the icon was positioned relatively to.