### PR TITLE
🐛 Remove focus from useEffect in Tabs to prevent unwanted scrolling in Storybook

### DIFF
--- a/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
@@ -93,10 +93,6 @@ Introduction.decorators = [
 export const States: Story<TabsProps> = () => {
   const focusedRef = useRef<HTMLButtonElement>(null)
 
-  useEffect(() => {
-    focusedRef.current?.focus()
-  }, [])
-
   return (
     <Tabs activeTab={2} onChange={noop}>
       <Tabs.List>
@@ -511,7 +507,6 @@ export const Compact: Story<TabsProps> = () => {
   const [density, setDensity] = useState<Density>('comfortable')
 
   useEffect(() => {
-    focusedRef.current?.focus()
     setDensity('compact')
   }, [density])
 


### PR DESCRIPTION
Resolves #2609 