### PR TITLE
🐛 TextField: id sent to inputwrapper was always null

### DIFF
--- a/packages/eds-core-react/src/components/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.tsx
@@ -130,8 +130,8 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
         ...fieldProps,
       }
       helperProps = {
-        id: helperTextId,
         ...helperProps,
+        id: helperTextId,
       }
     }
 


### PR DESCRIPTION
resolves #2469 