### PR TITLE
🐛 SideBar: fixed button and toggle ref

### DIFF
--- a/packages/eds-core-react/src/components/SideBar/SideBar.stories.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBar.stories.tsx
@@ -1,4 +1,5 @@
 import { Story, ComponentMeta } from '@storybook/react'
+import { useState } from 'react'
 import styled from 'styled-components'
 import {
   dashboard,
@@ -14,6 +15,7 @@ import {
   SidebarType,
   SidebarLinkProps,
   useSideBar,
+  Menu,
 } from '../..'
 import page from './SideBar.docs.mdx'
 
@@ -151,6 +153,15 @@ export const CustomContent: Story<SidebarType> = () => {
 }
 
 export const WithButton: Story<SidebarType> = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+
+  const openMenu = () => {
+    setIsOpen(true)
+  }
+  const closeMenu = () => {
+    setIsOpen(false)
+  }
   const menuItems: SidebarLinkProps[] = [
     {
       label: 'Dashboard',
@@ -171,9 +182,10 @@ export const WithButton: Story<SidebarType> = () => {
       <SideBar>
         <SideBar.Content>
           <SideBar.Button
-            label="Create story"
+            label="Add story"
             icon={add}
-            onClick={() => console.log('clicked')}
+            onClick={() => (isOpen ? closeMenu() : openMenu())}
+            ref={setAnchorEl}
           />
           <Divider size="2" color="light" style={{ marginBlockEnd: 0 }} />
           {menuItems.map((m) => (
@@ -184,6 +196,18 @@ export const WithButton: Story<SidebarType> = () => {
           <SideBar.Toggle />
         </SideBar.Footer>
       </SideBar>
+      <Menu
+        open={isOpen}
+        onClose={closeMenu}
+        anchorEl={anchorEl}
+        placement="right-start"
+      >
+        <Menu.Section title="Add story">
+          <Menu.Item onClick={closeMenu}>Featured story</Menu.Item>
+          <Menu.Item onClick={closeMenu}>News article</Menu.Item>
+          <Menu.Item onClick={closeMenu}>Blog post</Menu.Item>
+        </Menu.Section>
+      </Menu>
     </SidebarContainer>
   )
 }
@@ -228,13 +252,12 @@ export const ActivePath: Story<SidebarType> = () => {
     </SidebarContainer>
   )
 }
+const SidebarContainerWithTopbar = styled(SidebarContainer)`
+  display: grid;
+  grid-template-rows: auto 1fr;
+`
 
 export const WithTopbar: Story<SidebarType> = () => {
-  const SidebarContainerWithTopbar = styled(SidebarContainer)`
-    display: grid;
-    grid-template-rows: auto 1fr;
-  `
-
   const menuItems: SidebarLinkProps[] = [
     {
       label: 'Dashboard',

--- a/packages/eds-core-react/src/components/SideBar/SideBar.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBar.tsx
@@ -2,7 +2,7 @@ import { HTMLAttributes, forwardRef, useEffect } from 'react'
 import styled, { css, ThemeProvider } from 'styled-components'
 import { sidebar as tokens } from './SideBar.tokens'
 import { bordersTemplate, useToken } from '@equinor/eds-utils'
-import { useEds } from '../..'
+import { useEds } from '../EdsProvider'
 import { useSideBar, SideBarProvider } from './SideBar.context'
 
 type ContainerProps = {

--- a/packages/eds-core-react/src/components/SideBar/SideBarButton/index.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBarButton/index.tsx
@@ -1,5 +1,7 @@
 import { forwardRef } from 'react'
-import { Button, ButtonProps, Icon, Tooltip } from '../../..'
+import { Button, ButtonProps } from '../../Button'
+import { Icon } from '../../Icon'
+import { Tooltip } from '../../Tooltip'
 import { sidebar as tokens } from '../SideBar.tokens'
 import { useSideBar } from '../SideBar.context'
 import styled, { css } from 'styled-components'

--- a/packages/eds-core-react/src/components/SideBar/SideBarButton/index.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBarButton/index.tsx
@@ -1,4 +1,4 @@
-import { ForwardRefExoticComponent, forwardRef } from 'react'
+import { forwardRef } from 'react'
 import { Button, ButtonProps, Icon, Tooltip } from '../../..'
 import { sidebar as tokens } from '../SideBar.tokens'
 import { useSideBar } from '../SideBar.context'
@@ -48,11 +48,8 @@ export type SideBarButtonProps = {
   icon: IconData
 } & Omit<ButtonProps, 'href' | 'type' | 'fullWidth' | 'variant'>
 
-export const SideBarButton: ForwardRefExoticComponent<SideBarButtonProps> =
-  forwardRef<HTMLButtonElement, SideBarButtonProps>(function SideBarToggle(
-    { label, icon, style, className, ...rest },
-    ref,
-  ) {
+export const SideBarButton = forwardRef<HTMLButtonElement, SideBarButtonProps>(
+  function SideBarToggle({ label, icon, style, className, ...rest }, ref) {
     const props = {
       ...rest,
       ref,
@@ -80,4 +77,5 @@ export const SideBarButton: ForwardRefExoticComponent<SideBarButtonProps> =
         </MenuButtonContainer>
       </Tooltip>
     )
-  })
+  },
+)

--- a/packages/eds-core-react/src/components/SideBar/SideBarToggle.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBarToggle.tsx
@@ -1,5 +1,7 @@
 import { forwardRef, HTMLAttributes } from 'react'
-import { Button, Icon, Tooltip } from '../..'
+import { Button } from '../Button'
+import { Icon } from '../Icon'
+import { Tooltip } from '../Tooltip'
 import { useSideBar } from './SideBar.context'
 import { sidebar as tokens } from './SideBar.tokens'
 import { expand, collapse } from '@equinor/eds-icons'

--- a/packages/eds-core-react/src/components/SideBar/SideBarToggle.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBarToggle.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ForwardRefExoticComponent, HTMLAttributes } from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import { Button, Icon, Tooltip } from '../..'
 import { useSideBar } from './SideBar.context'
 import { sidebar as tokens } from './SideBar.tokens'
@@ -37,11 +37,8 @@ const ToggleContainer = styled.div<ContainerProps>(({ theme }) => {
 
 type SideBarToggleProps = HTMLAttributes<HTMLDivElement>
 
-export const SideBarToggle: ForwardRefExoticComponent<SideBarToggleProps> =
-  forwardRef<HTMLDivElement, SideBarToggleProps>(function SideBarToggle(
-    { ...rest },
-    ref,
-  ) {
+export const SideBarToggle = forwardRef<HTMLDivElement, SideBarToggleProps>(
+  function SideBarToggle({ ...rest }, ref) {
     const props = {
       ...rest,
       ref,
@@ -60,4 +57,5 @@ export const SideBarToggle: ForwardRefExoticComponent<SideBarToggleProps> =
         </Tooltip>
       </ToggleContainer>
     )
-  })
+  },
+)

--- a/packages/eds-core-react/src/components/SideBar/SidebarLink/index.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SidebarLink/index.tsx
@@ -5,7 +5,10 @@ import {
   outlineTemplate,
   OverridableComponent,
 } from '@equinor/eds-utils'
-import { Icon, Tooltip as EDSTooltip, Typography } from '../../..'
+import { Icon } from '../../Icon'
+import { Tooltip as EDSTooltip } from '../../Tooltip'
+import { Typography } from '../../Typography'
+
 import styled, { css } from 'styled-components'
 import { IconData } from '@equinor/eds-icons'
 import { useSideBar } from '../SideBar.context'


### PR DESCRIPTION
resolves #2649 

The ForwardRefExoticComponent type was not needed and made typescript reject adding `ref` to `SideBar.Button` and `SideBar.Toggle`
Also added a `Menu` to the SideBar "with button" story as this is what amplify is doing, and requires the button ref to work