### PR TITLE
🐛 TextField: Fix argstable crash in storybook

### DIFF
--- a/packages/eds-core-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.stories.tsx
@@ -56,6 +56,8 @@ export default {
       description:
         'Please note that the option list of icons is not complete, this selection is only for demo purposes',
     },
+    inputRef: { control: { type: null } },
+    textareaRef: { control: { type: null } },
   },
   parameters: {
     docs: {


### PR DESCRIPTION
resolves #2595 

Clicking on the "set object" button for `inputRef` and `textareaRef` in the argstable would crash the page, so I have removed them