### PR TITLE
Improve docs for Slider outputFunction

### DIFF
--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -182,8 +182,8 @@ export type SliderProps = {
     event: MouseEvent | KeyboardEvent,
     newValue: number[] | number,
   ) => void
-  /** Function for formatting the output, e.g. with dates */
-  outputFunction?: (text: number) => string
+  /** Function for formatting the displayed value. E.g. formatting dates, or adding a unit suffix */
+  outputFunction?: (value: number) => string
   /** Max value */
   max?: number
   /**  Min value */


### PR DESCRIPTION
I spent a bit of time on finding this option, as it was not clear to me that the `outputFunction` processes the current value for display text.

I added a suggested change, but feel free to change it 👍