### PR TITLE
🐛♿️ Autocomplete: change behaviour on inputBlur

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -323,10 +323,10 @@ function AutocompleteInner<T>(
     onStateChange: ({ type, selectedItem }) => {
       switch (type) {
         case useCombobox.stateChangeTypes.InputChange:
+        case useCombobox.stateChangeTypes.InputBlur:
           break
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
-        case useCombobox.stateChangeTypes.InputBlur:
           if (selectedItem && !optionDisabled(selectedItem)) {
             if (multiple) {
               selectedItems.includes(selectedItem)


### PR DESCRIPTION
when `multiple`: pressing `tab` no longer toggles the focused item selection state as the menu closes

resolves #2675 