### PR TITLE
✨ Input: Added css-variable to override background

### DIFF
--- a/packages/eds-core-react/src/components/Input/Input.docs.mdx
+++ b/packages/eds-core-react/src/components/Input/Input.docs.mdx
@@ -63,3 +63,8 @@ Compact `Input` using `EdsProvider`.
 
 
 <Story id="inputs-input--casted" />
+
+### Override input background color
+Use custom property `--eds-input-background` to change the background color of the input field. This also works for all components using input internally: `Autocomplete`, `Textfield`, `Search` and `Textarea`
+
+<Story id="inputs-input--override-background" />

--- a/packages/eds-core-react/src/components/Input/Input.stories.tsx
+++ b/packages/eds-core-react/src/components/Input/Input.stories.tsx
@@ -250,3 +250,21 @@ export const WithAdornments: Story<InputProps> = () => {
 export const casted: Story<InputProps> = (args) => {
   return <Input as="textarea" {...args} />
 }
+
+export const OverrideBackground: Story<InputProps> = (args) => {
+  return (
+    <Input
+      style={{ '--eds-input-background': '#fff' } as React.CSSProperties}
+      {...args}
+    />
+  )
+}
+OverrideBackground.decorators = [
+  (Story) => {
+    return (
+      <Stack style={{ background: '#f7f7f7', padding: '32px' }}>
+        <Story />
+      </Stack>
+    )
+  },
+]

--- a/packages/eds-core-react/src/components/Input/Input.tsx
+++ b/packages/eds-core-react/src/components/Input/Input.tsx
@@ -36,7 +36,7 @@ const Container = styled.div(({ token, disabled, readOnly }: StyledProps) => {
     border: none;
     box-sizing: border-box;
     box-shadow: ${token.boxShadow};
-    background: ${token.background};
+    background: var(--eds-input-background, ${token.background});
     ${outlineTemplate(token.outline)}
 
     &:focus-within {

--- a/packages/eds-core-react/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Input Matches snapshot 1`] = `
   border: none;
   box-sizing: border-box;
   box-shadow: inset 0px -1px 0px 0px var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
-  background: var(--eds_ui_background__light,rgba(247,247,247,1));
+  background: var(--eds-input-background,var(--eds_ui_background__light,rgba(247,247,247,1)));
   outline: 1px solid transparent;
   outline-offset: 0px;
   background: transparent;

--- a/packages/eds-core-react/src/components/Search/__snapshots__/Search.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Search/__snapshots__/Search.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Search Matches snapshot 1`] = `
   border: none;
   box-sizing: border-box;
   box-shadow: inset 0px -1px 0px 0px var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
-  background: var(--eds_ui_background__light,rgba(247,247,247,1));
+  background: var(--eds-input-background,var(--eds_ui_background__light,rgba(247,247,247,1)));
   outline: 1px solid transparent;
   outline-offset: 0px;
 }

--- a/packages/eds-core-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/eds-core-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`TextField Matches snapshot 1`] = `
   border: none;
   box-sizing: border-box;
   box-shadow: inset 0px -1px 0px 0px var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
-  background: var(--eds_ui_background__light,rgba(247,247,247,1));
+  background: var(--eds-input-background,var(--eds_ui_background__light,rgba(247,247,247,1)));
   outline: 1px solid transparent;
   outline-offset: 0px;
 }


### PR DESCRIPTION
resolves #2712 

From before, which I did not even realize until I updated snapshots, is that the colors from token are already wrapped in a css-variable with the color as fallback. So technically you can (and some people probably do already) use that. But since that is a core token (`--eds_ui_background__light`) which will most likely change with the new token system, I think it is still better to have a local variable that won't randomly change in the future