### PR TITLE
🚸⚡️ Slider: prevent crossing min/max, performance improved

### DIFF
--- a/packages/eds-core-react/src/components/Slider/Output.tsx
+++ b/packages/eds-core-react/src/components/Slider/Output.tsx
@@ -1,4 +1,9 @@
-import { forwardRef, OutputHTMLAttributes, ReactNode } from 'react'
+import {
+  forwardRef,
+  OutputHTMLAttributes,
+  ReactNode,
+  CSSProperties,
+} from 'react'
 import styled from 'styled-components'
 import { typographyTemplate } from '@equinor/eds-utils'
 import { slider as tokens } from './Slider.tokens'
@@ -7,10 +12,7 @@ const {
   entities: { track, output },
 } = tokens
 
-type StyledProps = Pick<OutputProps, 'value'>
-
-const StyledOutput = styled.output<StyledProps>`
-  --val: ${({ value }) => value};
+const StyledOutput = styled.output`
   --realWidth: calc(100% - 12px);
   width: fit-content;
   position: relative;
@@ -40,7 +42,11 @@ type OutputProps = {
 export const Output = forwardRef<HTMLOutputElement, OutputProps>(
   function Output({ children, value, htmlFor }, ref) {
     return (
-      <StyledOutput ref={ref} value={value} htmlFor={htmlFor}>
+      <StyledOutput
+        ref={ref}
+        style={{ '--val': value } as CSSProperties}
+        htmlFor={htmlFor}
+      >
         {children}
       </StyledOutput>
     )

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -320,7 +320,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
   }
 
   const handleDragging = (e: MouseEvent) => {
-    console.log(e)
     if (e.type === 'mousedown') {
       setMousePressed(true)
     } else {

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -264,6 +264,18 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     if (isRangeSlider) {
       const newValue = sliderValue.slice()
       newValue[valueArrIdx] = changedValue
+
+      //Prevent min/max values from crossing eachother
+      if (valueArrIdx === 0 && newValue[0] >= newValue[1]) {
+        newValue[0] = newValue[1]
+        maxRange.current?.focus()
+      }
+
+      if (valueArrIdx === 1 && newValue[1] <= newValue[0]) {
+        newValue[1] = newValue[0]
+        minRange.current?.focus()
+      }
+
       setSliderValue(newValue)
       if (onChange) {
         // Callback for provided onChange func
@@ -302,18 +314,27 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     const bounds = target.getBoundingClientRect()
     const x = event.clientX - bounds.left
     const inputWidth = minRange.current.offsetWidth
-    const minValue = minRange.current.value
-    const maxValue = maxRange.current.value
+    const minValue = parseFloat(minRange.current.value)
+    const maxValue = parseFloat(maxRange.current.value)
     const diff = max - min
 
     const normX = (x / inputWidth) * diff + min
 
-    const maxX = Math.abs(normX - parseFloat(maxValue))
-    const minX = Math.abs(normX - parseFloat(minValue))
+    const maxX = Math.abs(normX - maxValue)
+    const minX = Math.abs(normX - minValue)
     if (minX > maxX) {
       minRange.current.style.zIndex = '10'
       maxRange.current.style.zIndex = '20'
     } else {
+      minRange.current.style.zIndex = '20'
+      maxRange.current.style.zIndex = '10'
+    }
+    //special cases where both thumbs are all the way to the left or right
+    if (minValue === maxValue && minValue === min) {
+      minRange.current.style.zIndex = '10'
+      maxRange.current.style.zIndex = '20'
+    }
+    if (minValue === maxValue && maxValue === max) {
       minRange.current.style.zIndex = '20'
       maxRange.current.style.zIndex = '10'
     }

--- a/packages/eds-core-react/src/components/Slider/Slider.tsx
+++ b/packages/eds-core-react/src/components/Slider/Slider.tsx
@@ -235,7 +235,6 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
 ) {
   const isRangeSlider = Array.isArray(value)
   const parsedValue: number[] = isRangeSlider ? value : [value]
-  //if (isRangeSlider) if (value[0] > value[1]) parsedValue.reverse()
   const [initalValue, setInitalValue] = useState<number[]>(parsedValue)
   const [sliderValue, setSliderValue] = useState<number[]>(parsedValue)
   const [mousePressed, setMousePressed] = useState<boolean>(false)

--- a/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -3,10 +3,9 @@
 exports[`Simple slider Matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="Slider__Wrapper-sc-n1grrg-1 iJEvSY"
+    class="Slider__Wrapper-sc-n1grrg-1 dnlaQa"
     id="test"
-    max="100"
-    min="0"
+    style="--min: 0; --max: 100; --value: 0; --background: var(--eds_interactive_primary__resting, rgba(0, 112, 121, 1));"
     value="0"
   >
     <input
@@ -24,9 +23,9 @@ exports[`Simple slider Matches snapshot 1`] = `
       value="0"
     />
     <output
-      class="Output__StyledOutput-sc-1dy945x-0 jXDBrj"
+      class="Output__StyledOutput-sc-1dy945x-0 hFTnui"
       for="test-thumb"
-      value="0"
+      style="--val: 0;"
     >
       0
     </output>


### PR DESCRIPTION
resolves #2782 

Decided preventing max and min from crossing was the easiest to implement and least confusing.
When keyboardnavigating, focus seamlessly shifts to the other thumb when they cross. With mouse the thumb stops when reaching equal value to the other thumb.

I also refactored how dynamic styles are injected to significantly improve performance of the slider and made custom props transient.