### PR TITLE
🐛 DialogHeader: fix css syntax errors

### DIFF
--- a/packages/eds-core-react/src/components/Dialog/DialogHeader.tsx
+++ b/packages/eds-core-react/src/components/Dialog/DialogHeader.tsx
@@ -27,8 +27,8 @@ export const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
     }
 
     return (
-      <div {...props}>
-        <StyledDialogHeader>{children}</StyledDialogHeader>
+      <div>
+        <StyledDialogHeader {...props}>{children}</StyledDialogHeader>
         <StyledDivider variant="small" color="medium" />
       </div>
     )

--- a/packages/eds-core-react/src/components/Dialog/DialogHeader.tsx
+++ b/packages/eds-core-react/src/components/Dialog/DialogHeader.tsx
@@ -7,8 +7,8 @@ export type DialogHeaderProps = HTMLAttributes<HTMLDivElement>
 const StyledDialogHeader = styled.div(({ theme }) => {
   return css`
     display: flex;
-    justify-content: space-betweene;
-    algin-items: center;
+    justify-content: space-between;
+    align-items: center;
     padding: ${theme.entities.children.spacings.top}
       ${theme.entities.children.spacings.right} 0
       ${theme.entities.children.spacings.left};

--- a/packages/eds-core-react/src/components/Dialog/DialogHeader.tsx
+++ b/packages/eds-core-react/src/components/Dialog/DialogHeader.tsx
@@ -27,8 +27,8 @@ export const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
     }
 
     return (
-      <div>
-        <StyledDialogHeader {...props}>{children}</StyledDialogHeader>
+      <div {...props}>
+        <StyledDialogHeader>{children}</StyledDialogHeader>
         <StyledDivider variant="small" color="medium" />
       </div>
     )


### PR DESCRIPTION
resolves #2798 

Not sure if moving `...rest` into the inner div is the right call. The problem the reporter of this bug have is setting style on DialogHeader, but it has a surrounding div to contain both the header and `Divider` to prevent an extra gap due to dialog being a grid. 
Normally we: 
1. set ...rest to the outermost element
2. make sure `style` and `className` goes to the same place

But here we would want style to go to the styled component. So either seperate it from classname or be consistent 