### PR TITLE
react-datepicker: added selects for changing view

### DIFF
--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Meta, Story } from '@storybook/react/types-6-0'
 import { DatePicker, DatePickerProps } from './DatePicker'
 import { TimePicker } from '../TimePicker/TimePicker'
-import { SelectHeader } from './SelectHeader'
+import { DatePickerSelectHeader } from './DatePickerSelectHeader'
 
 const Container = styled.div`
   height: 380px;
@@ -213,7 +213,7 @@ export const DatePickerWithCustomHeader: Story<DatePickerProps> = ({
       className={className}
       popperPlacement={popperPlacement}
       disableBeforeDate={new Date()}
-      renderCustomHeader={SelectHeader}
+      renderCustomHeader={DatePickerSelectHeader}
     />
   )
 }

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
@@ -139,6 +139,60 @@ export const DatePickerDisabledFuture: Story<DatePickerProps> = ({
   )
 }
 
+DatePickerDisabledFuture.parameters = {
+  docs: {
+    description: {
+      component: `The date picker with disabled future dates.`,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '1em', height: '380px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const DatePickerDisabled: Story<DatePickerProps> = ({
+  id,
+  dateValue,
+  className,
+  popperPlacement,
+}: DatePickerProps) => {
+  const [startDate, setStartDate] = useState(dateValue)
+  const onChanged = (date: Date): void => {
+    setStartDate(date)
+  }
+
+  return (
+    <DatePicker
+      id={id}
+      dateValue={startDate}
+      label={'Date'}
+      onChanged={onChanged}
+      className={className}
+      popperPlacement={popperPlacement}
+      disabled={true}
+    />
+  )
+}
+
+DatePickerDisabled.parameters = {
+  docs: {
+    description: {
+      component: `The date picker when disabled`,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '1em', height: '380px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
 export const DatePickerWithCustomHeader: Story<DatePickerProps> = ({
   id,
   dateValue,
@@ -168,21 +222,6 @@ DatePickerWithCustomHeader.parameters = {
   docs: {
     description: {
       component: `The date picker with custom header.`,
-    },
-  },
-  decorators: [
-    (Story) => (
-      <div style={{ padding: '1em', height: '380px' }}>
-        <Story />
-      </div>
-    ),
-  ],
-}
-
-DatePickerDisabledFuture.parameters = {
-  docs: {
-    description: {
-      component: `The date picker with disabled future dates.`,
     },
   },
   decorators: [

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { Meta, Story } from '@storybook/react/types-6-0'
 import { DatePicker, DatePickerProps } from './DatePicker'
 import { TimePicker } from '../TimePicker/TimePicker'
+import { SelectHeader } from './SelectHeader'
 
 const Container = styled.div`
   height: 380px;
@@ -136,6 +137,46 @@ export const DatePickerDisabledFuture: Story<DatePickerProps> = ({
       disableFuture={true}
     />
   )
+}
+
+export const DatePickerWithCustomHeader: Story<DatePickerProps> = ({
+  id,
+  dateValue,
+  className,
+  popperPlacement,
+}: DatePickerProps) => {
+  const [startDate, setStartDate] = useState(dateValue)
+  const onChanged = (date: Date): void => {
+    setStartDate(date)
+  }
+
+  return (
+    <DatePicker
+      id={id}
+      dateValue={startDate}
+      label={'Date'}
+      onChanged={onChanged}
+      className={className}
+      popperPlacement={popperPlacement}
+      disableBeforeDate={new Date()}
+      renderCustomHeader={SelectHeader}
+    />
+  )
+}
+
+DatePickerWithCustomHeader.parameters = {
+  docs: {
+    description: {
+      component: `The date picker with custom header.`,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '1em', height: '380px' }}>
+        <Story />
+      </div>
+    ),
+  ],
 }
 
 DatePickerDisabledFuture.parameters = {

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.stories.tsx
@@ -239,6 +239,9 @@ export default {
   argTypes: {},
   parameters: {
     docs: {
+      source: {
+        type: 'code',
+      },
       description: {
         component: `The date picker opens as an overlaying interactive calendar that allows the user to select a date. If a date is chosen, this is reflected in the input field.`,
       },

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tokens.ts
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tokens.ts
@@ -15,6 +15,7 @@ const {
     },
     interactive: {
       primary__resting: { rgba: focusColor },
+      disabled__text: { rgba: disabledText },
     },
     ui: {
       background__light: { rgba: background },
@@ -34,6 +35,7 @@ export interface DatePickerToken extends ComponentToken {
     green13: string
     green100: string
     iconGray: string
+    disabledText: string
   }
 }
 
@@ -44,6 +46,7 @@ export const datePicker: DatePickerToken = {
     green13: primary13,
     green100: primary100,
     iconGray: iconTertiary,
+    disabledText,
   },
   border: {
     type: 'border',

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -70,6 +70,7 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
       dateValue,
       onChanged,
       id,
+      disabled,
       disableFuture,
       disableBeforeDate,
       className,
@@ -113,6 +114,7 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
               ref={localRef}
               locale={locale}
               selected={date}
+              disabled={disabled}
               className="eds-datepicker"
               calendarClassName="eds-datepicker-calendar"
               onChange={onDateValueChange}

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -10,6 +10,7 @@ import {
 import DatePicker, {
   ReactDatePickerCustomHeaderProps,
   registerLocale,
+  ReactDatePickerProps,
 } from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import enGb from 'date-fns/locale/en-GB'
@@ -22,6 +23,18 @@ import { Paper, Icon, Label } from '@equinor/eds-core-react'
 
 registerLocale('en-gb', enGb)
 
+type ReactDatePickerComponentProps = Pick<
+  ReactDatePickerProps,
+  | 'className'
+  | 'dateFormat'
+  | 'popperPlacement'
+  | 'locale'
+  | 'renderCustomHeader'
+  | 'minDate'
+  | 'maxDate'
+  | 'readOnly'
+>
+
 export type DatePickerProps = {
   id: string
   dateValue: Date | undefined | null
@@ -30,31 +43,9 @@ export type DatePickerProps = {
   disableFuture?: boolean
   disableBeforeDate?: Date
   disableAfterDate?: Date
-  className?: string
-  dateFormat?: string
   placeholder?: string
-  readOnly?: boolean
-  popperPlacement?:
-    | 'auto-start'
-    | 'auto'
-    | 'auto-end'
-    | 'top-start'
-    | 'top'
-    | 'top-end'
-    | 'right-start'
-    | 'right'
-    | 'right-end'
-    | 'bottom-end'
-    | 'bottom'
-    | 'bottom-start'
-    | 'left-end'
-    | 'left'
-    | 'left-start'
-  locale?: string
-  renderCustomHeader?: (
-    params: ReactDatePickerCustomHeaderProps,
-  ) => React.ReactNode
-} & InputHTMLAttributes<HTMLInputElement>
+} & InputHTMLAttributes<HTMLInputElement> &
+  ReactDatePickerComponentProps
 
 export type DatePickerRefProps = DatePicker &
   InputHTMLAttributes<HTMLInputElement> & {
@@ -82,6 +73,8 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
       popperPlacement,
       locale = 'en-gb',
       renderCustomHeader,
+      minDate,
+      maxDate,
     },
     ref,
   ) {
@@ -164,6 +157,8 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
                 {children}
               </Paper>
             )}
+            minDate={minDate}
+            maxDate={maxDate}
           />
           <CalendarIcon
             name="calendar"

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -182,6 +182,7 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
 
 const Container = styled.div`
   width: 100%;
+  min-width: 128px;
   max-width: 148px;
   display: flex;
   flex-direction: column;

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -109,7 +109,7 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
 
     return (
       <ThemeProvider theme={tokens}>
-        <Container className={`date-picker ${className}`}>
+        <Container className={`date-picker ${className || ''}`}>
           <Label
             label={label}
             htmlFor={id}

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -272,7 +272,6 @@ const StyledDatepicker = styled(DatePicker)`
 
 const CalendarIcon = styled(Icon)`
   position: absolute;
-  z-index: 1;
   bottom: 7px;
   right: 6px;
   cursor: pointer;

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -7,7 +7,10 @@ import {
   useImperativeHandle,
   useEffect,
 } from 'react'
-import DatePicker, { registerLocale } from 'react-datepicker'
+import DatePicker, {
+  ReactDatePickerCustomHeaderProps,
+  registerLocale,
+} from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import enGb from 'date-fns/locale/en-GB'
 import styled, { css, ThemeProvider } from 'styled-components'
@@ -47,6 +50,9 @@ export type DatePickerProps = {
     | 'left'
     | 'left-start'
   locale?: string
+  renderCustomHeader?: (
+    params: ReactDatePickerCustomHeaderProps,
+  ) => React.ReactNode
 } & InputHTMLAttributes<HTMLInputElement>
 
 export type DatePickerRefProps = DatePicker &
@@ -72,6 +78,7 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
       readOnly = false,
       popperPlacement,
       locale = 'en-gb',
+      renderCustomHeader,
     },
     ref,
   ) {
@@ -90,6 +97,12 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
 
     const localRef = useRef<DatePicker | null>()
     useImperativeHandle(ref, () => localRef.current)
+
+    const customHeader =
+      renderCustomHeader ||
+      ((props: ReactDatePickerCustomHeaderProps) => (
+        <PopupHeader {...props} changeDate={onDateValueChange} />
+      ))
 
     return (
       <ThemeProvider theme={tokens}>
@@ -128,9 +141,7 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
               }}
               autoComplete="false"
               popperPlacement={popperPlacement}
-              renderCustomHeader={(props) => (
-                <PopupHeader {...props} changeDate={onDateValueChange} />
-              )}
+              renderCustomHeader={customHeader}
               shouldCloseOnSelect={true}
               readOnly={readOnly}
               calendarContainer={({ children, ...rest }) => (

--- a/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePicker.tsx
@@ -139,14 +139,14 @@ const ReactDatePicker = forwardRef<DatePickerRefProps, DatePickerProps>(
               }
             }}
             filterDate={(date: Date): boolean => {
-              if (disableFuture) {
-                return new Date() > date
+              if (disableFuture && new Date() < date) {
+                return false
               }
-              if (disableBeforeDate) {
-                return date > disableBeforeDate
+              if (disableBeforeDate && date < disableBeforeDate) {
+                return false
               }
-              if (disableAfterDate) {
-                return date < disableAfterDate
+              if (disableAfterDate && date > disableAfterDate) {
+                return false
               }
               return true
             }}

--- a/packages/eds-lab-react/src/components/DatePicker/DatePickerSelectHeader.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/DatePickerSelectHeader.tsx
@@ -4,7 +4,7 @@ import { arrow_back, arrow_forward } from '@equinor/eds-icons'
 import { Icon, Button, NativeSelect } from '@equinor/eds-core-react'
 import { ReactDatePickerCustomHeaderProps } from 'react-datepicker'
 
-const SelectHeader: React.FC<ReactDatePickerCustomHeaderProps> = ({
+const DatePickerSelectHeader: React.FC<ReactDatePickerCustomHeaderProps> = ({
   date,
   changeYear,
   changeMonth,
@@ -133,4 +133,4 @@ const IconButton = styled(Button)`
   }
 `
 
-export { SelectHeader }
+export { DatePickerSelectHeader }

--- a/packages/eds-lab-react/src/components/DatePicker/SelectHeader.tsx
+++ b/packages/eds-lab-react/src/components/DatePicker/SelectHeader.tsx
@@ -1,18 +1,13 @@
 import styled from 'styled-components'
-import { getMonth, getYear } from 'date-fns'
 import { datePicker as tokens } from './DatePicker.tokens'
 import { arrow_back, arrow_forward } from '@equinor/eds-icons'
-import { typographyTemplate } from '@equinor/eds-utils'
-import { Typography, Icon, Button } from '@equinor/eds-core-react'
+import { Icon, Button, NativeSelect } from '@equinor/eds-core-react'
 import { ReactDatePickerCustomHeaderProps } from 'react-datepicker'
 
-type PopupHeaderProps = ReactDatePickerCustomHeaderProps & {
-  changeDate?: (date: Date) => void
-}
-
-const PopupHeader: React.FC<PopupHeaderProps> = ({
+const SelectHeader: React.FC<ReactDatePickerCustomHeaderProps> = ({
   date,
-  changeDate,
+  changeYear,
+  changeMonth,
   decreaseMonth,
   increaseMonth,
   prevMonthButtonDisabled,
@@ -33,6 +28,11 @@ const PopupHeader: React.FC<PopupHeaderProps> = ({
     'December',
   ]
 
+  const years: number[] = []
+  for (let i = 1970; i < 2060; i++) {
+    years.push(i)
+  }
+
   return (
     <Header>
       <IconButton
@@ -47,12 +47,32 @@ const PopupHeader: React.FC<PopupHeaderProps> = ({
         <Icon data={arrow_back} />
       </IconButton>
       <HeaderControls>
-        <HeaderTitle variant="body_short">
-          {months[getMonth(date)]} {getYear(date)}
-        </HeaderTitle>
-        <TodayLabel variant="ghost" onClick={() => changeDate?.(new Date())}>
-          Today
-        </TodayLabel>
+        <YearSelect
+          id="SelectHeaderYear"
+          label=""
+          name="year"
+          onChange={({ target: { value } }) => changeYear(Number(value))}
+          value={date.getFullYear()}
+        >
+          {years.map((year) => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))}
+        </YearSelect>
+        <MonthSelect
+          id="SelectHeaderMonth"
+          label=""
+          name="month"
+          onChange={({ target: { value } }) => changeMonth(Number(value))}
+          value={date.getMonth()}
+        >
+          {months.map((month, i) => (
+            <option key={month} value={i}>
+              {month}
+            </option>
+          ))}
+        </MonthSelect>
       </HeaderControls>
       <IconButton
         variant="ghost_icon"
@@ -69,8 +89,20 @@ const PopupHeader: React.FC<PopupHeaderProps> = ({
   )
 }
 
+const MonthSelect = styled(NativeSelect)`
+  select {
+    max-width: 110px;
+  }
+`
+
+const YearSelect = styled(NativeSelect)`
+  select {
+    max-width: 95px;
+  }
+`
+
 const Header = styled.div`
-  padding: ${tokens.spacings.top} ${tokens.spacings.right};
+  padding: ${tokens.spacings.top} calc(${tokens.spacings.right} / 2);
   width: 100%;
   max-width: ${tokens.width};
   display: grid;
@@ -82,6 +114,7 @@ const Header = styled.div`
 
 const HeaderControls = styled.div`
   display: grid;
+  gap: 2px;
   place-items: center;
   grid-auto-flow: column;
 `
@@ -100,16 +133,4 @@ const IconButton = styled(Button)`
   }
 `
 
-const HeaderTitle = styled(Typography)`
-  ${typographyTemplate(tokens.entities.title.typography)}
-`
-
-const TodayLabel = styled(Button)`
-  width: 100%;
-
-  span {
-    padding-left: 0 !important;
-  }
-`
-
-export { PopupHeader }
+export { SelectHeader }


### PR DESCRIPTION
### Description
The DatePicker component has a cumbersome navigation when you have to navigate several years.

- To simplify navigation i've added support for adding a custom header component.
- Forwarded disabled prop to allow disabling of DatePicker
- added min-width 128px to avoid icon overlapping label/text
- added disableAfterDate (considered overriding using a filterDate prop, but kept it in line with existing code instead)
- reworked filterDate to be able to use both disableBeforeDate and disableAfterDate at the same time
- removed the custom label and imported EDS Label
- Added disabled styling
- Forwarded minDate & maxDate

### minDate

When using disableBeforeDate for a future date, minDate seems like the only way to start picking dates in future without setting a date value

Also use this in our project to feed the component:

```
const minDate = disableBeforeDate;
const maxDate = disableAfterDate;
```

Otherwise if you want the user to start picking dates from 2024, they will start on current month with everything disabled. This way the user gets to start at the beginning of the valid time range

### DatePickerSelectHeader
There is an example DatePickerSelectHeadercomponent in this PR that's put in a Story for testing, but I'm not sure if it's wanted as it hasn't gone through the official channels and requires some more work

Resolves #2830 
