### PR TITLE
🔖Release eds-core-react@0.31.1

### DIFF
--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.1] - 2023-04-25
+
+### Fixed
+
+- 🐛 `Menu`: Fixed a warning occurring when using `Menu.Item` as `react-router` `Link` by @oddvernes in https://github.com/equinor/design-system/pull/2858
+
 ## [0.31.0] - 2023-04-25
 
 ### Added

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"


### PR DESCRIPTION
resolves #2859

Patches warning when using menu.item as react-router Link