### PR TITLE
💄Sidebar: Remove visible scrollbar when closed

### DIFF
--- a/packages/eds-core-react/src/components/SideBar/SideBar.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBar.tsx
@@ -49,6 +49,14 @@ const GridContainer = styled.div<ContainerProps>(({ theme, open }) => {
     overflow: auto;
     width: ${open ? theme.maxWidth : theme.minWidth};
     min-width: ${open ? theme.maxWidth : theme.minWidth};
+    ${!open &&
+    css`
+      scrollbar-width: none; //firefox
+      //chrome/edge/safari
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    `}
   `
 })
 


### PR DESCRIPTION
resolves #2853 

I propose we visibly hide the scrollbar when sidebar is collapsed. The scrolling is still accessible with mouse scrollwheel or dragging finger on touch screen or tabbing through items on keyboard. this is the solution they have in the slack sidebar (where you click between organizations). Also considering this is a pretty unlikely edge case 🤷‍♂️ 