### PR TITLE
📝 Storybook: Add null as a possible value for useState hooks that receive HTML elements to avoid type error

### DIFF
--- a/packages/eds-core-react/src/components/Button/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/eds-core-react/src/components/Button/ButtonGroup/ButtonGroup.stories.tsx
@@ -67,7 +67,7 @@ export const Vertical: StoryFn<ButtonGroupProps> = () => (
 export const Split: StoryFn<ButtonGroupProps> = () => {
   const options = ['Create task', 'Update task', 'Delete task']
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
 
   const handleMenuItemClick = (event: React.MouseEvent, index: number) => {

--- a/packages/eds-core-react/src/components/Menu/Menu.docs.mdx
+++ b/packages/eds-core-react/src/components/Menu/Menu.docs.mdx
@@ -32,7 +32,7 @@ import { Menu } from '@equinor/eds-core-react'
 
 const Demo = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const openMenu = () => {
     setIsOpen(true)

--- a/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
+++ b/packages/eds-core-react/src/components/Menu/Menu.stories.tsx
@@ -67,7 +67,7 @@ const onClick = (event: React.MouseEvent) => {
 
 export const Introduction: StoryFn<MenuProps> = (args) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const openMenu = () => {
     setIsOpen(true)
@@ -116,7 +116,7 @@ Introduction.args = {
 
 export const Complex: StoryFn<MenuProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const openMenu = () => {
     setIsOpen(true)
@@ -256,7 +256,7 @@ export const Complex: StoryFn<MenuProps> = () => {
 export const Compact: StoryFn<MenuProps> = () => {
   const [density, setDensity] = useState<Density>('comfortable')
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const openMenu = () => {
     setIsOpen(true)
@@ -302,7 +302,7 @@ export const Compact: StoryFn<MenuProps> = () => {
 
 export const StaysOpen: StoryFn<MenuProps> = (args) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const [optionOne, setOptionOne] = useState<boolean>(false)
   const [optionTwo, setOptionTwo] = useState<boolean>(false)
   const [optionThree, setOptionThree] = useState<boolean>(false)
@@ -398,7 +398,7 @@ StaysOpen.args = {
 
 export const MatchWidth: StoryFn<MenuProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const openMenu = () => {
     setIsOpen(true)
@@ -441,7 +441,7 @@ export const MatchWidth: StoryFn<MenuProps> = () => {
 
 export const AsLink: StoryFn<MenuProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const openMenu = () => {
     setIsOpen(true)

--- a/packages/eds-core-react/src/components/SideBar/SideBar.stories.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBar.stories.tsx
@@ -162,7 +162,7 @@ export const CustomContent: StoryFn<SidebarType> = () => {
 
 export const WithButton: StoryFn<SidebarType> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const openMenu = () => {
     setIsOpen(true)


### PR DESCRIPTION
Adds null as possible type for anchor Elements in storybooks documentation.
This does not produce and error in the eds project itself as typescript is not set to strict, but does produce an error in most projects.

The default for most popular react bootstrapping tools like: create-react-app, create-vite and create-next-app default to typescript in strict mode.