### PR TITLE
fixed: Issue with refocusing after closing floating dialog

### DIFF
--- a/packages/eds-core-react/src/components/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.tsx
@@ -43,10 +43,19 @@ export type DialogProps = {
   open: boolean
   /** callback to handle closing scrim */
   onClose?: () => void
+  /** Wheter the dialog should return focus to the previous focused element */
+  returnFocus?: boolean
 } & React.HTMLAttributes<HTMLDivElement>
 
 export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
-  { children, open, onClose, isDismissable = false, ...props },
+  {
+    children,
+    open,
+    onClose,
+    isDismissable = false,
+    returnFocus = true,
+    ...props
+  },
   ref,
 ) {
   const { density } = useEds()
@@ -71,7 +80,11 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
       <ThemeProvider theme={token}>
         {open && (
           <Scrim open isDismissable={isDismissable} onClose={handleDismiss}>
-            <FloatingFocusManager context={context} modal returnFocus>
+            <FloatingFocusManager
+              context={context}
+              modal
+              returnFocus={returnFocus}
+            >
               <StyledDialog elevation="above_scrim" {...rest} ref={dialogRef}>
                 {children}
               </StyledDialog>

--- a/packages/eds-core-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/eds-core-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -6,12 +6,15 @@ import {
   Table,
   Icon,
   Checkbox,
+  Dialog,
 } from '../..'
 import { data, columns, toCellValues } from '../../stories'
 import { StoryFn, Meta } from '@storybook/react'
 import { explore } from '@equinor/eds-icons'
 import { Stack } from './../../../.storybook/components'
 import page from './Tooltip.docs.mdx'
+import styled from 'styled-components'
+import { useState } from 'react'
 
 const meta: Meta<typeof Tooltip> = {
   title: 'Data Display/Tooltip',
@@ -34,6 +37,14 @@ const meta: Meta<typeof Tooltip> = {
     },
   ],
 }
+
+const Wrapper = styled.div`
+  display: grid;
+  column-gap: 16px;
+  grid-template-columns: repeat(2, auto);
+  justify-content: end;
+  justify-self: end;
+`
 
 export default meta
 
@@ -169,3 +180,36 @@ export const TooltipOnButton: StoryFn<TooltipProps> = () => (
   </>
 )
 TooltipOnButton.storyName = 'Tooltip on disabled Button'
+
+export const TooltipOnButtonWithDialog: StoryFn<TooltipProps> = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  const handleOpen = () => {
+    setIsOpen(true)
+  }
+  const handleClose = () => {
+    setIsOpen(false)
+  }
+  return (
+    <>
+      <Tooltip title="Click to open dialog">
+        <Button onClick={handleOpen}>Click me</Button>
+      </Tooltip>
+      <Dialog
+        open={isOpen}
+        onClose={handleClose}
+        isDismissable
+        returnFocus={false}
+      >
+        <Dialog.Header>
+          <Dialog.Title>Close me</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Actions>
+          <Wrapper>
+            <Button onClick={handleClose}>Close</Button>
+          </Wrapper>
+        </Dialog.Actions>
+      </Dialog>
+    </>
+  )
+}
+TooltipOnButtonWithDialog.storyName = 'Tooltip on Button with dialog'


### PR DESCRIPTION
When closing a díalog utilizing the floating-ui library the previous focused element is always refocused. This pull-request makes this feature an optional configuration.