### PR TITLE
♻️🚸Dialog: refactor to use native dialog

### DIFF
--- a/packages/eds-core-react/src/components/Dialog/Dialog.docs.mdx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.docs.mdx
@@ -45,7 +45,7 @@ const Demo = () => {
       <Button aria-haspopup="dialog" onClick={handleOpen}>
         Trigger Dialog
       </Button>
-      <Dialog open={isOpen}>
+      <Dialog open={isOpen} isDismissable onClose={handleClose}>
         <Dialog.Header>
           <Dialog.Title>Title</Dialog.Title>
         </Dialog.Header>

--- a/packages/eds-core-react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.stories.tsx
@@ -53,6 +53,16 @@ const RadioWrapper = styled(Radio)`
   display: flex;
 `
 
+const Placeholder = styled.div`
+  background: rgba(255, 146, 0, 0.15);
+  border: 1px dashed #ff9200;
+  box-sizing: border-box;
+  border-radius: 4px;
+  padding: 8px;
+  width: 100%;
+  display: inline-block;
+`
+
 export const Introduction: StoryFn<DialogProps> = (args) => {
   const { open, isDismissable } = args
   const [, updateArgs] = useArgs()
@@ -164,16 +174,6 @@ export const PlaceholderPlusAction: StoryFn<DialogProps> = () => {
   const handleClose = () => {
     setIsOpen(false)
   }
-
-  const Placeholder = styled.div`
-    background: rgba(255, 146, 0, 0.15);
-    border: 1px dashed #ff9200;
-    box-sizing: border-box;
-    border-radius: 4px;
-    padding: 8px;
-    width: 100%;
-    display: inline-block;
-  `
 
   return (
     <>

--- a/packages/eds-core-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.test.tsx
@@ -17,6 +17,10 @@ const StyledDialog = styled(Dialog)`
   min-height: ${minHeight};
   width: ${width};
 `
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = jest.fn()
+  HTMLDialogElement.prototype.close = jest.fn()
+})
 
 afterEach(cleanup)
 
@@ -60,10 +64,9 @@ describe('Dialog', () => {
   it('Is dismissable with button click', () => {
     render(<DismissableDialog data-testid="dialog" />)
     const dialog = screen.getByTestId('dialog')
-
     expect(dialog).toBeInTheDocument()
-    expect(screen.queryByText('OK')).toBeVisible()
-    const targetButton = screen.queryByText('OK')
+    expect(screen.getByText('OK')).toBeInTheDocument()
+    const targetButton = screen.getByText('OK')
     fireEvent.click(targetButton)
     expect(dialog).not.toBeInTheDocument()
   })
@@ -72,7 +75,7 @@ describe('Dialog', () => {
     const dialog = screen.getByTestId('dialog')
 
     expect(dialog).toBeInTheDocument()
-    expect(screen.queryByText('OK')).toBeVisible()
+    expect(screen.getByText('OK')).toBeInTheDocument()
     fireEvent.keyDown(dialog, {
       key: 'Escape',
     })

--- a/packages/eds-core-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.test.tsx
@@ -17,6 +17,7 @@ const StyledDialog = styled(Dialog)`
   min-height: ${minHeight};
   width: ${width};
 `
+//dialog is not yet implemented in jsdom, keep an eye on: https://github.com/jsdom/jsdom/issues/3294
 beforeAll(() => {
   HTMLDialogElement.prototype.showModal = jest.fn()
   HTMLDialogElement.prototype.close = jest.fn()

--- a/packages/eds-core-react/src/components/Dialog/Dialog.tokens.ts
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.tokens.ts
@@ -12,6 +12,7 @@ const {
   colors: {
     ui: {
       background__default: { rgba: background },
+      background__scrim: { rgba: backdrop },
     },
   },
   shape: {
@@ -52,6 +53,9 @@ export const dialog: DialogToken = {
     },
     actions: {
       minHeight: '48px',
+    },
+    scrim: {
+      background: backdrop,
     },
   },
   modes: {

--- a/packages/eds-core-react/src/components/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.tsx
@@ -57,8 +57,8 @@ export type DialogProps = {
   /** callback to handle closing */
   onClose?: () => void
   /**
-   * Wether the dialog should return focus to the previous focused element
-   * @deprecated  Component is now based on native dialog and no longer uses floating-ui
+   * return focus to the previous focused element
+   * @deprecated  Component is now based on native dialog where focus is handled by the browser automatically
    * */
   returnFocus?: boolean
   dialogRef?: ForwardedRef<HTMLDialogElement>

--- a/packages/eds-core-react/src/components/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.tsx
@@ -104,7 +104,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
       }
   }
   useGlobalKeyPress('Escape', (e) => {
-    if (!isDismissable) e.preventDefault()
+    e.preventDefault()
     if (isDismissable && onClose && open) {
       onClose && onClose()
     }

--- a/packages/eds-core-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -83,12 +83,8 @@ exports[`Dialog Matches snapshot 1`] = `
 <div
   aria-describedby="eds-dialog-customcontent"
   aria-labelledby="eds-dialog-title"
-  aria-modal="true"
   class="c0 c1"
   data-testid="dialog"
-  open=""
-  role="dialog"
-  tabindex="-1"
 >
   <div
     class="c2"

--- a/packages/eds-utils/src/hooks/useHideBodyScroll.ts
+++ b/packages/eds-utils/src/hooks/useHideBodyScroll.ts
@@ -1,17 +1,39 @@
 import { useEffect, useRef } from 'react'
 
+type Styles = {
+  overflow: string
+  paddingRight: string
+}
+
 export const useHideBodyScroll = (active: boolean): void => {
-  const overflowState = useRef<string | undefined>()
+  const originalStyles = useRef<Styles | undefined>()
   useEffect(() => {
+    if (typeof document === 'undefined') return
+    const html = document.documentElement
+    const { body } = document
+
     if (active) {
-      overflowState.current = document.body.style.overflow
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = overflowState.current
+      const scrollBarWidth = window.innerWidth - html.clientWidth
+      const bodyPaddingRight =
+        parseInt(
+          window.getComputedStyle(body).getPropertyValue('padding-right'),
+        ) || 0
+      const oldStyle: Styles = {
+        overflow: body.style.overflow,
+        paddingRight: body.style.paddingRight,
+      }
+      originalStyles.current = oldStyle
+
+      body.style.overflow = 'hidden'
+      body.style.paddingRight = `${bodyPaddingRight + scrollBarWidth}px`
+    } else if (originalStyles.current) {
+      body.style.overflow = originalStyles.current.overflow
+      body.style.paddingRight = originalStyles.current.paddingRight
     }
-    const originalState = overflowState.current
+    const originalState = originalStyles.current
     return () => {
-      document.body.style.overflow = originalState
+      body.style.overflow = originalState?.overflow
+      body.style.paddingRight = originalState?.paddingRight
     }
   }, [active])
 }


### PR DESCRIPTION
resolves #2949 

removes `Scrim` and `floating-ui` as dependencies and instead uses a native `<dialog>` element in modal mode (uses `DialogElement.showModal()`)
I kept the functionality the same as the old Dialog to not introduce breaking changes (which means i did block pressing escape to close unless `isDismissable` is true, maybe something to discuss