### PR TITLE
🔖Release eds-core-react-0.32.1

### DIFF
--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ⏪️Added back commonjs build and changed file extension of modules from `.mjs` to `.js` due to a compatability issue with `React 17`. Restricted `styled-components` to below version 6 in `peerDependencies`.
+- ⏪️Added back commonjs build and changed file extension of modules from `.mjs` to `.js` due to a compatability issue with `React 17`. 
+- 📌 Restricted `styled-components` to below version 6 in `peerDependencies`. this package does not support v6 yet.
 
 ## [0.32.0] - 2023-07-10
 

--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.1] - 2023-07-11
+
+### Changed
+
+- ⏪️Added back commonjs build and changed file extension of modules from `.mjs` to `.js` due to a compatability issue with `React 17`. Restricted `styled-components` to below version 6 in `peerDependencies`.
+
 ## [0.32.0] - 2023-07-10
 
 ### Fixed

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -5,14 +5,9 @@
   "sideEffects": [
     "**/*.css"
   ],
-  "exports": {
-    "import": {
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.js"
-    }
-  },
   "types": "dist/types/index.d.ts",
-  "module": "./dist/esm/index.js",
+  "main": "dist/eds-core-react.cjs",
+  "module": "dist/esm/index.js",
   "license": "MIT",
   "author": {
     "name": "EDS Core Team",

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,19 +1,18 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.32.0",
+  "version": "0.32.1-dev20230711",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"
   ],
-  "type": "module",
   "exports": {
     "import": {
       "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.mjs"
+      "default": "./dist/esm/index.js"
     }
   },
   "types": "dist/types/index.d.ts",
-  "module": "./dist/esm/index.mjs",
+  "module": "./dist/esm/index.js",
   "license": "MIT",
   "author": {
     "name": "EDS Core Team",

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.32.1-dev20230711",
+  "version": "0.32.1",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -88,7 +88,7 @@
   "peerDependencies": {
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "styled-components": ">=4.2"
+    "styled-components": ">=4.2 < 6"
   },
   "dependencies": {
     "@babel/runtime": "^7.22.5",

--- a/packages/eds-core-react/rollup.config.js
+++ b/packages/eds-core-react/rollup.config.js
@@ -48,7 +48,9 @@ export default [
         preserveModulesRoot: 'src',
         format: 'es',
         sourcemap: isDevelopment,
+        /* entryFileNames: '[name].mjs', */
       },
+      { file: './dist/eds-core-react.cjs', format: 'cjs' },
     ],
   },
 ]

--- a/packages/eds-core-react/rollup.config.js
+++ b/packages/eds-core-react/rollup.config.js
@@ -48,7 +48,6 @@ export default [
         preserveModulesRoot: 'src',
         format: 'es',
         sourcemap: isDevelopment,
-        entryFileNames: '[name].mjs',
       },
     ],
   },

--- a/packages/eds-lab-react/jest.config.cjs
+++ b/packages/eds-lab-react/jest.config.cjs
@@ -11,7 +11,7 @@ module.exports = {
     '^react$': '<rootDir>/node_modules/react',
     '^styled-components$': '<rootDir>/node_modules/styled-components',
     '^@equinor/eds-core-react$':
-      '<rootDir>/node_modules/@equinor/eds-core-react/dist/esm/index.mjs',
+      '<rootDir>/node_modules/@equinor/eds-core-react/dist/esm/index.js',
   },
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$',
   moduleFileExtensions: ['ts', 'tsx', 'js'],


### PR DESCRIPTION
resolves #2962 

I think stoybook fixed the issue with modules in one of the dependency updates because now it seems I am able to build and run the storybook using the old and technically incorrect syntax in package.json, which is needed for react 17 users to run core-react