### PR TITLE
🐛 Dialog: remove check to allow open on mount

### DIFF
--- a/packages/eds-core-react/src/components/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.tsx
@@ -72,7 +72,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
   )
 
   useEffect(() => {
-    if (open && !localRef?.current?.hasAttribute('open')) {
+    if (open) {
       localRef?.current?.showModal()
     } else {
       localRef?.current?.close()


### PR DESCRIPTION
resolves #3002 

I was unable to reproduce this problem in storybook, but was able to do it in downstream app and this fix seems to have resolved it 🤷‍♂️. I don't remember if I added the check (this pr removes) due to a bug or just an assumption that calling showModal multiple times is bad but it doesn't seem like removing it is causing any ill effects 🤞 