### PR TITLE
🐛Autocomplete: Added a workaround for touch crash

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Option.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Option.tsx
@@ -27,6 +27,7 @@ const StyledListItem = styled.li<StyledListItemType>(
       background-color: ${backgroundColor};
       user-select: none;
       overflow: hidden;
+      touch-action: manipulation;
       cursor: ${highlighted === 'true' ? 'pointer' : 'default'};
       ${typographyTemplate(theme.typography)}
       ${spacingsTemplate(theme.spacings)}
@@ -80,7 +81,12 @@ function AutocompleteOptionInner<T>(
       isdisabled={isDisabled ? 'true' : 'false'}
       aria-hidden={isDisabled}
       active={!multiple && isSelected ? 'true' : 'false'}
-      onClick={(e) => !isDisabled && onClick(e)}
+      onClick={(e) => {
+        //timeout: workaround for "Maximum update depth exceeded" error that happens when touch input
+        setTimeout(() => {
+          !isDisabled && onClick(e)
+        }, 0)
+      }}
       aria-selected={multiple ? isSelected : ariaSelected}
       {...other}
     >

--- a/packages/eds-core-react/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`Autocomplete Matches snapshot 1`] = `
   -ms-user-select: none;
   user-select: none;
   overflow: hidden;
+  touch-action: manipulation;
   cursor: default;
   margin: 0;
   color: var(--eds_text__static_icons__default,rgba(61,61,61,1));


### PR DESCRIPTION
resolves #2889 

This does not fix the problem completely, but at least now it does not crash the component on item click using touch input.
I can still trigger "maximum update depth" infinite loop by selecting items quickly enough with keyboard on multiselect.
It looks to be some sort of race condition inside downshift that the added settimeout mitigates