### PR TITLE
✨Tabs: controlled mode

### DIFF
--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -76,6 +76,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.0",
+    "react-router-dom": "^6.15.0",
     "remark-gfm": "^3.0.1",
     "rollup": "^3.25.3",
     "rollup-plugin-delete": "^2.0.0",

--- a/packages/eds-core-react/pnpm-lock.yaml
+++ b/packages/eds-core-react/pnpm-lock.yaml
@@ -133,6 +133,9 @@ devDependencies:
   react-hook-form:
     specifier: ^7.45.0
     version: 7.45.0(react@18.2.0)
+  react-router-dom:
+    specifier: ^6.15.0
+    version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
   remark-gfm:
     specifier: ^3.0.1
     version: 3.0.1
@@ -2709,6 +2712,11 @@ packages:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
       '@babel/runtime': 7.22.5
+    dev: true
+
+  /@remix-run/router@1.8.0:
+    resolution: {integrity: sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /@rollup/plugin-babel@6.0.3(@babel/core@7.22.10)(rollup@3.25.3):
@@ -9378,6 +9386,29 @@ packages:
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /react-router-dom@6.15.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.8.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 6.15.0(react@18.2.0)
+    dev: true
+
+  /react-router@6.15.0(react@18.2.0):
+    resolution: {integrity: sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.8.0
+      react: 18.2.0
     dev: true
 
   /react-style-singleton@2.2.1(@types/react@18.0.21)(react@18.2.0):

--- a/packages/eds-core-react/src/components/Tabs/Tab.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tab.tsx
@@ -108,6 +108,7 @@ export type TabProps = {
 export const Tab: OverridableSubComponent = forwardRef<
   HTMLButtonElement,
   TabProps
->(function Tab({ active, ...rest }, ref) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+>(function Tab({ active, value, ...rest }, ref) {
   return <StyledTab ref={ref} $active={active} {...rest} />
 })

--- a/packages/eds-core-react/src/components/Tabs/Tab.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tab.tsx
@@ -99,6 +99,8 @@ const StyledTab = styled.button.attrs<StyledTabProps>(
 export type TabProps = {
   /** @ignore */
   active?: boolean
+  /** Optional to `onChange` on Tabs. A value that when matched with
+   * `activeTab` will set tab as active (such as the path when using third party routers) */
   value?: number | string
   /** If `true`, the tab will be disabled. */
   disabled?: boolean

--- a/packages/eds-core-react/src/components/Tabs/Tab.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tab.tsx
@@ -17,15 +17,16 @@ type OverridableSubComponent = OverridableComponent<
 type StyledTabProps = {
   $active?: boolean
   disabled: boolean
+  $value: string | number
 }
 
 const StyledTab = styled.button.attrs<StyledTabProps>(
-  ({ $active = false, disabled = false }) => ({
+  ({ $active = false, disabled = false, $value }) => ({
     type: 'button',
     role: 'tab',
     'aria-selected': $active,
     'aria-disabled': disabled,
-    tabIndex: $active ? '0' : '-1',
+    tabIndex: $value ? '0' : $active ? '0' : '-1',
   }),
 )<StyledTabProps>(({ theme, $active, disabled }) => {
   const {
@@ -108,7 +109,6 @@ export type TabProps = {
 export const Tab: OverridableSubComponent = forwardRef<
   HTMLButtonElement,
   TabProps
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 >(function Tab({ active, value, ...rest }, ref) {
-  return <StyledTab ref={ref} $active={active} {...rest} />
+  return <StyledTab ref={ref} $active={active} $value={value} {...rest} />
 })

--- a/packages/eds-core-react/src/components/Tabs/Tab.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tab.tsx
@@ -98,6 +98,7 @@ const StyledTab = styled.button.attrs<StyledTabProps>(
 export type TabProps = {
   /** @ignore */
   active?: boolean
+  value?: number | string
   /** If `true`, the tab will be disabled. */
   disabled?: boolean
   /** Override element type */

--- a/packages/eds-core-react/src/components/Tabs/Tabs.context.ts
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.context.ts
@@ -5,7 +5,7 @@ type State = {
   variant: Variants
   scrollable: boolean
   handleChange: (index: number) => void
-  activeTab: number
+  activeTab: number | string
   tabsId: string
   tabsFocused: boolean
 }

--- a/packages/eds-core-react/src/components/Tabs/Tabs.docs.mdx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.docs.mdx
@@ -81,14 +81,16 @@ Focus outline is only visible when navigating using the keyboard.
 import { Tabs } from '@equinor/eds-core-react'
 import { Link, Outlet } from "react-router-dom";
 
-  <Tabs>
+  <Tabs activeTab="/foo/bar">
   <Tabs.List>
-      <Tabs.Tab as={Link} to="/foo/bar">bar</Tabs.Tab>
-      <Tabs.Tab as={Link} to="/foo/baz">baz</Tabs.Tab>
+      <Tabs.Tab as={Link} value="/foo/bar" to="/foo/bar">bar</Tabs.Tab>
+      <Tabs.Tab as={Link} value="/foo/baz" to="/foo/baz">baz</Tabs.Tab>
   </Tabs.List>
   <Outlet />
   </Tabs>
 ```
+Routes can of course be entered by other means than clicking tabs. Therefore, we can not reliably use `onChange` to send a new index to `activeTab`. Instead `activeTab` can take a string value that sets the correct active tab if it matches the `value` prop on a tab. In the below example we use `react-router-dom` and its provided functions to match the current path to the correct tab.
+<Canvas of={ComponentStories.Router} />
 
 ### With search
 

--- a/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.stories.tsx
@@ -7,6 +7,14 @@ import { Meta, StoryFn } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Stack } from './../../../.storybook/components'
 import page from './Tabs.docs.mdx'
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  Link,
+  matchPath,
+  useLocation,
+} from 'react-router-dom'
 
 const icons = {
   chevron_left,
@@ -181,6 +189,65 @@ WithPanels.decorators = [
   (Story) => {
     return (
       <Stack>
+        <Story />
+      </Stack>
+    )
+  },
+]
+
+export const Router: StoryFn<TabsProps> = () => {
+  /*import {MemoryRouter, Route, Routes, Link, matchPath, useLocation} from 'react-router-dom' */
+  function CurrentRoute() {
+    const location = useLocation()
+    return <Typography>Current route: {location.pathname}</Typography>
+  }
+  function useRouteMatch(patterns: readonly string[]) {
+    const { pathname } = useLocation()
+
+    for (let i = 0; i < patterns.length; i += 1) {
+      const pattern = patterns[i]
+      const possibleMatch = matchPath(pattern, pathname)
+      if (possibleMatch !== null) {
+        return possibleMatch
+      }
+    }
+
+    return null
+  }
+  function RouterTabs() {
+    const routeMatch = useRouteMatch(['/wells/:id', '/home', '/settings'])
+    const currentPath = routeMatch?.pattern?.path
+
+    return (
+      <Tabs activeTab={currentPath}>
+        <Tabs.List>
+          <Tabs.Tab value="/home" to="/home" as={Link}>
+            Home
+          </Tabs.Tab>
+          <Tabs.Tab value="/wells/:id" to="/wells/1" as={Link}>
+            Wells
+          </Tabs.Tab>
+          <Tabs.Tab value="/settings" to="/settings" as={Link}>
+            Settings
+          </Tabs.Tab>
+        </Tabs.List>
+      </Tabs>
+    )
+  }
+
+  return (
+    <MemoryRouter initialEntries={['/home']} initialIndex={0}>
+      <RouterTabs />
+      <Routes>
+        <Route path="*" element={<CurrentRoute />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+Router.decorators = [
+  (Story) => {
+    return (
+      <Stack direction="column">
         <Story />
       </Stack>
     )

--- a/packages/eds-core-react/src/components/Tabs/Tabs.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.tsx
@@ -15,7 +15,7 @@ import { useEds } from '../EdsProvider'
 
 export type TabsProps = {
   /** The index of the active tab */
-  activeTab?: number
+  activeTab?: number | string
   /** The callback function for selecting a tab */
   onChange?: (index: number) => void
   /** Sets the width of the tabs. Tabs can have a maximum width of 360px */

--- a/packages/eds-core-react/src/components/Tabs/Tabs.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@ import { ThemeProvider } from 'styled-components'
 import { useEds } from '../EdsProvider'
 
 export type TabsProps = {
-  /** The index of the active tab */
+  /** The index of the active tab OR a string matching the value prop on the active tab */
   activeTab?: number | string
   /** The callback function for selecting a tab */
   onChange?: (index: number) => void


### PR DESCRIPTION
resolves #3022 

The feature request was to fix the `active` prop on `<Tabs.Tab>` so it could be used to manually set active tab when using tabs as router links, however this proved difficult due to how the internal logic controls the active state. So instead I opted to implement it the way MUI does it by having a `value` prop on `<Tabs.Tab>` that sets the active tab if it matches the value sent into `activeTab`.
I also created a storybook story with a practical example using `react-router-dom`