### PR TITLE
fix(sidebar): add aria-label to toggle button

### DIFF
--- a/packages/eds-core-react/src/components/SideBar/SideBarToggle.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBarToggle.tsx
@@ -49,7 +49,11 @@ export const SideBarToggle = forwardRef<HTMLDivElement, SideBarToggleProps>(
     return (
       <ToggleContainer open={isOpen} {...props}>
         <Tooltip title={isOpen ? 'Collapse' : 'Expand'} placement="right">
-          <Button variant="ghost_icon" onClick={() => setIsOpen(!isOpen)}>
+          <Button
+            variant="ghost_icon"
+            onClick={() => setIsOpen(!isOpen)}
+            aria-label={isOpen ? 'Collapse' : 'Expand'}
+          >
             <Icon
               size={24}
               data={isOpen ? collapse : expand}


### PR DESCRIPTION
The toggle button causes an accessibility warning for missing text label. Also, without the label the button is hard to find in playwright tests and the like.