### PR TITLE
🐛 Table.Row: fix Styled v6 false positive warning on active prop

### DIFF
--- a/packages/eds-core-react/src/components/Table/Row/Row.tsx
+++ b/packages/eds-core-react/src/components/Table/Row/Row.tsx
@@ -20,11 +20,9 @@ export type RowProps = {
 } & React.HTMLAttributes<HTMLTableRowElement>
 
 export const Row = forwardRef<HTMLTableRowElement, RowProps>(function Row(
-  { ...props },
+  { children, active, ...props },
   ref,
 ) {
-  const { children, active } = props
-
   return (
     <StyledRow {...props} $active={active} ref={ref}>
       {children}


### PR DESCRIPTION
resolves #3103 