### PR TITLE
✨ Breadcrumb: custom separator

### DIFF
--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.docs.mdx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.docs.mdx
@@ -63,6 +63,12 @@ It might be a good idea to use `forceTooltip` on the `Breadcrumbs.Breadcrumb` wh
 
 <Canvas of={ComponentStories.Wrapped} />
 
+### Custom seperator
+
+Seperator can be a character or an `Icon`.
+
+<Canvas of={ComponentStories.CustomSeperator} />
+
 ### Third-party routing libraries
 
 Use the `as` prop on `Breadcrumbs.Breadcrumb` to utilize third party routers such as react-router with `Breadcrumbs`

--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -159,22 +159,41 @@ export const Wrapped: StoryFn<BreadcrumbsProps> = () => {
 
 export const CustomSeperator: StoryFn<BreadcrumbsProps> = () => {
   return (
-    <Breadcrumbs seperator={<Icon data={chevron_right}></Icon>}>
-      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
-        Label One
-      </Breadcrumbs.Breadcrumb>
-      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
-        Label Two
-      </Breadcrumbs.Breadcrumb>
-      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
-        A really rally long label
-      </Breadcrumbs.Breadcrumb>
-      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
-        Label Four
-      </Breadcrumbs.Breadcrumb>
-      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
-        Label Five
-      </Breadcrumbs.Breadcrumb>
-    </Breadcrumbs>
+    <>
+      <Breadcrumbs separator={<Icon data={chevron_right}></Icon>}>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label One
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label Two
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          A really rally long label
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label Four
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label Five
+        </Breadcrumbs.Breadcrumb>
+      </Breadcrumbs>
+      <Breadcrumbs separator="\">
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label One
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label Two
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          A really rally long label
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label Four
+        </Breadcrumbs.Breadcrumb>
+        <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+          Label Five
+        </Breadcrumbs.Breadcrumb>
+      </Breadcrumbs>
+    </>
   )
 }

--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -159,7 +159,7 @@ export const Wrapped: StoryFn<BreadcrumbsProps> = () => {
 
 export const CustomSeperator: StoryFn<BreadcrumbsProps> = () => {
   return (
-    <>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
       <Breadcrumbs separator={<Icon data={chevron_right}></Icon>}>
         <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
           Label One
@@ -194,6 +194,6 @@ export const CustomSeperator: StoryFn<BreadcrumbsProps> = () => {
           Label Five
         </Breadcrumbs.Breadcrumb>
       </Breadcrumbs>
-    </>
+    </div>
   )
 }

--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,4 +1,5 @@
-import { Breadcrumbs, BreadcrumbsProps, Checkbox } from '../..'
+import { Breadcrumbs, BreadcrumbsProps, Checkbox, Icon } from '../..'
+import { chevron_right } from '@equinor/eds-icons'
 import { useState, ChangeEvent } from 'react'
 import { action } from '@storybook/addon-actions'
 import { StoryFn, Meta } from '@storybook/react'
@@ -153,5 +154,27 @@ export const Wrapped: StoryFn<BreadcrumbsProps> = () => {
         </Breadcrumbs>
       </Resizable>
     </div>
+  )
+}
+
+export const CustomSeperator: StoryFn<BreadcrumbsProps> = () => {
+  return (
+    <Breadcrumbs seperator={<Icon data={chevron_right}></Icon>}>
+      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+        Label One
+      </Breadcrumbs.Breadcrumb>
+      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+        Label Two
+      </Breadcrumbs.Breadcrumb>
+      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+        A really rally long label
+      </Breadcrumbs.Breadcrumb>
+      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+        Label Four
+      </Breadcrumbs.Breadcrumb>
+      <Breadcrumbs.Breadcrumb href="#" onClick={handleClick}>
+        Label Five
+      </Breadcrumbs.Breadcrumb>
+    </Breadcrumbs>
   )
 }

--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -55,7 +55,8 @@ export type BreadcrumbsProps = {
    * @default false
    */
   collapse?: boolean
-  seperator?: ReactNode
+  /** Custom separator can be a character or an Icon */
+  separator?: ReactNode
   /** Will not wrap breadcrumbs when set to false, but will instead trunkate each breadcrumb when viewport narrows
    * @default true
    */
@@ -66,7 +67,7 @@ export type BreadcrumbsProps = {
 
 export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
   function Breadcrumbs(
-    { children, collapse, wrap = true, seperator = '/', ...rest },
+    { children, collapse, wrap = true, separator = '/', ...rest },
     ref,
   ) {
     const props = {
@@ -109,7 +110,7 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
             </Collapsed>
           </ListItem>
           <li aria-hidden>
-            <Separator variant="body_short">{seperator}</Separator>
+            <Separator variant="body_short">{separator}</Separator>
           </li>
         </Fragment>,
         allCrumbs[allCrumbs.length - 1],
@@ -122,7 +123,7 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
         <ListItem>{child}</ListItem>
         {index !== ReactChildren.toArray(children).length - 1 && (
           <li aria-hidden>
-            <Separator variant="body_short">{seperator}</Separator>
+            <Separator variant="body_short">{separator}</Separator>
           </li>
         )}
       </Fragment>

--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -33,6 +33,9 @@ const Separator = styled(Typography)`
   ${spacingsTemplate(spacings)}
   display: block;
   line-height: 1;
+  & > svg {
+    margin-inline: -8px;
+  }
 `
 
 const Collapsed = styled(Typography)`

--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -52,6 +52,7 @@ export type BreadcrumbsProps = {
    * @default false
    */
   collapse?: boolean
+  seperator?: ReactNode
   /** Will not wrap breadcrumbs when set to false, but will instead trunkate each breadcrumb when viewport narrows
    * @default true
    */
@@ -61,7 +62,10 @@ export type BreadcrumbsProps = {
 } & HTMLAttributes<HTMLElement>
 
 export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
-  function Breadcrumbs({ children, collapse, wrap = true, ...rest }, ref) {
+  function Breadcrumbs(
+    { children, collapse, wrap = true, seperator = '/', ...rest },
+    ref,
+  ) {
     const props = {
       ...rest,
       ref,
@@ -102,7 +106,7 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
             </Collapsed>
           </ListItem>
           <li aria-hidden>
-            <Separator variant="body_short">/</Separator>
+            <Separator variant="body_short">{seperator}</Separator>
           </li>
         </Fragment>,
         allCrumbs[allCrumbs.length - 1],
@@ -115,7 +119,7 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
         <ListItem>{child}</ListItem>
         {index !== ReactChildren.toArray(children).length - 1 && (
           <li aria-hidden>
-            <Separator variant="body_short">/</Separator>
+            <Separator variant="body_short">{seperator}</Separator>
           </li>
         )}
       </Fragment>

--- a/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/eds-core-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -33,6 +33,7 @@ const Separator = styled(Typography)`
   ${spacingsTemplate(spacings)}
   display: block;
   line-height: 1;
+  display: flex;
   & > svg {
     margin-inline: -8px;
   }

--- a/packages/eds-core-react/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -33,6 +33,11 @@ exports[`Breadcrumbs Matches snapshot 1`] = `
   padding-right: 16px;
   display: block;
   line-height: 1;
+  display: flex;
+}
+
+.c4>svg {
+  margin-inline: -8px;
 }
 
 .c3 {


### PR DESCRIPTION
resolves #3001 

the regular separator have an inline padding of 16px. If the seperator contains an icon, It gets an inline margin of -8px to make the spacing roughly similar. 
![bilde](https://github.com/equinor/design-system/assets/4499531/5b7f4c5d-004c-4dd3-8786-2ad8ee5682ac)
   

pending design review/figma update