### PR TITLE
🐛 Slider: fix safari hover bug

### DIFF
--- a/packages/eds-core-react/src/components/Slider/Output.tsx
+++ b/packages/eds-core-react/src/components/Slider/Output.tsx
@@ -16,7 +16,7 @@ const StyledOutput = styled.output`
   --realWidth: calc(100% - 12px);
   --background: rgb(0 0 0 / 0.8);
   width: fit-content;
-  position: relative;
+  position: absolute;
   display: flex;
   align-items: center;
   border-radius: 4px;
@@ -25,7 +25,7 @@ const StyledOutput = styled.output`
   color: white;
   background: var(--background);
   padding: 8px;
-  top: -32px;
+  bottom: calc(100% + 8px);
   pointer-events: none;
   /* Calculate the distance on the track*/
   margin-left: calc((var(--val) - var(--min)) / var(--dif) * var(--realWidth));

--- a/packages/eds-core-react/src/components/Slider/Output.tsx
+++ b/packages/eds-core-react/src/components/Slider/Output.tsx
@@ -24,7 +24,7 @@ const StyledOutput = styled.output`
   ${typographyTemplate(output.typography)};
   color: white;
   background: var(--background);
-  padding: 8px;
+  padding: 4px 8px;
   bottom: calc(100% + 8px);
   pointer-events: none;
   /* Calculate the distance on the track*/

--- a/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Simple slider Matches snapshot 1`] = `
   --realWidth: calc(100% - 12px);
   --background: rgb(0 0 0 / 0.8);
   width: fit-content;
-  position: relative;
+  position: absolute;
   display: flex;
   align-items: center;
   border-radius: 4px;
@@ -44,7 +44,7 @@ exports[`Simple slider Matches snapshot 1`] = `
   color: white;
   background: var(--background);
   padding: 8px;
-  top: -32px;
+  bottom: calc(100% + 8px);
   pointer-events: none;
   margin-left: calc((var(--val) - var(--min)) / var(--dif) * var(--realWidth));
   transform: translate(calc(-1 * calc(var(--realWidth) / 2)));

--- a/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Simple slider Matches snapshot 1`] = `
   text-align: left;
   color: white;
   background: var(--background);
-  padding: 8px;
+  padding: 4px 8px;
   bottom: calc(100% + 8px);
   pointer-events: none;
   margin-left: calc((var(--val) - var(--min)) / var(--dif) * var(--realWidth));


### PR DESCRIPTION
resolves #3119 

the problem was the calculation in` margin-left` of the `output` element. I believe the definition of 100% changes on hover when using safari, causing the calculated value to increase more and more. By making the `output` `position: absolute` it no longer contributes to the width and that fixed it