### PR TITLE
Data-grid filter improvements (+ external paginator)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:storybook:data-grid": "pnpm --filter ./packages/eds-data-grid-react run build:storybook",
     "test": "pnpm run test:utils && pnpm run test:core-react && pnpm run test:lab && pnpm run test:data-grid-react",
     "test:core-react": "pnpm --filter @equinor/eds-core-react run test",
-    "test:data-grid-react": "pnpm --filter @equinor/eds-core-react run test",
+    "test:data-grid-react": "pnpm --filter @equinor/eds-data-grid-react run test",
     "test:lab": "pnpm --filter @equinor/eds-lab-react run test",
     "test:utils": "pnpm --filter @equinor/eds-utils run test",
     "test:watch:core-react": "pnpm --filter @equinor/eds-core-react run test:watch",

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -3,10 +3,19 @@ import { EdsDataGrid, EdsDataGridProps } from './EdsDataGrid'
 import { columns, groupedColumns, Photo } from './stories/columns'
 import { data } from './stories/data'
 import { CSSProperties, useEffect, useState } from 'react'
-import { Button, Checkbox, Paper, Typography } from '@equinor/eds-core-react'
+import {
+  Banner,
+  Button,
+  Card,
+  Checkbox,
+  Pagination,
+  Paper,
+  Typography,
+} from '@equinor/eds-core-react'
 import page from './EdsDataGrid.docs.mdx'
 import { Column, Row } from '@tanstack/react-table'
 import { tokens } from '@equinor/eds-tokens'
+import { action } from '@storybook/addon-actions'
 
 const meta: Meta<typeof EdsDataGrid<Photo>> = {
   title: 'EDS Data grid',
@@ -55,6 +64,35 @@ export const Paging: StoryFn<EdsDataGridProps<Photo>> = (args) => {
 Paging.args = {
   enablePagination: true,
   pageSize: 10,
+}
+
+export const ExternalPaging: StoryFn<EdsDataGridProps<Photo>> = (args) => {
+  return (
+    <>
+      <div>
+        <Typography variant={'body_long'}>
+          Using externalPaginator gives you control over setting the appropriate
+          rows yourself.
+        </Typography>
+        <Typography variant={'body_long'}>
+          This is useful for e.g server-side pagination
+        </Typography>
+      </div>
+      <EdsDataGrid
+        {...args}
+        externalPaginator={
+          <Pagination
+            itemsPerPage={10}
+            totalItems={40}
+            withItemIndicator
+            onChange={(event, page) => {
+              action(`Page changed`)(page)
+            }}
+          />
+        }
+      />
+    </>
+  )
 }
 
 export const ColumnGrouping: StoryFn<EdsDataGridProps<Photo>> = (args) => {

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -96,6 +96,11 @@ export type EdsDataGridProps<T> = {
    */
   pageSize?: number
   /**
+   * Add this if you want to implement a custom pagination component
+   * Useful for e.g server-side paging
+   */
+  externalPaginator?: ReactElement
+  /**
    * The message to display when there are no rows
    * @default undefined
    */
@@ -191,6 +196,7 @@ export function EdsDataGrid<T>({
   rowStyle,
   headerClass,
   headerStyle,
+  externalPaginator,
 }: EdsDataGridProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [selection, setSelection] = useState<RowSelectionState>(
@@ -467,17 +473,21 @@ export function EdsDataGrid<T>({
                 .rows.map((row) => <TableRow key={row.id} row={row} />)}
           </Table.Body>
         </Table>
-        {enablePagination && (
-          <div style={{ maxWidth: `${table.getTotalSize()}px` }}>
-            <Pagination
-              totalItems={table.getFilteredRowModel().rows.length}
-              withItemIndicator={true}
-              itemsPerPage={page.pageSize}
-              onChange={(e, p) => setPage((s) => ({ ...s, pageIndex: p - 1 }))}
-              defaultPage={1}
-            />
-          </div>
-        )}
+        {externalPaginator
+          ? externalPaginator
+          : enablePagination && (
+              <div style={{ maxWidth: `${table.getTotalSize()}px` }}>
+                <Pagination
+                  totalItems={table.getFilteredRowModel().rows.length}
+                  withItemIndicator={true}
+                  itemsPerPage={page.pageSize}
+                  onChange={(e, p) =>
+                    setPage((s) => ({ ...s, pageIndex: p - 1 }))
+                  }
+                  defaultPage={1}
+                />
+              </div>
+            )}
       </div>
       {debug && enableVirtual && (
         <span>

--- a/packages/eds-data-grid-react/src/components/Filter.tsx
+++ b/packages/eds-data-grid-react/src/components/Filter.tsx
@@ -1,19 +1,56 @@
 /* istanbul ignore file */
 import { Column, Table as TanStackTable } from '@tanstack/react-table'
-import { useMemo } from 'react'
+import { useMemo, useState, useRef, MouseEvent } from 'react'
 import { DebouncedInput } from './DebouncedInput'
+import { Icon, Popover, Button } from '@equinor/eds-core-react'
+import { filter_alt, filter_alt_active } from '@equinor/eds-icons'
+import styled from 'styled-components'
 
 type FilterProps<T = unknown> = {
   column: Column<T>
   table: TanStackTable<T>
 }
 
+const NumberContainer = styled.div`
+  display: grid;
+  grid-template-columns: 80px 80px;
+  grid-column-gap: 32px;
+`
+
 export function Filter<T = unknown>({ column, table }: FilterProps<T>) {
   const firstValue = table
     .getPreFilteredRowModel()
     .flatRows[0]?.getValue(column.id)
+  const [open, setOpen] = useState(false)
+  const filterIconRef = useRef<HTMLButtonElement | null>()
 
-  const columnFilterValue = column.getFilterValue()
+  const togglePopover = (event: MouseEvent) => {
+    event.stopPropagation()
+    setOpen(!open)
+  }
+
+  const columnText = useMemo<string | undefined>(() => {
+    let header: string | undefined
+    try {
+      if (typeof column.columnDef.header === 'function') {
+        const obj: React.ReactElement<{ children: string }> =
+          column.columnDef.header(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument
+            {} as any,
+          ) as React.ReactElement<{
+            children: string
+          }>
+        header = obj.props.children
+      } else {
+        header = column.columnDef.header
+      }
+    } catch {
+      /*em all*/
+    }
+    return header
+  }, [column.columnDef])
+
+  const columnFilterValue = column.getFilterValue() as T | Array<T>
 
   const sortedUniqueValues = useMemo<Array<string>>(
     () =>
@@ -26,47 +63,97 @@ export function Filter<T = unknown>({ column, table }: FilterProps<T>) {
     [column.getFacetedUniqueValues()],
   )
 
-  return typeof firstValue === 'number' ? (
-    <div>
-      <DebouncedInput
-        type="number"
-        values={sortedUniqueValues}
-        min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
-        max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
-        value={(columnFilterValue as [number, number])?.[0] ?? ''}
-        onChange={(value) =>
-          column.setFilterValue((old: [number, number]) => [value, old?.[1]])
-        }
-        placeholder={`Min ${
-          column.getFacetedMinMaxValues()?.[0]
-            ? `(${column.getFacetedMinMaxValues()?.[0]})`
-            : ''
-        }`}
-      />
-      <DebouncedInput
-        type="number"
-        values={sortedUniqueValues}
-        min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
-        max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
-        value={(columnFilterValue as [number, number])?.[1] ?? ''}
-        onChange={(value) =>
-          column.setFilterValue((old: [number, number]) => [old?.[0], value])
-        }
-        placeholder={`Max ${
-          column.getFacetedMinMaxValues()?.[1]
-            ? `(${column.getFacetedMinMaxValues()?.[1]})`
-            : ''
-        }`}
-      />
-    </div>
-  ) : (
-    <DebouncedInput
-      type="text"
-      values={sortedUniqueValues}
-      value={(columnFilterValue ?? '') as string}
-      onChange={(value) => column.setFilterValue(value)}
-      placeholder={`Search (${column.getFacetedUniqueValues().size})`}
-      list={column.id + 'list'}
-    />
+  const hasActiveFilters = (value: T | Array<T>) => {
+    if (Array.isArray(value)) {
+      if (typeof firstValue === 'number') {
+        return (value as Array<number>).some((v) => !isNaN(v) && !!v)
+      } else {
+        return value.filter((v) => !!v).length > 0
+      }
+    }
+    return value
+  }
+
+  return (
+    <>
+      <Button
+        aria-haspopup
+        aria-expanded={open}
+        data-testid={'open-filters'}
+        ref={filterIconRef}
+        onClick={togglePopover}
+        variant={'ghost_icon'}
+      >
+        <Icon
+          data={
+            hasActiveFilters(columnFilterValue) ? filter_alt_active : filter_alt
+          }
+        />
+      </Button>
+      <Popover
+        style={{ width: typeof firstValue === 'number' ? '220px' : '340px' }}
+        anchorEl={filterIconRef.current}
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        <Popover.Content
+          style={{ width: typeof firstValue === 'number' ? '180px' : '310px' }}
+        >
+          {typeof firstValue === 'number' ? (
+            <NumberContainer>
+              <DebouncedInput
+                type="number"
+                values={sortedUniqueValues}
+                min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
+                max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
+                value={(columnFilterValue as [number, number])?.[0] ?? ''}
+                onChange={(value) =>
+                  column.setFilterValue((old: [number, number]) => [
+                    value,
+                    old?.[1],
+                  ])
+                }
+                placeholder={`Min ${
+                  column.getFacetedMinMaxValues()?.[0]
+                    ? `(${column.getFacetedMinMaxValues()?.[0]})`
+                    : ''
+                }`}
+              />
+              <DebouncedInput
+                type="number"
+                values={sortedUniqueValues}
+                min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
+                max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
+                value={(columnFilterValue as [number, number])?.[1] ?? ''}
+                onChange={(value) =>
+                  column.setFilterValue((old: [number, number]) => [
+                    old?.[0],
+                    value,
+                  ])
+                }
+                placeholder={`Max ${
+                  column.getFacetedMinMaxValues()?.[1]
+                    ? `(${column.getFacetedMinMaxValues()?.[1]})`
+                    : ''
+                }`}
+              />
+            </NumberContainer>
+          ) : (
+            <DebouncedInput
+              type="text"
+              label={columnText}
+              values={sortedUniqueValues}
+              debounce={100}
+              value={(columnFilterValue ?? []) as Array<string>}
+              onChange={(value) => column.setFilterValue(value)}
+              placeholder={`${
+                ((columnFilterValue ?? []) as Array<string>).length
+              } / ${column.getFacetedUniqueValues().size} selected`}
+              list={column.id + 'list'}
+            />
+          )}
+        </Popover.Content>
+      </Popover>
+    </>
   )
 }

--- a/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
@@ -81,7 +81,7 @@ export function TableHeaderCell<T>({ header, columnResizeMode }: Props<T>) {
         colSpan: header.colSpan,
         style: {
           width: header.getSize(),
-          verticalAlign: ctx.enableColumnFiltering ? 'baseline' : 'middle',
+          verticalAlign: ctx.enableColumnFiltering ? 'top' : 'middle',
           ...(ctx.headerStyle ? ctx.headerStyle(header.column) : {}),
         },
       }}
@@ -91,18 +91,19 @@ export function TableHeaderCell<T>({ header, columnResizeMode }: Props<T>) {
           <span className="table-header-cell-label">
             {flexRender(header.column.columnDef.header, header.getContext())}
           </span>
-          {header.column.getCanFilter() ? (
-            // Supressing this warning - div is not interactive, but prevents propagation of events to avoid unintended sorting
-            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-            <div onClick={(e) => e.stopPropagation()}>
-              <Filter column={header.column} table={table} />
-            </div>
-          ) : null}
         </div>
         {{
           asc: <Icon data={arrow_up} />,
           desc: <Icon data={arrow_down} />,
         }[header.column.getIsSorted() as string] ?? null}
+
+        {header.column.getCanFilter() ? (
+          // Supressing this warning - div is not interactive, but prevents propagation of events to avoid unintended sorting
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+          <div onClick={(e) => e.stopPropagation()}>
+            <Filter column={header.column} table={table} />
+          </div>
+        ) : null}
       </>
       {columnResizeMode && (
         <Resizer

--- a/packages/eds-data-grid-react/src/tests/EdsDataGrid.test.tsx
+++ b/packages/eds-data-grid-react/src/tests/EdsDataGrid.test.tsx
@@ -25,7 +25,7 @@ describe('EdsDataGrid', () => {
 
   describe('Filtering', () => {
     it('should have built-in filtering if enabled', async () => {
-      render(
+      const {} = render(
         <EdsDataGrid
           enableColumnFiltering={true}
           columns={columns}
@@ -34,8 +34,20 @@ describe('EdsDataGrid', () => {
       )
       expect(screen.getAllByRole('columnheader').length).toBe(columns.length)
       expect(
-        within(screen.getAllByRole('columnheader')[0]).getByRole('combobox'),
+        within(screen.getAllByRole('columnheader')[0]).getByTestId(
+          'open-filters',
+        ),
       ).toBeTruthy()
+
+      const header = screen.getAllByRole('columnheader')[0]
+      const button = within(header).getByTestId('open-filters')
+      fireEvent(
+        button,
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
 
       expect(
         within(screen.getAllByRole('listbox')[0]).queryAllByRole('option')

--- a/packages/eds-data-grid-react/src/tests/Filter.test.tsx
+++ b/packages/eds-data-grid-react/src/tests/Filter.test.tsx
@@ -10,6 +10,17 @@ import { data, Data } from './data'
 import { columns } from './columns'
 import userEvent from '@testing-library/user-event'
 
+const openPopover = (header: HTMLElement) => {
+  const button = within(header).getByTestId('open-filters')
+  fireEvent(
+    button,
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  )
+}
+
 describe('Filter', () => {
   let table: Table<Data>
   let filterChangeSpy: jest.SpyInstance
@@ -55,10 +66,14 @@ describe('Filter', () => {
       const { baseElement } = render(
         <Filter column={table.getColumn('status')} table={table} />,
       )
+      openPopover(baseElement)
       expect(within(baseElement).getAllByRole('combobox').length).toBe(1)
     })
     it('should have 2 inputs for number-columns', () => {
-      render(<Filter column={table.getColumn('numeric')} table={table} />)
+      const { baseElement } = render(
+        <Filter column={table.getColumn('numeric')} table={table} />,
+      )
+      openPopover(baseElement)
       expect(screen.queryAllByRole('spinbutton').length).toBe(2)
     })
   })
@@ -68,6 +83,7 @@ describe('Filter', () => {
       const { baseElement } = render(
         <Filter column={table.getColumn('status')} table={table} />,
       )
+      openPopover(baseElement)
       const input = within(baseElement).getByRole('combobox')
       const col = table.getColumn('status')
       const spy = jest.spyOn(col, 'setFilterValue')
@@ -90,6 +106,7 @@ describe('Filter', () => {
       const { baseElement } = render(
         <Filter column={table.getColumn('status')} table={table} />,
       )
+      openPopover(baseElement)
       const input = within(baseElement).getByRole('combobox')
       const col = table.getColumn('status')
       const spy = jest.spyOn(col, 'setFilterValue')
@@ -104,6 +121,7 @@ describe('Filter', () => {
       const { baseElement } = render(
         <Filter column={table.getColumn('numeric')} table={table} />,
       )
+      openPopover(baseElement)
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const inputs = within(baseElement).getAllByRole(
         'spinbutton',
@@ -122,6 +140,8 @@ describe('Filter', () => {
     it('should have min/max for numeric', () => {
       const col = table.getColumn('numeric')
       const { baseElement } = render(<Filter column={col} table={table} />)
+
+      openPopover(baseElement)
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const inputs = within(baseElement).getAllByRole(
         'spinbutton',
@@ -134,8 +154,8 @@ describe('Filter', () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const maxValue = Math.max(...data.map((v) => v.qty))
-      expect(min.placeholder).toBe(`Min (${minValue})`)
-      expect(max.placeholder).toBe(`Max (${maxValue})`)
+      expect(min.placeholder).toBe(`0`)
+      expect(max.placeholder).toBe(`0`)
     })
 
     it('should work with min/max if no faceted values', () => {
@@ -149,6 +169,7 @@ describe('Filter', () => {
       })
       const col = table.getColumn('numeric')
       const { baseElement } = render(<Filter column={col} table={table} />)
+      openPopover(baseElement)
       // eslint complains about unneccessary cast, but HTMLElement != HTMLInputElement
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const inputs = within(baseElement).getAllByRole(
@@ -156,8 +177,8 @@ describe('Filter', () => {
       ) as Array<HTMLInputElement>
       const min = inputs[0]
       const max = inputs[1]
-      expect(min.placeholder).toBe(`Min `)
-      expect(max.placeholder).toBe(`Max `)
+      expect(min.placeholder).toBe(`0`)
+      expect(max.placeholder).toBe(`0`)
     })
   })
 })


### PR DESCRIPTION
Fixes design-issues reported by @BirteThornquist 

* Filter
  * Add a filter-toggle-button instead of inlining the filters
  * Move inputs inside a popover
* Paging
  * Added a prop to use external pagination (e.g for server-side paging)
* Also fixed an error where the root package.json pointed tests to core-react
  * This identified another bug that I mentioned to @oddvernes , where eds-core-react breaks most tests due to babel-plugin-styled-components not handling .cjs correctly. This only applies when running tests, and does not fail in the browser.


The bug was fixed by making a tweak in `packages/eds-core-react/node_modules/.pnpm/babel-plugin-styled-components@2.1.4_@babel+core@7.23.3_styled-components@6.1.0/node_modules/babel-plugin-styled-components/lib/utils/detectors.js`, adding a null-check to tag.object:
`state.styledRequired && t.isMemberExpression(tag) && t.isMemberExpression(tag.object) && tag.object?.property.name === 'default' && tag.object.object.name === state.styledRequired || state.styledRequired && t.isCallExpression(tag) && t.isMemberExpression(tag.callee) && tag.callee?.property.name === 'default' && tag.callee.object.name === state.styledRequired || state.styledRequired && t.isCallExpression(tag) && t.isSequenceExpression(tag.callee) && t.isMemberExpression((0, _getSequenceExpressionValue.default)(tag.callee)) && (0, _getSequenceExpressionValue.default)(tag.callee)?.property.name === 'default' && (0, _getSequenceExpressionValue.default)(tag.callee).object.name === state.styledRequired || importLocalName('default', state) && t.isMemberExpression(tag) && t.isMemberExpression(tag.object) && tag.object?.property.name === 'default' && tag.object.object.name === importLocalName('default', state) || importLocalName('default', state) && t.isCallExpression(tag) && t.isMemberExpression(tag.callee) && tag.object?.property.name === 'default' && tag.object.object.name === importLocalName('default', state);`