### PR TITLE
🐛Autocomplete: Firefox scrollbar clipping issue

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -68,6 +68,10 @@ const StyledList = styled(List)(
     overflow-x: hidden;
     padding: 0;
     display: grid;
+    /* hack to fix clipping issue in firefox (#3170) */
+    @supports (-moz-appearance: none) {
+      scrollbar-width: thin;
+    }
   `,
 )
 

--- a/packages/eds-core-react/src/components/Autocomplete/Option.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Option.tsx
@@ -47,6 +47,10 @@ const Label = styled.span<{ $multiline: boolean }>(({ theme, $multiline }) => {
     white-space: ${$multiline ? 'normal' : 'nowrap'};
     overflow: ${$multiline ? 'initial' : 'hidden'};
     overflow-wrap: anywhere;
+    /* hack to fix clipping issue in firefox (#3170) */
+    @supports (-moz-appearance: none) {
+      overflow: ${$multiline ? 'initial' : 'clip'};
+    }
   `
 })
 

--- a/packages/eds-core-react/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/eds-core-react/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -66,6 +66,18 @@ exports[`Autocomplete Matches snapshot 1`] = `
 
 }
 
+@supports (-moz-appearance:none) {
+  .c3 {
+    overflow: clip;
+  }
+}
+
+@supports (-moz-appearance:none) {
+  .c1 {
+    scrollbar-width: thin;
+  }
+}
+
 <ul
   aria-labelledby="downshift-:r0:-label"
   class="c0 c1"


### PR DESCRIPTION
resolves #3170 

The problem was the scollbar (when `autowith` and `multiline` is not set) cutting off the rightmost part of the label (it steals the content width) in firefox, whereas in chrome etc the scrollbar does not cut but instead adds to the total width.

I have tried a bunch of things to try and coax the scrollbar to behave in firefox as it does in chrome to no avail, so I decided to instead sacrifice the ellipsis by making the label `overflow: clip` in firefox only (so if `autowidth` is true and label is wider than input, it will clip the end insead of showing ellipsis).  I Also made the `scrollbar-width: thin` for firefox so it looks less weird