### PR TITLE
🔖Release eds-core-react@0.35.0, eds-icons@0.20.0, eds-data-grid-react@0.2.0

### DIFF
--- a/packages/eds-core-react/CHANGELOG.md
+++ b/packages/eds-core-react/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.0] - 2023-12-13
+
+### Added
+
+- ✨ `Icon`: Added support for multiple paths (type `IconData.svgPathData` is now `string | Array<string>`) by @oddvernes in https://github.com/equinor/design-system/pull/3177
+
+### Fixed
+
+- 🐛 `Autocomplete`: Fixed scrollbar clipping issue that manifested in Firefox by @oddvernes in https://github.com/equinor/design-system/pull/3179
+- 🐛 `Slider`: Fixed a bug where label tooltip was always visible for users with `styled-components@5.x.x` by @oddvernes in https://github.com/equinor/design-system/pull/3173
+
+### Changed
+
+- 🧑‍💻 `SideSheet`: `open` prop type changed to required, conditionally render title and close button to reflect the optional types of `title` and `onClose` props by @oddvernes in https://github.com/equinor/design-system/pull/3161
+
 ## [0.34.0] - 2023-11-17
 
 ### Added

--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-data-grid-react/CHANGELOG.md
+++ b/packages/eds-data-grid-react/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-12-13
+
+### Added
+
+- ✨ Column pinning feature (adding `columnPinState`, `scrollbarHorizontal`, `width` and `height` props) by @yusijs in https://github.com/equinor/design-system/pull/3176
+- ✨ Functionality for manual/external sorting (adding `manualSorting`, `onSortingChange` and `sortingState` props) by @yusijs in https://github.com/equinor/design-system/pull/3172
+- ✨ Support for external paginator via a new `externalPaginator` prop by @yusijs in https://github.com/equinor/design-system/pull/3162
+
+### Changed
+
+- 💄 Design improvements to filter functionality by @yusijs in https://github.com/equinor/design-system/pull/3162
 
 ## [0.1.0-beta.3] - 2023-09-26
 

--- a/packages/eds-data-grid-react/package.json
+++ b/packages/eds-data-grid-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-data-grid-react",
-  "version": "0.1.0-beta.3",
+  "version": "0.2.0",
   "description": "A feature-rich data-grid written in React, implementing the Equinor Design System",
   "license": "MIT",
   "types": "dist/types/index.d.ts",

--- a/packages/eds-icons/CHANGELOG.md
+++ b/packages/eds-icons/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2023-12-13
+
+### Changed
+
+- `IconData` type: `svgPathData` changed to `string | Array<string>` to allow multiple paths in the eds-core-react `Icon` component by @oddvernes in https://github.com/equinor/design-system/pull/3177
+
 ## [0.19.3] - 2023-07-14
 
 ### Changed

--- a/packages/eds-icons/package.json
+++ b/packages/eds-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-icons",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "description": "Icons from the Equinor Design System",
   "main": "dist/icons.cjs",
   "module": "dist/esm/index.js",

--- a/packages/eds-lab-react/CHANGELOG.md
+++ b/packages/eds-lab-react/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] - 2023-10-20
+
+### Changed
+
+- ⬆️ Updated `eds-core-react`/`eds-icons` dependencies
+
 ## [0.7.3] - 2023-10-20
 
 ### Fixed

--- a/packages/eds-lab-react/CHANGELOG.md
+++ b/packages/eds-lab-react/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.4] - 2023-10-20
+## [0.7.4] - 2023-12-13
 
 ### Changed
 

--- a/packages/eds-lab-react/package.json
+++ b/packages/eds-lab-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-lab-react",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "The lab for the Equinor Design System",
   "sideEffects": [
     "**/*.css"


### PR DESCRIPTION
resolves #3183 #3184 #3185 

I will also release a patch update for lab-react so its core-react/icons dependencies are up to date