### PR TITLE
🐛 Typography: Fix line clamp bug for styled v6

### DIFF
--- a/packages/eds-core-react/src/components/Typography/Typography.tsx
+++ b/packages/eds-core-react/src/components/Typography/Typography.tsx
@@ -85,16 +85,13 @@ const StyledTypography = styled.p<StyledProps>`
   ${({ $typography, $link }) => typographyTemplate($typography, $link)}
   ${({ $color }) => css({ color: findColor($color) })}
   ${({ $lines }) =>
-    //https://caniuse.com/#feat=css-line-clamp
-    $lines > 0 &&
+    $lines &&
     css`
-      & {
-        display: -webkit-box;
-        -webkit-line-clamp: ${$lines};
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
+      display: -webkit-box;
+      -webkit-line-clamp: ${$lines};
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
     `}
   ${({ $link }) =>
     $link &&


### PR DESCRIPTION
resolves #3192 

This was another one of those random changes in behaviour between styled components v5 and v6