### PR TITLE
:sparkles: Improve data grid

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,13 @@
   "task.allowAutomaticTasks": "off",
   "[bicep]": {
     "editor.defaultFormatter": "ms-azuretools.vscode-bicep"
+  },
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#1C3408",
+    "titleBar.activeBackground": "#27480C",
+    "titleBar.activeForeground": "#F4FCED"
+  },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "never"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,13 +18,5 @@
   "task.allowAutomaticTasks": "off",
   "[bicep]": {
     "editor.defaultFormatter": "ms-azuretools.vscode-bicep"
-  },
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#1C3408",
-    "titleBar.activeBackground": "#27480C",
-    "titleBar.activeForeground": "#F4FCED"
-  },
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "never"
   }
 }

--- a/packages/eds-data-grid-react/package.json
+++ b/packages/eds-data-grid-react/package.json
@@ -25,10 +25,10 @@
   "peerDependencies": {
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "styled-components": ">=4.2"
+    "styled-components": ">=4.2",
+    "@equinor/eds-core-react": "workspace:^"
   },
   "dependencies": {
-    "@equinor/eds-core-react": "workspace:^",
     "@equinor/eds-icons": "workspace:^",
     "@equinor/eds-tokens": "workspace:*",
     "@equinor/eds-utils": "workspace:^",

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -2,12 +2,20 @@ import { Meta, StoryFn } from '@storybook/react'
 import { EdsDataGrid } from './EdsDataGrid'
 import { columns, groupedColumns, Photo } from './stories/columns'
 import { data } from './stories/data'
-import { CSSProperties, useEffect, useState } from 'react'
+import {
+  CSSProperties,
+  ChangeEvent,
+  FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import {
   Button,
   Checkbox,
   Pagination,
   Paper,
+  TextField,
   Typography,
 } from '@equinor/eds-core-react'
 import page from './EdsDataGrid.docs.mdx'
@@ -15,6 +23,7 @@ import { Column, Row } from '@tanstack/react-table'
 import { tokens } from '@equinor/eds-tokens'
 import { action } from '@storybook/addon-actions'
 import { EdsDataGridProps } from './EdsDataGridProps'
+import { Virtualizer } from './types'
 
 const meta: Meta<typeof EdsDataGrid<Photo>> = {
   title: 'EDS Data grid',
@@ -196,6 +205,69 @@ export const ColumnOrdering: StoryFn<EdsDataGridProps<Photo>> = (args) => {
       <EdsDataGrid columnOrder={sort} {...args} />
     </>
   )
+}
+
+export const ScrollToIndex: StoryFn<EdsDataGridProps<Photo>> = (args) => {
+  const [index, setIndex] = useState<number>(100)
+
+  const rowVirtualizerInstanceRef =
+    useRef<Virtualizer<HTMLDivElement, Element>>(null)
+
+  const scrollToIndex = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    rowVirtualizerInstanceRef.current?.scrollToIndex(index, {
+      align: 'center',
+      behavior: 'smooth',
+    })
+  }
+
+  return (
+    <>
+      <form
+        style={{
+          display: 'flex',
+          alignItems: 'end',
+          gap: '1rem',
+          marginBottom: '1rem',
+        }}
+        onSubmit={scrollToIndex}
+      >
+        <TextField
+          id="index"
+          type="number"
+          label="Index"
+          name="index"
+          value={String(index)}
+          style={{ width: '8rem' }}
+          min={0}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setIndex(e.target.valueAsNumber)
+          }
+        />
+        <Button type="submit" style={{ flexShrink: 0 }} disabled={isNaN(index)}>
+          Scroll To Index
+        </Button>
+      </form>
+
+      <EdsDataGrid
+        {...args}
+        rowVirtualizerInstanceRef={rowVirtualizerInstanceRef}
+      />
+    </>
+  )
+}
+
+ScrollToIndex.args = {
+  stickyHeader: true,
+  enableVirtual: true,
+  height: 300,
+  rows: Array.from(new Array(100)).flatMap((_, copyNumber) =>
+    data.map<(typeof data)[number]>((item, index, { length }) => ({
+      ...item,
+      id: index + copyNumber * length,
+    })),
+  ),
 }
 
 export const HideShowColumns: StoryFn<EdsDataGridProps<Photo>> = (args) => {

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -323,7 +323,7 @@ export function EdsDataGrid<T>({
           ...parentRefStyle,
           width: scrollbarHorizontal ? width ?? '100%' : 'auto',
           overflow: 'auto',
-          contain: 'strict',
+          contain: 'layout paint style',
         }}
         ref={parentRef}
       >

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -65,6 +65,7 @@ export function EdsDataGrid<T>({
   columnPinState,
   scrollbarHorizontal,
   width,
+  minWidth,
   height,
 }: EdsDataGridProps<T>) {
   const [sorting, setSorting] = useState<SortingState>(sortingState ?? [])
@@ -331,6 +332,7 @@ export function EdsDataGrid<T>({
             style: {
               tableLayout: scrollbarHorizontal ? 'fixed' : 'auto',
               width: table.getTotalSize(),
+              minWidth: scrollbarHorizontal ? width : 'auto',
             },
           }}
         >
@@ -349,7 +351,7 @@ export function EdsDataGrid<T>({
           <Table.Body style={{ backgroundColor: 'inherit' }}>
             {table.getRowModel().rows.length === 0 && emptyMessage && (
               <Table.Row>
-                <Table.Cell colSpan={table.getHeaderGroups().length}>
+                <Table.Cell colSpan={table.getFlatHeaders().length}>
                   {emptyMessage}
                 </Table.Cell>
               </Table.Row>

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -30,6 +30,7 @@ import { TableRow } from './components/TableRow'
 import { TableProvider } from './EdsDataGridContext'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { EdsDataGridProps } from './EdsDataGridProps'
+import { Typography } from '@equinor/eds-core-react'
 
 export function EdsDataGrid<T>({
   rows,
@@ -147,6 +148,23 @@ export function EdsDataGrid<T>({
   const options: TableOptions<T> = {
     data: rows,
     columns: _columns,
+    defaultColumn: {
+      cell: (context) => {
+        return (
+          <Typography
+            style={{
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
+            group="table"
+            variant="cell_text"
+          >
+            {String(context.getValue() ?? '')}
+          </Typography>
+        )
+      },
+    },
     columnResizeMode: columnResizeMode,
     state: {
       sorting,

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Pagination, Table, Typography, useEds } from '@equinor/eds-core-react'
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -16,7 +17,7 @@ import {
   TableOptions,
   useReactTable,
 } from '@tanstack/react-table'
-import { Pagination, Table, Typography, useEds } from '@equinor/eds-core-react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   CSSProperties,
   useCallback,
@@ -28,7 +29,6 @@ import {
 import { TableHeaderRow } from './components/TableHeaderRow'
 import { TableRow } from './components/TableRow'
 import { TableProvider } from './EdsDataGridContext'
-import { useVirtualizer } from '@tanstack/react-virtual'
 import { EdsDataGridProps } from './EdsDataGridProps'
 
 export function EdsDataGrid<T>({
@@ -67,7 +67,7 @@ export function EdsDataGrid<T>({
   minWidth,
   height,
   getRowId,
-  rowVirtualizedInstanceRef,
+  rowVirtualizerInstanceRef,
 }: EdsDataGridProps<T>) {
   const [sorting, setSorting] = useState<SortingState>(sortingState ?? [])
   const [selection, setSelection] = useState<RowSelectionState>(
@@ -288,7 +288,7 @@ export function EdsDataGrid<T>({
     getScrollElement: () => parentRef.current,
     estimateSize,
   })
-  if (rowVirtualizedInstanceRef) rowVirtualizedInstanceRef.current = virtualizer
+  if (rowVirtualizerInstanceRef) rowVirtualizerInstanceRef.current = virtualizer
 
   const virtualRows = virtualizer.getVirtualItems()
   const paddingTop = virtualRows.length ? virtualRows[0].start : 0

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -67,6 +67,7 @@ export function EdsDataGrid<T>({
   width,
   minWidth,
   height,
+  getRowId,
 }: EdsDataGridProps<T>) {
   const [sorting, setSorting] = useState<SortingState>(sortingState ?? [])
   const [selection, setSelection] = useState<RowSelectionState>(
@@ -192,6 +193,7 @@ export function EdsDataGrid<T>({
     enableRowSelection: rowSelection ?? false,
     enableColumnPinning: true,
     enablePinning: true,
+    getRowId,
   }
 
   useEffect(() => {

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -68,6 +68,7 @@ export function EdsDataGrid<T>({
   minWidth,
   height,
   getRowId,
+  rowVirtualizedInstanceRef,
 }: EdsDataGridProps<T>) {
   const [sorting, setSorting] = useState<SortingState>(sortingState ?? [])
   const [selection, setSelection] = useState<RowSelectionState>(
@@ -288,6 +289,8 @@ export function EdsDataGrid<T>({
     getScrollElement: () => parentRef.current,
     estimateSize,
   })
+  if (rowVirtualizedInstanceRef) rowVirtualizedInstanceRef.current = virtualizer
+
   const virtualRows = virtualizer.getVirtualItems()
   const paddingTop = virtualRows.length ? virtualRows[0].start : 0
   const paddingBottom = virtualRows.length
@@ -334,7 +337,7 @@ export function EdsDataGrid<T>({
             style: {
               tableLayout: scrollbarHorizontal ? 'fixed' : 'auto',
               width: table.getTotalSize(),
-              minWidth: scrollbarHorizontal ? width : 'auto',
+              minWidth: scrollbarHorizontal ? minWidth : 'auto',
             },
           }}
         >
@@ -360,16 +363,19 @@ export function EdsDataGrid<T>({
             )}
             {enableVirtual && (
               <>
-                <Table.Row
-                  data-testid="virtual-padding-top"
-                  className={'virtual-padding-top'}
-                >
-                  <Table.Cell
-                    style={{
-                      height: `${paddingTop}px`,
-                    }}
-                  ></Table.Cell>
-                </Table.Row>
+                {paddingTop > 0 && (
+                  <Table.Row
+                    data-testid="virtual-padding-top"
+                    className={'virtual-padding-top'}
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    <Table.Cell
+                      style={{
+                        height: `${paddingTop}px`,
+                      }}
+                    />
+                  </Table.Row>
+                )}
 
                 {virtualRows.map((row) => (
                   <TableRow
@@ -377,16 +383,20 @@ export function EdsDataGrid<T>({
                     row={table.getRowModel().rows[row.index]}
                   />
                 ))}
-                <Table.Row
-                  data-testid="virtual-padding-bottom"
-                  className={'virtual-padding-bottom'}
-                >
-                  <Table.Cell
-                    style={{
-                      height: `${paddingBottom}px`,
-                    }}
-                  ></Table.Cell>
-                </Table.Row>
+
+                {paddingBottom > 0 && (
+                  <Table.Row
+                    data-testid="virtual-padding-bottom"
+                    className={'virtual-padding-bottom'}
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    <Table.Cell
+                      style={{
+                        height: `${paddingBottom}px`,
+                      }}
+                    />
+                  </Table.Row>
+                )}
               </>
             )}
             {!enableVirtual &&

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -16,7 +16,7 @@ import {
   TableOptions,
   useReactTable,
 } from '@tanstack/react-table'
-import { Pagination, Table, useEds } from '@equinor/eds-core-react'
+import { Pagination, Table, Typography, useEds } from '@equinor/eds-core-react'
 import {
   CSSProperties,
   useCallback,
@@ -30,7 +30,6 @@ import { TableRow } from './components/TableRow'
 import { TableProvider } from './EdsDataGridContext'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { EdsDataGridProps } from './EdsDataGridProps'
-import { Typography } from '@equinor/eds-core-react'
 
 export function EdsDataGrid<T>({
   rows,

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -345,7 +345,7 @@ export function EdsDataGrid<T>({
               />
             ))}
           </Table.Head>
-          <Table.Body>
+          <Table.Body style={{ backgroundColor: 'inherit' }}>
             {table.getRowModel().rows.length === 0 && emptyMessage && (
               <Table.Row>
                 <Table.Cell colSpan={table.getHeaderGroups().length}>

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -316,9 +316,9 @@ export function EdsDataGrid<T>({
         style={{
           height: height ?? 'auto',
           ...parentRefStyle,
-          width: scrollbarHorizontal ? width : 'auto',
-          tableLayout: scrollbarHorizontal ? 'fixed' : 'auto',
+          width: scrollbarHorizontal ? width ?? '100%' : 'auto',
           overflow: 'auto',
+          contain: 'strict',
         }}
         ref={parentRef}
       >
@@ -329,6 +329,7 @@ export function EdsDataGrid<T>({
             .join(' ')}
           {...{
             style: {
+              tableLayout: scrollbarHorizontal ? 'fixed' : 'auto',
               width: table.getTotalSize(),
             },
           }}

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -201,7 +201,7 @@ type ColumnProps = {
 }
 
 type RefProps = {
-  rowVirtualizedInstanceRef?: MutableRefObject<Virtualizer<
+  rowVirtualizerInstanceRef?: MutableRefObject<Virtualizer<
     HTMLDivElement,
     Element
   > | null>

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -7,6 +7,7 @@ import {
   Row,
   RowSelectionState,
   SortingState,
+  TableOptions,
 } from '@tanstack/react-table'
 import { CSSProperties, ReactElement } from 'react'
 
@@ -86,6 +87,13 @@ type BaseProps<T> = {
    * @default none
    */
   height?: string | number
+  /**
+   * This optional function is used to derive a unique ID for any given row. If not provided the rows index is used (nested rows join together with `.` using their grandparents' index eg. `index.index.index`). If you need to identify individual rows that are originating from any server-side operations, it's suggested you use this function to return an ID that makes sense regardless of network IO/ambiguity eg. a userId, taskId, database ID field, etc.
+   * @example getRowId: row => row.userId
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getrowid)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getRowId?: TableOptions<T>['getRowId']
 }
 
 type StyleProps<T> = {

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -9,7 +9,8 @@ import {
   SortingState,
   TableOptions,
 } from '@tanstack/react-table'
-import { CSSProperties, ReactElement } from 'react'
+import { Virtualizer } from '@tanstack/react-virtual'
+import { CSSProperties, MutableRefObject, ReactElement } from 'react'
 
 type BaseProps<T> = {
   /**
@@ -199,13 +200,21 @@ type ColumnProps = {
   columnPinState?: ColumnPinningState
 }
 
+type RefProps = {
+  rowVirtualizedInstanceRef?: MutableRefObject<Virtualizer<
+    HTMLDivElement,
+    Element
+  > | null>
+}
+
 export type EdsDataGridProps<T> = BaseProps<T> &
   StyleProps<T> &
   SortProps &
   FilterProps &
   PagingProps &
   ColumnProps &
-  VirtualProps & {
+  VirtualProps &
+  RefProps & {
     /**
      * Which columns are visible. If not set, all columns are visible. undefined means that the column is visible.
      * @default undefined

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -67,14 +67,18 @@ type BaseProps<T> = {
   scrollbarHorizontal?: boolean
   /**
    * Width of the table. Only takes effect if {@link scrollbarHorizontal} is true.
+   *
+   * No suffix (like `px` or `rem`) equals to `px`.
    * @default 800
    */
-  width?: number
+  width?: string | number
   /**
    * Height of the table.
+   *
+   * No suffix (like `px` or `rem`) equals to `px`.
    * @default none
    */
-  height?: number
+  height?: string | number
 }
 
 type StyleProps<T> = {

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -73,6 +73,13 @@ type BaseProps<T> = {
    */
   width?: string | number
   /**
+   * Min width of the table element.
+   *
+   * @example minWidth: 800
+   * @default none
+   */
+  minWidth?: string | number
+  /**
    * Height of the table.
    *
    * No suffix (like `px` or `rem`) equals to `px`.

--- a/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
@@ -1,8 +1,7 @@
 import { Cell, ColumnPinningPosition, flexRender } from '@tanstack/react-table'
-import { Table, Typography } from '@equinor/eds-core-react'
+import { Table } from '@equinor/eds-core-react'
 import { useTableContext } from '../EdsDataGridContext'
 import { useMemo } from 'react'
-import { tokens } from '@equinor/eds-tokens'
 import styled from 'styled-components'
 
 type Props<T> = {

--- a/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
@@ -21,8 +21,7 @@ const StyledCell = styled(Table.Cell)<{
     return ''
   }}
   z-index: ${(p) => (p.$pinned ? 11 : 'auto')};
-  background-color: ${(p) =>
-    p.$pinned ? tokens.colors.ui.background__default.hex : 'inherit'};
+  background-color: inherit;
 `
 
 export function TableBodyCell<T>({ cell }: Props<T>) {

--- a/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
@@ -23,9 +23,6 @@ const StyledCell = styled(Table.Cell)<{
   z-index: ${(p) => (p.$pinned ? 11 : 'auto')};
   background-color: ${(p) =>
     p.$pinned ? tokens.colors.ui.background__default.hex : 'inherit'};
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 `
 
 export function TableBodyCell<T>({ cell }: Props<T>) {
@@ -54,9 +51,7 @@ export function TableBodyCell<T>({ cell }: Props<T>) {
         },
       }}
     >
-      <Typography as="span" group="table" variant="cell_text">
-        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-      </Typography>
+      {flexRender(cell.column.columnDef.cell, cell.getContext())}
     </StyledCell>
   )
 }

--- a/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
@@ -78,10 +78,9 @@ const Cell = styled(Table.Cell)<{
     }
     return ''
   }}
-  z-index: ${(p) => {
-    if (p.$sticky && p.$pinned) return 13
-    if (p.$sticky || p.$pinned) return 12
-    return 'auto'
+  ${(p) => {
+    if (p.$sticky && p.$pinned) return 'z-index: 13'
+    if (p.$sticky || p.$pinned) return 'z-index: 12'
   }};
   &:hover ${ResizeInner} {
     background: ${tokens.colors.interactive.primary__hover.rgba};

--- a/packages/eds-data-grid-react/src/components/TableRow.tsx
+++ b/packages/eds-data-grid-react/src/components/TableRow.tsx
@@ -3,6 +3,7 @@ import { Row } from '@tanstack/react-table'
 import { TableBodyCell } from './TableBodyCell'
 import { HTMLAttributes } from 'react'
 import { useTableContext } from '../EdsDataGridContext'
+import styled from 'styled-components'
 
 type Props<T> = {
   row: Row<T>
@@ -11,7 +12,7 @@ type Props<T> = {
 export function TableRow<T>({ row }: Props<T>) {
   const { rowClass, rowStyle } = useTableContext()
   return (
-    <Table.Row
+    <StyledTableRow
       style={{
         cursor: row.getCanSelect() ? 'pointer' : 'inherit',
         ...(rowStyle?.(row) ?? {}),
@@ -22,6 +23,11 @@ export function TableRow<T>({ row }: Props<T>) {
       {row.getVisibleCells().map((cell) => (
         <TableBodyCell key={cell.id} cell={cell} />
       ))}
-    </Table.Row>
+    </StyledTableRow>
   )
 }
+
+// Neccessary to have this attribute as class to prevent overriding hover color
+const StyledTableRow = styled(Table.Row)`
+  background-color: inherit;
+`

--- a/packages/eds-data-grid-react/src/index.ts
+++ b/packages/eds-data-grid-react/src/index.ts
@@ -1,2 +1,3 @@
 export * from './EdsDataGrid'
 export * from './EdsDataGridProps'
+export * from './types'

--- a/packages/eds-data-grid-react/src/tests/EdsDataGrid.test.tsx
+++ b/packages/eds-data-grid-react/src/tests/EdsDataGrid.test.tsx
@@ -342,7 +342,8 @@ describe('EdsDataGrid', () => {
         screen.queryByRole('table')?.classList.contains('virtual'),
       ).toBeFalsy()
     })
-    it('should show virtual scroll if specified', () => {
+
+    it('should show virtual scroll if enabled', () => {
       let manyRows: Array<Data> = []
       for (let i = 0; i < 200; i++) {
         manyRows = [...manyRows, ...data]
@@ -355,8 +356,23 @@ describe('EdsDataGrid', () => {
         screen.getByRole('table')?.classList.contains('virtual'),
       ).toBeTruthy()
       // Has 2 virtual padding elements
-      expect(screen.getByTestId('virtual-padding-top')).toBeTruthy()
+      // Only bottom scroll element is visible before scrolling
+      expect(screen.queryByTestId('virtual-padding-top')).toBeFalsy()
       expect(screen.getByTestId('virtual-padding-bottom')).toBeTruthy()
+    })
+
+    it('should not show virtual scroll if enabled, but not needed', () => {
+      const fewRows: Data[] = data.slice(0, 2)
+      render(
+        <EdsDataGrid enableVirtual={true} columns={columns} rows={fewRows} />,
+      )
+      // Applies virtual class
+      expect(
+        screen.getByRole('table')?.classList.contains('virtual'),
+      ).toBeTruthy()
+      // Only bottom scroll element is visible before scrolling
+      expect(screen.queryByTestId('virtual-padding-top')).toBeFalsy()
+      expect(screen.queryByTestId('virtual-padding-bottom')).toBeFalsy()
     })
   })
 

--- a/packages/eds-data-grid-react/src/types.ts
+++ b/packages/eds-data-grid-react/src/types.ts
@@ -1,0 +1,34 @@
+// Re-exports from react-table
+import type {
+  Cell,
+  CellContext,
+  ColumnDef,
+  ColumnPinningState,
+  ColumnResizeMode,
+  ColumnSort,
+  ExpandedState,
+  HeaderContext,
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Table,
+  VisibilityState,
+} from '@tanstack/react-table'
+
+export type {
+  Cell,
+  CellContext,
+  ColumnDef,
+  ColumnPinningState,
+  ColumnResizeMode,
+  ColumnSort,
+  ExpandedState,
+  HeaderContext,
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Table,
+  VisibilityState,
+}

--- a/packages/eds-data-grid-react/src/types.ts
+++ b/packages/eds-data-grid-react/src/types.ts
@@ -15,6 +15,7 @@ import type {
   Table,
   VisibilityState,
 } from '@tanstack/react-table'
+import type { Virtualizer } from '@tanstack/react-virtual'
 
 export type {
   Cell,
@@ -31,4 +32,5 @@ export type {
   SortingState,
   Table,
   VisibilityState,
+  Virtualizer,
 }


### PR DESCRIPTION
resolves #3234 

## What does this pull request change?

This pull request introduces the following improvements to the data-grid:

Most of these changes have been discussed with @yusijs.

- ✨ Reexport `@tanstack/react-table` types to ease typing in apps using the data grid
- 📌 Move eds-core-react to peer dependencies
  - This is neccessary because EDS uses React Context and the grid and the project should
have the same React instance running. This makes it possible to set EDS Density of the
table above the component.
- ♻️ Move text truncating into default cell to enable overwriting cell content
  - This enables custom cells like popover, autocomplete or other cells that overflows the cell itself.
- 🐛 Inherit row background color for pinned cells
  - This ensures hover color on the whole row when columns are pinned
- 🐛 Support 100% width
  - Support string `width` and `height`
- ✨ Allow setting minWidth of table
- ✨ Expose getRowId callback from react-table
- ✨ Expose virtualizer ref
  - This is needed to be able to run "scroll to" functionality in apps.
- 🐛 Hide virtualizer rows top and bottom rows when not needed

## Why is this pull request needed?

In order to implement this in our project, we need to be able to use custom cells, set 100% width and use the EdsProvider with the table. Also, there are some minor bugs discovered during implementation.