### PR TITLE
🐛 Fix 100% width bug by removing contain strict

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -323,7 +323,6 @@ export function EdsDataGrid<T>({
           ...parentRefStyle,
           width: scrollbarHorizontal ? width ?? '100%' : 'auto',
           overflow: 'auto',
-          contain: 'layout paint style',
         }}
         ref={parentRef}
       >


### PR DESCRIPTION
Setting `width="100%` does not currently work due to the current contain CSS value. Removing the contain attribute from the table wrapper element solves the issue. Setting `contain: strict` for performance reasons can be done per project by nesting classes using `styled-components`.

#3251 

@yusijs