### PR TITLE
Data-grid: Allow controlling size

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -57,8 +57,43 @@ ColumnFiltering.args = {
   enableColumnFiltering: true,
 }
 
+const defaultSizeState = columns
+  .map((c) => ({ [c.id]: c.size }))
+  .reduce((a, b) => ({ ...a, ...b }), {})
+
 export const ColumnResize: StoryFn<EdsDataGridProps<Photo>> = (args) => {
-  return <EdsDataGrid {...args} />
+  const [size, setSize] = useState(defaultSizeState)
+  const randomizeSize = () => {
+    setSize(
+      Object.keys(defaultSizeState)
+        .map((k) => ({ [k]: Math.floor(Math.random() * 200) }))
+        .reduce((a, b) => ({ ...a, ...b }), {}),
+    )
+  }
+  const throttle = useRef<number | null>(null)
+  return (
+    <>
+      <Button onClick={randomizeSize}>Randomize</Button>
+      <pre>
+        columnSizing=
+        {JSON.stringify(size, null, 2)}
+      </pre>
+      <EdsDataGrid
+        {...args}
+        columnSizing={size}
+        onColumnResize={(e) => {
+          setSize(e)
+          if (throttle.current) {
+            clearTimeout(throttle.current)
+            throttle.current = null
+          }
+          throttle.current = setTimeout(() => {
+            action('onResize')(e)
+          }, 300) as unknown as number
+        }}
+      />
+    </>
+  )
 }
 
 ColumnResize.args = {

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -4,6 +4,7 @@ import {
   ColumnDef,
   ColumnFiltersState,
   ColumnPinningState,
+  ColumnSizingState,
   getCoreRowModel,
   getFacetedMinMaxValues,
   getFacetedRowModel,
@@ -68,6 +69,8 @@ export function EdsDataGrid<T>({
   height,
   getRowId,
   rowVirtualizerInstanceRef,
+  columnSizing,
+  onColumnResize,
 }: EdsDataGridProps<T>) {
   const [sorting, setSorting] = useState<SortingState>(sortingState ?? [])
   const [selection, setSelection] = useState<RowSelectionState>(
@@ -77,6 +80,8 @@ export function EdsDataGrid<T>({
     columnPinState ?? {},
   )
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [internalColumnSize, setInternalColumnSize] =
+    useState<ColumnSizingState>(columnSizing ?? {})
   const [visible, setVisible] = useState(columnVisibility ?? {})
   const [globalFilter, setGlobalFilter] = useState('')
   const [columnOrderState, setColumnOrderState] = useState<string[]>([])
@@ -168,11 +173,22 @@ export function EdsDataGrid<T>({
       },
     },
     columnResizeMode: columnResizeMode,
+    onColumnSizingChange: (change) => {
+      if (typeof change === 'function') {
+        setInternalColumnSize(change(internalColumnSize))
+      } else {
+        setInternalColumnSize(change)
+      }
+      if (onColumnResize) {
+        onColumnResize(internalColumnSize)
+      }
+    },
     state: {
       sorting,
       columnPinning: columnPin,
       rowSelection: selection,
       columnOrder: columnOrderState,
+      columnSizing: columnSizing ?? internalColumnSize,
     },
     onSortingChange: (changes) => {
       if (onSortingChange) {

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -3,6 +3,7 @@ import {
   ColumnDef,
   ColumnPinningState,
   ColumnResizeMode,
+  ColumnSizingState,
   OnChangeFn,
   Row,
   RowSelectionState,
@@ -198,6 +199,8 @@ type SortProps = {
 
 type ColumnProps = {
   columnPinState?: ColumnPinningState
+  columnSizing?: ColumnSizingState
+  onColumnResize?: (e: ColumnSizingState) => void
 }
 
 type RefProps = {

--- a/packages/eds-data-grid-react/src/stories/columns.tsx
+++ b/packages/eds-data-grid-react/src/stories/columns.tsx
@@ -25,6 +25,7 @@ export const columns: Array<ColumnDef<Photo>> = [
   helper.accessor('albumId', {
     header: 'Album ID',
     id: 'albumId',
+    size: 150,
   }),
   helper.accessor('title', {
     header: 'Title',
@@ -35,10 +36,12 @@ export const columns: Array<ColumnDef<Photo>> = [
     header: 'URL',
     cell: (cell) => <Link href={cell.getValue()}>Open</Link>,
     id: 'url',
+    size: 150,
   }),
   helper.accessor('thumbnailUrl', {
     header: 'Thumbnail URL',
     id: 'thumbnailUrl',
+    size: 150,
   }),
 ]
 


### PR DESCRIPTION
Closes https://github.com/equinor/design-system/issues/3269

As it is implemented today, the column size is only controlled within the datagrid. This should be possible to control externally from the consuming application, to allow preserving the previous settings.