### PR TITLE
📌data-grid: changed core-react peerDependency range

### DIFF
--- a/packages/eds-data-grid-react/package.json
+++ b/packages/eds-data-grid-react/package.json
@@ -23,7 +23,7 @@
     "email": "fg_eds@equinor.com"
   },
   "peerDependencies": {
-    "@equinor/eds-core-react": "workspace:^",
+    "@equinor/eds-core-react": "workspace:>=0.36.0",
     "react": ">=16.8",
     "react-dom": ">=16.8",
     "styled-components": ">=4.2"

--- a/packages/eds-data-grid-react/pnpm-lock.yaml
+++ b/packages/eds-data-grid-react/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   '@equinor/eds-core-react':
-    specifier: workspace:^
+    specifier: workspace:>=0.36.0
     version: link:../eds-core-react
   '@equinor/eds-icons':
     specifier: workspace:^


### PR DESCRIPTION
resolves #3266 

Unfortunately pnpm does not seem to support dynamic` "workspace:>=*"` syntax so we'll hardcode it as `"workspace:>=0.36.0"` instead and then update this number manually when there are breaking changes in core-react. We are also puzzled by why "workspace:^" does not work but speculate that maybe due to the leading 0 in 0.36.0