### PR TITLE
Fix prop-spreading in datagrid + add defaultColumn prop

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -77,6 +77,7 @@ export function EdsDataGrid<T>({
   expansionState,
   setExpansionState,
   getSubRows,
+  defaultColumn,
 }: EdsDataGridProps<T>) {
   const [sorting, setSorting] = useState<SortingState>(sortingState ?? [])
   const [selection, setSelection] = useState<RowSelectionState>(
@@ -161,7 +162,7 @@ export function EdsDataGrid<T>({
   const options: TableOptions<T> = {
     data: rows,
     columns: _columns,
-    defaultColumn: {
+    defaultColumn: defaultColumn ?? {
       size: 150,
       cell: (context) => {
         return (

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -97,6 +97,11 @@ type BaseProps<T> = {
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
    */
   getRowId?: TableOptions<T>['getRowId']
+  /**
+   * Optional prop to override the default column setup (cell, header, size etc.)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#defaultcolumn)
+   */
+  defaultColumn?: Partial<ColumnDef<T, unknown>>
 }
 
 type StyleProps<T> = {

--- a/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableBodyCell.tsx
@@ -40,13 +40,11 @@ export function TableBodyCell<T>({ cell }: Props<T>) {
       $pinned={pinned}
       $offset={pinnedOffset}
       className={cellClass ? cellClass(cell.row, cell.column.id) : ''}
-      {...{
-        key: cell.id,
-        style: {
-          width: cell.column.getSize(),
-          maxWidth: cell.column.getSize(),
-          ...(cellStyle?.(cell.row, cell.column.id) ?? {}),
-        },
+      key={cell.id}
+      style={{
+        width: cell.column.getSize(),
+        maxWidth: cell.column.getSize(),
+        ...(cellStyle?.(cell.row, cell.column.id) ?? {}),
       }}
     >
       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
@@ -69,7 +69,6 @@ const Cell = styled(Table.Cell)<{
   $offset: number
 }>`
   font-weight: bold;
-  height: 30px;
   position: ${(p) => (p.$sticky || p.$pinned ? 'sticky' : 'relative')};
   top: 0;
   ${(p) => {
@@ -118,15 +117,13 @@ export function TableHeaderCell<T>({ header, columnResizeMode }: Props<T>) {
       $pinned={pinned}
       className={ctx.headerClass ? ctx.headerClass(header.column) : ''}
       aria-sort={getSortLabel(header.column.getIsSorted())}
-      {...{
-        onClick: header.column.getToggleSortingHandler(),
-        key: header.id,
-        colSpan: header.colSpan,
-        style: {
-          width: header.getSize(),
-          verticalAlign: ctx.enableColumnFiltering ? 'top' : 'middle',
-          ...(ctx.headerStyle ? ctx.headerStyle(header.column) : {}),
-        },
+      key={header.id}
+      onClick={header.column.getToggleSortingHandler()}
+      colSpan={header.colSpan}
+      style={{
+        width: header.getSize(),
+        verticalAlign: ctx.enableColumnFiltering ? 'top' : 'middle',
+        ...(ctx.headerStyle ? ctx.headerStyle(header.column) : {}),
       }}
     >
       <>


### PR DESCRIPTION
* Closes #3299 (warning in next.js when spreading key)
* Adds `defaultColumn` prop to allow overriding stuff like size, cells etc