### PR TITLE
🐛 TextField: dynamically update padding for icon

### DIFF
--- a/packages/eds-core-react/src/components/Input/Input.stories.tsx
+++ b/packages/eds-core-react/src/components/Input/Input.stories.tsx
@@ -1,12 +1,18 @@
 import { useState, useEffect } from 'react'
 import { StoryFn, Meta } from '@storybook/react'
-import { anchor } from '@equinor/eds-icons'
+import { anchor, done } from '@equinor/eds-icons'
 import { Input, InputProps, Label, EdsProvider, Density } from '../..'
 import styled from 'styled-components'
 import { Stack } from './../../../.storybook/components'
 import page from './Input.docs.mdx'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
+
+const icons = {
+  done,
+}
+
+Icon.add(icons)
 
 const meta: Meta<typeof Input> = {
   title: 'Inputs/Input',
@@ -157,6 +163,69 @@ const SmallButton = styled(Button)`
   height: 24px;
   width: 24px;
 `
+
+export const WithIcons: StoryFn<InputProps> = () => {
+  const [icon, setIcon] = useState(true)
+  return (
+    <>
+      <div>
+        <Button
+          variant="outlined"
+          onClick={() => setIcon(!icon)}
+          style={{ marginBottom: '16px' }}
+        >
+          Toggle Icon
+        </Button>
+        <Input
+          id="icons-text"
+          type="date"
+          defaultValue="Input text"
+          label="Label text"
+          meta="Meta"
+          helperText="Helper Text"
+          leftAdornments={icon && <Icon name="done" title="Done" />}
+        />
+        <Input
+          id="icons-text"
+          type="date"
+          defaultValue="Input text"
+          label="Label text"
+          meta="Meta"
+          helperText="Helper Text"
+          rightAdornments={icon && <Icon name="done" title="Done" />}
+        />
+        <Input
+          id="icons-text"
+          type="date"
+          defaultValue="Input text"
+          label="Label text"
+          meta="Meta"
+          helperText="Helper Text"
+          rightAdornments={icon && <Icon name="done" title="Done" />}
+          leftAdornments={icon && <Icon name="done" title="Done" />}
+        />
+      </div>
+    </>
+  )
+}
+
+WithIcons.storyName = 'With icons'
+WithIcons.decorators = [
+  (Story) => {
+    return (
+      <Stack
+        align="baseline"
+        style={{
+          display: 'grid',
+          gridGap: '32px',
+          gridTemplateColumns: 'repeat(3, auto)',
+        }}
+      >
+        <Story />
+      </Stack>
+    )
+  },
+]
 
 export const WithAdornments: StoryFn<InputProps> = () => {
   return (

--- a/packages/eds-core-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.stories.tsx
@@ -236,26 +236,39 @@ WithUnit.decorators = [
   },
 ]
 
-export const WithIcons: Story = () => (
-  <>
-    <TextField
-      id="icons-text"
-      defaultValue="Input text"
-      label="Label text"
-      meta="Meta"
-      helperText="Helper Text"
-      inputIcon={<Icon name="done" title="Done" />}
-    />
-    <TextField
-      id="storybook-multiline-two"
-      placeholder="Placeholder text that spans multiple lines"
-      label="With icon"
-      multiline
-      rows={3}
-      inputIcon={<Icon name="comment" title="Comment" />}
-    />
-  </>
-)
+export const WithIcons: Story = () => {
+  const [icon, setIcon] = useState(true)
+  return (
+    <>
+      <div>
+        <Button
+          variant="outlined"
+          onClick={() => setIcon(!icon)}
+          style={{ marginBottom: '16px' }}
+        >
+          Toggle Icon
+        </Button>
+        <TextField
+          id="icons-text"
+          type="date"
+          defaultValue="Input text"
+          label="Label text"
+          meta="Meta"
+          helperText="Helper Text"
+          inputIcon={icon && <Icon name="done" title="Done" />}
+        />
+      </div>
+      <TextField
+        id="storybook-multiline-two"
+        placeholder="Placeholder text that spans multiple lines"
+        label="With icon"
+        multiline
+        rows={3}
+        inputIcon={<Icon name="comment" title="Comment" />}
+      />
+    </>
+  )
+}
 WithIcons.storyName = 'With icons'
 WithIcons.decorators = [
   (Story) => {

--- a/packages/eds-core-react/src/components/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.tsx
@@ -4,6 +4,9 @@ import {
   TextareaHTMLAttributes,
   forwardRef,
   ForwardedRef,
+  useState,
+  useCallback,
+  useEffect,
 } from 'react'
 import { useId } from '@equinor/eds-utils'
 import { InputWrapper } from '../InputWrapper'
@@ -82,6 +85,12 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     ref,
   ) {
     const helperTextId = useId(null, 'helpertext')
+    const [, updateState] = useState<object>({})
+    const forceUpdate = useCallback(() => updateState({}), [])
+    //if rightAdornments are updated dynamically, we need to force re-render the component so the Input can set correct padding
+    useEffect(() => {
+      forceUpdate()
+    }, [unit, inputIcon, forceUpdate])
 
     let fieldProps = {
       'aria-invalid': variant === 'error' || undefined,

--- a/packages/eds-core-react/src/components/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.tsx
@@ -4,9 +4,6 @@ import {
   TextareaHTMLAttributes,
   forwardRef,
   ForwardedRef,
-  useState,
-  useCallback,
-  useEffect,
 } from 'react'
 import { useId } from '@equinor/eds-utils'
 import { InputWrapper } from '../InputWrapper'
@@ -85,20 +82,14 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     ref,
   ) {
     const helperTextId = useId(null, 'helpertext')
-    const [, updateState] = useState<object>({})
-    const forceUpdate = useCallback(() => updateState({}), [])
-    //if rightAdornments are updated dynamically, we need to force re-render the component so the Input can set correct padding
-    useEffect(() => {
-      forceUpdate()
-    }, [unit, inputIcon, forceUpdate])
-
+    const hasRightAdornments = Boolean(unit || inputIcon)
     let fieldProps = {
       'aria-invalid': variant === 'error' || undefined,
       disabled,
       placeholder,
       id,
       variant,
-      rightAdornments: (
+      rightAdornments: hasRightAdornments && (
         <>
           {inputIcon}
           <span>{unit}</span>

--- a/packages/eds-core-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/eds-core-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -83,24 +83,6 @@ exports[`TextField Matches snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c5 {
-  position: absolute;
-  top: 6px;
-  bottom: 6px;
-  display: flex;
-  align-items: center;
-  font-family: Equinor;
-  font-size: 0.750rem;
-  font-weight: 500;
-  line-height: 1.333em;
-  color: var(--eds-input-adornment-color);
-}
-
-.c6 {
-  right: 0;
-  padding-right: 8px;
-}
-
 <div
     class=""
     style="width: 100%;"
@@ -124,11 +106,6 @@ exports[`TextField Matches snapshot 1`] = `
         style="resize: none;"
         type="text"
       />
-      <div
-        class="c5 c6"
-      >
-        <span />
-      </div>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
resolves #3354 

I could not find any other way to make this work then forcing a re-render in `TextField` if `rightAdornments` change

Updated the TextField "with icons" story with a button to toggle icon to demonstrate that it works
![bilde](https://github.com/equinor/design-system/assets/4499531/e92a8540-64dc-4efb-8f72-883385e273e0)
