### PR TITLE
🚸 Autocomplete: show "no options" on focus

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -735,10 +735,7 @@ function AutocompleteInner<T>(
     (selectedItems.length > 0 || inputValue) && !readOnly && !hideClearButton
 
   const showNoOptions =
-    isOpen &&
-    !availableItems.length &&
-    inputValue.length > 0 &&
-    noOptionsText.length > 0
+    isOpen && !availableItems.length && noOptionsText.length > 0
 
   const selectedItemsLabels = useMemo(
     () => selectedItems.map(getLabel),


### PR DESCRIPTION
resolves #3381 

If there are no options in the Autocomplete, it will show the "no otions" text on focus instead of waiting until the user starts typing