### PR TITLE
Broken link in Datepicker.docs.mdx

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/Datepicker.docs.mdx
+++ b/packages/eds-core-react/src/components/Datepicker/Datepicker.docs.mdx
@@ -7,7 +7,7 @@ import { Links } from '../../../.storybook/components'
 
 <Links
   documentationUrl="https://eds.equinor.com/0b0c666ab/p/07b531-datetime-picker/b/86826a"
-  sourceUrl="https://github.com/equinor/design-system/blob/develop/packages/eds-core-react/src/components/DatePicker/DatePicker.tsx"
+  sourceUrl="https://github.com/equinor/design-system/blob/develop/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx"
   npmUrl="https://www.npmjs.com/package/@equinor/eds-core-react"
 />
 


### PR DESCRIPTION
Case sensitive path (broken link to code in storybook [DatePicker](https://storybook.eds.equinor.com/?path=/docs/inputs-dates-datepicker--docs))

The convention for other components is using pascal case for names with multiple words. EDS documentation uses two words for this ("[Date/time picker](https://eds.equinor.com/0b0c666ab/v/0/p/07b531-datetime-picker)"), so perhaps a better fix is renaming the folder and files to "Date**P**icker" for consistency.

Edit: eds-lab-react uses pascal case for the [DatePicker](https://github.com/equinor/design-system/tree/develop/packages/eds-lab-react/src/components/DatePicker) component.