### PR TITLE
Bugfix/select all crashes

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -726,12 +726,6 @@ function AutocompleteInner<T>(
     reset: resetCombobox,
   } = useCombobox(comboBoxProps)
 
-  useEffect(() => {
-    if (isControlled) {
-      setSelectedItems(selectedOptions)
-    }
-  }, [isControlled, selectedOptions, setSelectedItems])
-
   const { x, y, refs, update, strategy } = useFloating<HTMLInputElement>({
     placement: 'bottom-start',
     middleware: [

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -367,14 +367,6 @@ function AutocompleteInner<T>(
     return _availableItems
   }, [_availableItems, showSelectAll])
 
-  const toggleAllSelected = () => {
-    if (selectedItems.length === inputOptions.length) {
-      setSelectedItems([])
-    } else {
-      setSelectedItems(inputOptions)
-    }
-  }
-
   useEffect(() => {
     const availableHash = JSON.stringify(inputOptions)
     const optionsHash = JSON.stringify(options)
@@ -445,6 +437,14 @@ function AutocompleteInner<T>(
       return 'SOME'
     return 'NONE'
   }, [inputOptions, selectedItems])
+
+  const toggleAllSelected = () => {
+    if (selectedItems.length === inputOptions.length) {
+      setSelectedItems([])
+    } else {
+      setSelectedItems(inputOptions)
+    }
+  }
 
   const getLabel = useCallback(
     (item: T) => {


### PR DESCRIPTION
Removes a seemingly unnecessary useEffect, which resolves an issue where choosing select all would crash when clicked twice in rapid succession. (#3426)