### PR TITLE
🐛 Autocomplete select all: consider disabled items

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -341,15 +341,22 @@ export const DisabledOption: StoryFn<AutocompleteProps<MyOptionType>> = (
   args,
 ) => {
   const { options, optionLabel } = args
-
+  const [filter, setFilter] = useState<boolean>(false)
   const isOptionDisabled = (item: MyOptionType) => item.trend === '📉'
 
   return (
     <>
+      <Checkbox
+        label="disable options"
+        onChange={() => {
+          setFilter(!filter)
+        }}
+        checked={filter}
+      />
       <Autocomplete
         label="Select a stock"
         options={options}
-        optionDisabled={isOptionDisabled}
+        optionDisabled={filter ? isOptionDisabled : undefined}
         optionLabel={optionLabel}
         multiple
         allowSelectAll

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -351,6 +351,8 @@ export const DisabledOption: StoryFn<AutocompleteProps<MyOptionType>> = (
         options={options}
         optionDisabled={isOptionDisabled}
         optionLabel={optionLabel}
+        multiple
+        allowSelectAll
       />
     </>
   )

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -341,7 +341,7 @@ export const DisabledOption: StoryFn<AutocompleteProps<MyOptionType>> = (
   args,
 ) => {
   const { options, optionLabel } = args
-  const [filter, setFilter] = useState<boolean>(false)
+  const [filter, setFilter] = useState<boolean>(true)
   const isOptionDisabled = (item: MyOptionType) => item.trend === '📉'
 
   return (

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -425,7 +425,6 @@ function AutocompleteInner<T>(
     addSelectedItem,
     removeSelectedItem,
     selectedItems,
-    reset: resetSelection,
     setSelectedItems,
   } = useMultipleSelection(multipleSelectionProps)
 
@@ -779,7 +778,8 @@ function AutocompleteInner<T>(
 
   const clear = () => {
     resetCombobox()
-    resetSelection()
+    //dont clear items if they are selected and disabled
+    setSelectedItems([...selectedDisabledItems])
     setTypedInputValue('')
   }
   const showClearButton =

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -428,38 +428,37 @@ function AutocompleteInner<T>(
     setSelectedItems,
   } = useMultipleSelection(multipleSelectionProps)
 
-  const notDisabledItems = useMemo(() => {
+  const enabledItems = useMemo(() => {
     const disabledItemsSet = new Set(inputOptions.filter(optionDisabled))
     return inputOptions.filter((x) => !disabledItemsSet.has(x))
   }, [inputOptions, optionDisabled])
 
-  const selectedDisabledItems = useMemo(
+  const selectedDisabledItemsSet = useMemo(
     () => new Set(selectedItems.filter(optionDisabled)),
     [selectedItems, optionDisabled],
   )
 
-  const selectedNotDisabledItems = useMemo(
-    () => selectedItems.filter((x) => !selectedDisabledItems.has(x)),
-    [selectedItems, selectedDisabledItems],
+  const selectedEnabledItems = useMemo(
+    () => selectedItems.filter((x) => !selectedDisabledItemsSet.has(x)),
+    [selectedItems, selectedDisabledItemsSet],
   )
 
   const allSelectedState = useMemo(() => {
-    if (!notDisabledItems || !selectedNotDisabledItems) return 'NONE'
-    if (notDisabledItems.length === selectedNotDisabledItems.length)
-      return 'ALL'
+    if (!enabledItems || !selectedEnabledItems) return 'NONE'
+    if (enabledItems.length === selectedEnabledItems.length) return 'ALL'
     if (
-      notDisabledItems.length != selectedNotDisabledItems.length &&
-      selectedNotDisabledItems.length > 0
+      enabledItems.length != selectedEnabledItems.length &&
+      selectedEnabledItems.length > 0
     )
       return 'SOME'
     return 'NONE'
-  }, [notDisabledItems, selectedNotDisabledItems])
+  }, [enabledItems, selectedEnabledItems])
 
   const toggleAllSelected = () => {
-    if (selectedNotDisabledItems.length === notDisabledItems.length) {
-      setSelectedItems([...selectedDisabledItems])
+    if (selectedEnabledItems.length === enabledItems.length) {
+      setSelectedItems([...selectedDisabledItemsSet])
     } else {
-      setSelectedItems([...notDisabledItems, ...selectedDisabledItems])
+      setSelectedItems([...enabledItems, ...selectedDisabledItemsSet])
     }
   }
 
@@ -779,7 +778,7 @@ function AutocompleteInner<T>(
   const clear = () => {
     resetCombobox()
     //dont clear items if they are selected and disabled
-    setSelectedItems([...selectedDisabledItems])
+    setSelectedItems([...selectedDisabledItemsSet])
     setTypedInputValue('')
   }
   const showClearButton =

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -379,10 +379,11 @@ function AutocompleteInner<T>(
     setAvailableItems(inputOptions)
   }, [inputOptions])
 
-  const disabledItems = useMemo(
-    () => options.filter(optionDisabled),
-    [options, optionDisabled],
-  )
+  const notDisabledItems = useMemo(() => {
+    const disabledItemsSet = new Set(inputOptions.filter(optionDisabled))
+    return inputOptions.filter((x) => !disabledItemsSet.has(x))
+  }, [inputOptions, optionDisabled])
+
   const { density } = useEds()
   const token = useToken(
     { density },
@@ -431,18 +432,21 @@ function AutocompleteInner<T>(
   } = useMultipleSelection(multipleSelectionProps)
 
   const allSelectedState = useMemo(() => {
-    if (!inputOptions || !selectedItems) return 'NONE'
-    if (inputOptions.length === selectedItems.length) return 'ALL'
-    if (inputOptions.length != selectedItems.length && selectedItems.length > 0)
+    if (!notDisabledItems || !selectedItems) return 'NONE'
+    if (notDisabledItems.length === selectedItems.length) return 'ALL'
+    if (
+      notDisabledItems.length != selectedItems.length &&
+      selectedItems.length > 0
+    )
       return 'SOME'
     return 'NONE'
-  }, [inputOptions, selectedItems])
+  }, [notDisabledItems, selectedItems])
 
   const toggleAllSelected = () => {
-    if (selectedItems.length === inputOptions.length) {
+    if (selectedItems.length === notDisabledItems.length) {
       setSelectedItems([])
     } else {
-      setSelectedItems(inputOptions)
+      setSelectedItems(notDisabledItems)
     }
   }
 
@@ -631,9 +635,7 @@ function AutocompleteInner<T>(
     placeholderText =
       typeof placeholderText !== 'undefined'
         ? placeholderText
-        : `${selectedItems.length}/${
-            options.length - disabledItems.length
-          } selected`
+        : `${selectedItems.length}/${notDisabledItems.length} selected`
     comboBoxProps = {
       ...comboBoxProps,
       selectedItem: null,

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -202,6 +202,8 @@ const findPrevIndex: IndexFinderType = ({
   return prevIndex
 }
 
+const defaultOptionDisabled = () => false
+
 type OptionLabelProps<T> = T extends string | number
   ? {
       /**  Custom option label */
@@ -328,7 +330,7 @@ function AutocompleteInner<T>(
     allowSelectAll,
     initialSelectedOptions = [],
     disablePortal,
-    optionDisabled = () => false,
+    optionDisabled = defaultOptionDisabled,
     optionsFilter,
     autoWidth,
     placeholder,


### PR DESCRIPTION
resolves #3427 

changes
- moved defaultValue of `optionDisabled` to an external const so it does not break useMemo's where it is a dependency
- "select all" now only selects/unselects items that are not disabled
- "clear" button only unselects all selected items that are not disabled
- "x/y selected" text - changed y from "all not disabled items length" to "all items length" (due to the fact that disabled items can still have selected state)