### PR TITLE
fix: Datetime-input is formatted with / instead of :

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/fields/DateSegment.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/DateSegment.tsx
@@ -39,7 +39,10 @@ export function DateSegment({
     ? formatter.formatToParts(state.value.toDate(timezone))
     : []
   const part = parts.find((p) => p.type === segment.type)
-  const value = part?.value ?? segment.text
+  const value =
+    segment.isPlaceholder || segment.type === 'literal'
+      ? segment.text
+      : part?.value ?? segment.text
 
   const [focus, setFocus] = useState(false)
   const ref = useRef(null)


### PR DESCRIPTION
I forgot to account for literals/placeholder-values, so it acts a bit... off now.

In latest release:
![image](https://github.com/equinor/design-system/assets/11261560/9b3ed532-563f-4ac5-a970-b02eb796443e)

This fix:
![image](https://github.com/equinor/design-system/assets/11261560/a7e310f8-cde8-4918-8a25-757e31d7cec9)
