### PR TITLE
EdsDataGrid: disable enableSubRowSelection by default

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -256,6 +256,7 @@ export function EdsDataGrid<T>({
     debugColumns: debug,
     enableRowSelection: enableRowSelection ?? rowSelection ?? false,
     enableMultiRowSelection: enableMultiRowSelection ?? false,
+    enableMultiRowSelection: enableMultiRowSelection ?? false,
     enableColumnPinning: true,
     enablePinning: true,
     getRowId,

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -46,6 +46,7 @@ export function EdsDataGrid<T>({
   rowSelection,
   enableRowSelection,
   enableMultiRowSelection,
+  enableSubRowSelection,
   selectedRows,
   rowSelectionState,
   enableColumnFiltering,

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -256,7 +256,7 @@ export function EdsDataGrid<T>({
     debugColumns: debug,
     enableRowSelection: enableRowSelection ?? rowSelection ?? false,
     enableMultiRowSelection: enableMultiRowSelection ?? false,
-    enableMultiRowSelection: enableMultiRowSelection ?? false,
+    enableSubRowSelection: enableSubRowSelection ?? false,
     enableColumnPinning: true,
     enablePinning: true,
     getRowId,

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -110,6 +110,12 @@ type RowSelectionProps<T> = {
    * @default false
    */
   enableMultiRowSelection?: boolean | ((row: Row<T>) => boolean)
+  /** 
+   * Enables/disables automatic sub-row selection when a parent row is selected, or a function that enables/disables automatic sub-row selection 
+   * @link https://tanstack.com/table/v8/docs/api/features/row-selection#enablesubrowselection
+   * @default false
+   */
+  enableSubRowSelection?: boolean | ((row: Row<T>) => boolean)
   /**
    * The currently selected rows
    * @deprecated Use `rowSelectionState`


### PR DESCRIPTION
This PR ensures that enableSubRowSelection is disabled by default and can be enabled by passing the optional parameter enableSubRowSelection if needed.