### PR TITLE
:label: Make Autocomplete options prop readonly

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -250,7 +250,7 @@ export type AutocompleteChanges<T> = { selectedItems: T[] }
 
 export type AutocompleteProps<T> = {
   /** List of options in dropdown */
-  options: T[]
+  options: readonly T[]
   /** Label for the select element */
   label: ReactNode
   /** Array of initial selected items


### PR DESCRIPTION
## What does this pull request change?

Allow `options` prop in `Autocomplete` to be readonly. This way you can pass readonly arrays such as the one below without getting any TypeScript errors.

```
const READONLY_OPTIONS = [
  { id: 1, label: "One" },
  { id: 2, label: "Two" },
] as const
```

## Why is this pull request needed?

The autocomplete should not change the options array anyways, so I cannot see any reason why not to support readonly options prop.

(became a fork by accident)