### PR TITLE
fix: fixes alignemnt of content in chip component

### DIFF
--- a/packages/eds-core-react/src/components/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/Chip/Chip.tsx
@@ -39,10 +39,15 @@ const StyledChips = styled.div.attrs<StyleProps>(
   grid-gap: 8px;
   grid-auto-flow: column;
   grid-auto-columns: max-content;
-  align-items: center;
+  align-items: end;
 
   svg {
     fill: ${typography.color};
+    align-self: center;
+  }
+
+  & > div {
+    align-self: center;
   }
 
   &:focus {

--- a/packages/eds-tokens/src/base/json/typography.json
+++ b/packages/eds-tokens/src/base/json/typography.json
@@ -421,7 +421,7 @@
       "fontFamily": "Equinor",
       "fontSize": "0.750rem",
       "fontWeight": 500,
-      "lineHeight": "1.333em",
+      "lineHeight": "1.55em",
       "textAlign": "left"
     },
     "chart": {

--- a/packages/eds-tokens/src/base/typography.ts
+++ b/packages/eds-tokens/src/base/typography.ts
@@ -429,7 +429,7 @@ export const typography = {
       fontFamily: 'Equinor',
       fontSize: '0.750rem',
       fontWeight: 500,
-      lineHeight: '1.333em',
+      lineHeight: '1.55em',
       textAlign: 'left',
     },
     chart: {

--- a/packages/eds-tokens/tokens.json
+++ b/packages/eds-tokens/tokens.json
@@ -660,7 +660,7 @@
           "fontFamily": "Equinor",
           "fontSize": "0.750rem",
           "fontWeight": 500,
-          "lineHeight": "1.333em",
+          "lineHeight": "1.55rem",
           "textAlign": "left"
         },
         "chart": {


### PR DESCRIPTION
This pull request fixes the aligment of content inside the `Chip` component

before:
![image](https://github.com/equinor/design-system/assets/25079611/9cebf495-d458-4504-9962-b44a23852f44)

after:
![image](https://github.com/equinor/design-system/assets/25079611/2aa7537a-aa9f-49ef-a2eb-fe7f5bfee783)
