### PR TITLE
:bug: Do not attach document.body if SSR

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -809,7 +809,7 @@ function AutocompleteInner<T>(
     middleware: [
       offset(4),
       flip({
-        boundary: document?.body,
+        boundary: typeof document === 'undefined' ? undefined : document?.body,
       }),
       size({
         apply({ rects, elements }: MiddlewareState) {


### PR DESCRIPTION
## What does this pull request change?

This pull request improves support for SSR for `Autocomplete` by checking if `typeof document === "undefined"` before attaching `document.body` to `floating-ui`.

This should not change any existing functionality since the code is already checking that document is defined using `?`. `typeof` can be used on the server.

## Why is this pull request needed?

Get this error when our `Next.js` application tries to render an Autocomplete.

<img width="842" alt="image" src="https://github.com/equinor/design-system/assets/146428101/ee90bee0-2f91-47dd-bee7-e0eb4a7456bb">

Did not manage to reproduce it in CodeSandbox, so it was just as fast creating a PR for it 😄 
