### PR TITLE
fix(Icon): improve icon type definition by making it a descriminated union on name and data

### DIFF
--- a/packages/eds-core-react/src/components/Icon/Icon.tsx
+++ b/packages/eds-core-react/src/components/Icon/Icon.tsx
@@ -64,22 +64,41 @@ const findIcon = (name: string, data: IconData, size: number) => {
   return { icon, count }
 }
 
-export type IconProps = {
-  /** Title for icon when used semantically */
-  title?: string
-  /** Color */
-  color?: string
-  /** Size */
-  size?: 16 | 18 | 24 | 32 | 40 | 48
-  /** Rotation */
-  rotation?: 0 | 90 | 180 | 270
-  /** Name */
-  name?: Name
-  /** Manually specify which icon data to use */
-  data?: IconData
-  /** @ignore */
-  ref?: Ref<SVGSVGElement>
-} & SVGProps<SVGSVGElement>
+export type IconProps = (
+  | {
+      /** Title for icon when used semantically */
+      title?: string
+      /** Color */
+      color?: string
+      /** Size */
+      size?: 16 | 18 | 24 | 32 | 40 | 48
+      /** Rotation */
+      rotation?: 0 | 90 | 180 | 270
+      /** Name */
+      name: Name
+      /** Manually specify which icon data to use */
+      data?: IconData
+      /** @ignore */
+      ref?: Ref<SVGSVGElement>
+    }
+  | {
+      /** Title for icon when used semantically */
+      title?: string
+      /** Color */
+      color?: string
+      /** Size */
+      size?: 16 | 18 | 24 | 32 | 40 | 48
+      /** Rotation */
+      rotation?: 0 | 90 | 180 | 270
+      /** Name */
+      name?: Name
+      /** Manually specify which icon data to use */
+      data: IconData
+      /** @ignore */
+      ref?: Ref<SVGSVGElement>
+    }
+) &
+  SVGProps<SVGSVGElement>
 
 export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
   { size, color = 'currentColor', name, rotation, title, data, ...rest },


### PR DESCRIPTION
This pull request improves the type defintion of the `Icon` component by making it a discrimited union on the props `name` and `data`. This makes it so that you have to supplie either as if you the `Icon` ends up crashing and throwing an error