### PR TITLE
Bugfix/add missing bounds check for findIndex

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
@@ -331,6 +331,28 @@ describe('Autocomplete', () => {
     expect(input).toHaveValue('')
   })
 
+  it('Correctly handles keypresses up/down when all options are disabled', async () => {
+    render(
+      <Autocomplete
+        options={items}
+        label={labelText}
+        optionDisabled={() => true}
+      />,
+    )
+    const labeledNodes = await screen.findAllByLabelText(labelText)
+    const input = labeledNodes[0]
+    const optionsList = labeledNodes[1]
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    const options = within(optionsList).queryAllByRole('option')
+    expect(options).toHaveLength(0) // since all options is disabled
+
+    // Prevent regression: key up/down when all (visible) options are disabled causes infinite loop
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.blur(input)
+    expect(input).toHaveValue('')
+  })
+
   const StyledAutocomplete = styled(Autocomplete)`
     clip-path: unset;
   `

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -133,7 +133,7 @@ const findIndex: IndexFinderType = ({
   availableItems,
 }) => {
   const nextItem = availableItems[index]
-  if (optionDisabled(nextItem)) {
+  if (optionDisabled(nextItem) && index >= 0 && index < availableItems.length) {
     const nextIndex = calc(index)
     return findIndex({ calc, index: nextIndex, availableItems, optionDisabled })
   }


### PR DESCRIPTION
* Adds a bounds check for Autocomplete's findIndex, to prevent infinite recursion once the index has gone beyond bounds.
* Adds test to prevent regression