### PR TITLE
🩹 Fix error in parsing value for scrollbar-width

### DIFF
--- a/packages/eds-core-react/src/components/Tabs/TabList.tsx
+++ b/packages/eds-core-react/src/components/Tabs/TabList.tsx
@@ -49,7 +49,7 @@ const StyledTabList = styled.div.attrs(
   @media (hover: none) {
     overflow-x: scroll;
     -webkit-overflow-scrolling: touch;
-    scrollbar-width: 0;
+    scrollbar-width: none;
     & ::-webkit-scrollbar {
       width: 0;
       height: 0;


### PR DESCRIPTION
This PR fixes a minor issue in the CSS value for the ⁠`scrollbar-width` property in the ⁠`TabList.tsx` component, which resulted in errors being logged in the console of the Firefox Developer Tools. Changing the value to `none` fixes this. 