### PR TITLE
fix(eds-data-grid-react): Sortindicator should be hidden on custom filters

### DIFF
--- a/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
+++ b/packages/eds-data-grid-react/src/components/TableHeaderCell.tsx
@@ -132,7 +132,7 @@ export function TableHeaderCell<T>({ header, columnResizeMode }: Props<T>) {
             {flexRender(header.column.columnDef.header, header.getContext())}
           </span>
         </div>
-        {header.column.columnDef.meta?.customFilterInput && (
+        {!header.column.columnDef.meta?.customFilterInput && (
           <SortIndicator column={header.column} />
         )}
 


### PR DESCRIPTION
See https://equinor.slack.com/archives/CJT20H1B9/p1724243461395399