### PR TITLE
🎨 Pass className to root

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -22,6 +22,7 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   CSSProperties,
+  HTMLAttributes,
   useCallback,
   useEffect,
   useMemo,
@@ -94,8 +95,8 @@ export function EdsDataGrid<T>({
   onCellClick,
   enableFooter,
   enableSortingRemoval,
-  className
-}: EdsDataGridProps<T>) {
+  ...rest
+}: EdsDataGridProps<T> & HTMLAttributes<HTMLDivElement>) {
   logDevelopmentWarningOfPropUse({
     virtualHeight: {
       value: virtualHeight,
@@ -395,8 +396,9 @@ export function EdsDataGrid<T>({
       stickyFooter={!!stickyFooter}
     >
       <TableWrapper
-        className={`${className} table-wrapper`}
-        style={tableWrapperStyle}
+        {...rest}
+        className={`table-wrapper ${rest.className ?? ''}`}
+        style={{ ...rest.style, ...tableWrapperStyle  }}
         ref={parentRef}
         $height={height}
         $width={width}

--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -94,6 +94,7 @@ export function EdsDataGrid<T>({
   onCellClick,
   enableFooter,
   enableSortingRemoval,
+  className
 }: EdsDataGridProps<T>) {
   logDevelopmentWarningOfPropUse({
     virtualHeight: {
@@ -394,7 +395,7 @@ export function EdsDataGrid<T>({
       stickyFooter={!!stickyFooter}
     >
       <TableWrapper
-        className="table-wrapper"
+        className={`${className} table-wrapper`}
         style={tableWrapperStyle}
         ref={parentRef}
         $height={height}

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -104,10 +104,6 @@ type BaseProps<T> = {
    * Optional props to show table footer
    */
   enableFooter?: boolean
-  /**
-   * Optional prop to pass classname to the root component
-   */
-  className?: string
 }
 
 type RowSelectionProps<T> = {

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -104,6 +104,10 @@ type BaseProps<T> = {
    * Optional props to show table footer
    */
   enableFooter?: boolean
+  /**
+   * Optional prop to pass classname to the root component
+   */
+  className?: string
 }
 
 type RowSelectionProps<T> = {


### PR DESCRIPTION
Like in EDS, we are also using styled components. 
It would be nice to be able to pass the className prop to the root to have more control of the styles.

https://styled-components.com/docs/basics#styling-any-component