### PR TITLE
fix: when using menu in a form, the form is submitted

### DIFF
--- a/packages/eds-core-react/src/components/Menu/MenuItem.tsx
+++ b/packages/eds-core-react/src/components/Menu/MenuItem.tsx
@@ -154,6 +154,7 @@ export const MenuItem: OverridableSubComponent = forwardRef<
     <Item
       {...props}
       $active={active}
+      type="button"
       ref={mergeRefs<HTMLButtonElement>(ref, (el) => {
         if (isFocused) {
           requestAnimationFrame(() => {


### PR DESCRIPTION
When using `Menu` in a form, the form is submitted when clicking on a menu item if `closeMenuOnClcik` is set to false

The problem is a missing `type="button"`.
Looks like this bug has been hiding behind the fact that having it in a form and having `closeMenuOnClick` set to `false` is rare.
The `onClick` callback being called twice when you set `closeMenuOnClick` set to `false` and dont give a `onClose` callback seems to have some have resolved for that instance