### PR TITLE
feat(data-grid): Expose table-instance via ref

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -85,6 +85,7 @@ export function EdsDataGrid<T>({
   height,
   getRowId,
   rowVirtualizerInstanceRef,
+  tableInstanceRef,
   columnSizing,
   onColumnResize,
   expansionState,
@@ -334,6 +335,9 @@ export function EdsDataGrid<T>({
   }, [pageSize])
 
   const table = useReactTable(options)
+  if (tableInstanceRef) {
+    tableInstanceRef.current = table
+  }
 
   let tableWrapperStyle: CSSProperties = {}
 

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -10,6 +10,7 @@ import {
   Row,
   RowSelectionState,
   SortingState,
+  Table,
   TableOptions,
 } from '@tanstack/react-table'
 import { Virtualizer } from '@tanstack/react-virtual'
@@ -307,11 +308,12 @@ type ColumnProps = {
   onColumnResize?: (e: ColumnSizingState) => void
 }
 
-type RefProps = {
+type RefProps<T> = {
   rowVirtualizerInstanceRef?: MutableRefObject<Virtualizer<
     HTMLDivElement,
     Element
   > | null>
+  tableInstanceRef?: MutableRefObject<Table<T> | null>
 }
 
 type ExpansionProps<T> = {
@@ -329,7 +331,7 @@ export type EdsDataGridProps<T> = BaseProps<T> &
   PagingProps &
   ColumnProps &
   VirtualProps &
-  RefProps &
+  RefProps<T> &
   ExpansionProps<T> & {
     /**
      * Which columns are visible. If not set, all columns are visible. undefined means that the column is visible.


### PR DESCRIPTION
There are a few instances where people want / need to access the `table` instance returned from `useReactTable`, or where certain features that we can't prioritize immediately (for example #3667) is required. By exposing the instance, we allow the consumers to bypass these limitations until we can either address their request, or we still allow them to do whatever they need to do without us having to officially ™️ support it.

Resolves #3586

