### PR TITLE
fix: fixes issue where sidebar default state always starts as closed

### DIFF
--- a/packages/eds-core-react/src/components/SideBar/SideBar.context.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBar.context.tsx
@@ -23,10 +23,16 @@ const initalState: State = {
 
 const SideBarContext = createContext<State>(initalState)
 
-type ProviderProps = { children: ReactNode }
+type ProviderProps = { children: ReactNode; isOpen: boolean }
 
-export const SideBarProvider = ({ children }: ProviderProps): JSX.Element => {
-  const [state, setState] = useState<State>(initalState)
+export const SideBarProvider = ({
+  children,
+  isOpen: isOpenProp = false,
+}: ProviderProps) => {
+  const [state, setState] = useState<State>({
+    onToggle: () => {},
+    isOpen: isOpenProp,
+  })
   const { isOpen, onToggle } = state
 
   const setIsOpen = useCallback(

--- a/packages/eds-core-react/src/components/SideBar/SideBar.tsx
+++ b/packages/eds-core-react/src/components/SideBar/SideBar.tsx
@@ -11,21 +11,16 @@ type ContainerProps = {
 
 const SideBarContainer = forwardRef<HTMLDivElement, SidebarProps>(
   function SideBarContainer(
-    { onToggle: onToggleCallback, open = false, children, ...rest },
+    { onToggle: onToggleCallback, children, ...rest },
     ref,
   ) {
-    const { isOpen, setIsOpen, onToggle, setOnToggle } = useSideBar()
+    const { isOpen, onToggle, setOnToggle } = useSideBar()
 
     useEffect(() => {
       if (onToggle === null && onToggleCallback) {
         setOnToggle(onToggleCallback)
       }
     }, [onToggle, onToggleCallback, setOnToggle])
-
-    useEffect(() => {
-      setIsOpen(open)
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [open])
 
     return (
       <GridContainer {...rest} open={isOpen} ref={ref}>
@@ -79,7 +74,7 @@ export const SideBar = forwardRef<HTMLDivElement, SidebarProps>(
 
     return (
       <ThemeProvider theme={token}>
-        <SideBarProvider>
+        <SideBarProvider isOpen={open}>
           <SideBarContainer {...props} ref={ref} />
         </SideBarProvider>
       </ThemeProvider>


### PR DESCRIPTION
This PR addresses a bug in the sidebar component where setting the `open` state to `true` by default results in an initial layout shift. The component briefly renders as closed before opening, causing an unwanted animation.

### Issue

The issue stems from using a `useEffect` to sync the internal state with the `open` prop, leading to a mismatch on initial render.

### Fix

The internal state now defaults directly to the `open` prop, ensuring the sidebar renders correctly without unnecessary transitions.
