### PR TITLE
🐛 Autocomplete: undefined param in optionDiabled

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -467,7 +467,7 @@ function AutocompleteInner<T>(
   const allDisabled = enabledItems.length === 0
 
   const selectedDisabledItemsSet = useMemo(
-    () => new Set(selectedItems.filter(optionDisabled)),
+    () => new Set(selectedItems.filter((x) => x !== null && optionDisabled(x))),
     [selectedItems, optionDisabled],
   )
 


### PR DESCRIPTION
resolves #3677 

For some reason `selectedItems` (returned from `useMultipleSelection` from downshift) contains an array with null (`[null]`) if you have a controlled singleselect and update `selectedOptions` with an empty array from the outside. This then causes the component to crash if `optionDisabled` is defined and tries to read a property from null. I have fixed this by adding an extra null check when creating the `selectedDisabledItemsSet`