### PR TITLE
feat(eds-core-react): :sparkles: use locale prop for text and formats when it is defined

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.stories.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.stories.tsx
@@ -106,6 +106,7 @@ export const CustomLocale: StoryFn = () => {
   const [locale, setLocale] = useState('en-US')
   const locales = [
     { value: 'en-US', label: 'English' },
+    { value: 'nb-NO', label: 'Norwegian' },
     { value: 'uk', label: 'Ukrainian' },
     { value: 'sv-SE', label: 'Swedish' },
     { value: 'zh-Hans', label: 'Chinese (Simplified)' },

--- a/packages/eds-core-react/src/components/Datepicker/DateRangePicker.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DateRangePicker.tsx
@@ -191,6 +191,7 @@ export const DateRangePicker = forwardRef(
               ref={ref}
               variant={props.variant}
               disabled={isDisabled}
+              locale={locale}
               rightAdornments={
                 <Toggle
                   showClearButton={showClearButton}

--- a/packages/eds-core-react/src/components/Datepicker/fields/DateField.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/DateField.tsx
@@ -20,7 +20,7 @@ type Props = {
 }
 
 /**
- * Datefield is the input field used in {@link DatePicker} to type in a single date.
+ * DateField is the input field used in {@link DatePicker} to type in a single date.
  * Encapsulates styling / functionality for typing a date
  */
 export const DateField = forwardRef<HTMLDivElement, Props>(function (
@@ -39,7 +39,12 @@ export const DateField = forwardRef<HTMLDivElement, Props>(function (
       ref={ref}
       className={`field ${state.isInvalid ? 'invalid' : 'valid'}`}
     >
-      <DateFieldSegments {...state} {...fieldProps} ref={inputRef} />
+      <DateFieldSegments
+        {...state}
+        {...fieldProps}
+        locale={dateCreateProps.locale}
+        ref={inputRef}
+      />
       <span style={{ flex: '1 1 auto' }} />
       {props.rightAdornments}
     </InputFieldWrapper>

--- a/packages/eds-core-react/src/components/Datepicker/fields/DateFieldSegments.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/DateFieldSegments.tsx
@@ -4,7 +4,7 @@ import {
   DateFieldStateOptions,
   useDateFieldState,
 } from '@react-stately/datepicker'
-import { useDateField, useLocale } from 'react-aria'
+import { useDateField } from 'react-aria'
 import { createCalendar } from '@internationalized/date'
 import { DateSegment } from './DateSegment'
 import { forwardRef, RefObject } from 'react'
@@ -16,10 +16,9 @@ type Props = Partial<DateFieldStateOptions>
  */
 export const DateFieldSegments = forwardRef(
   (props: Props, ref: RefObject<HTMLDivElement>) => {
-    const { locale } = useLocale()
     const state = useDateFieldState({
       ...props,
-      locale,
+      locale: props.locale,
       createCalendar,
     })
 

--- a/packages/eds-core-react/src/components/Datepicker/fields/DateRangeField.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/DateRangeField.tsx
@@ -10,6 +10,7 @@ type Props = {
   startFieldProps: AriaDatePickerProps<DateValue>
   endFieldProps: AriaDatePickerProps<DateValue>
   groupProps: GroupDOMAttributes
+  locale: string
 } & Partial<InputProps>
 
 /**
@@ -31,7 +32,11 @@ export const DateRangeField = forwardRef<HTMLDivElement, Props>(function (
       color={props.variant}
       {...props.groupProps}
     >
-      <DateFieldSegments {...props.startFieldProps} ref={fromRef} />
+      <DateFieldSegments
+        {...props.startFieldProps}
+        ref={fromRef}
+        locale={props.locale}
+      />
       <Typography
         as={'span'}
         variant={'text'}
@@ -40,7 +45,11 @@ export const DateRangeField = forwardRef<HTMLDivElement, Props>(function (
       >
         &mdash;
       </Typography>
-      <DateFieldSegments {...props.endFieldProps} ref={toRef} />
+      <DateFieldSegments
+        {...props.endFieldProps}
+        ref={toRef}
+        locale={props.locale}
+      />
       <span style={{ flex: '1 1 auto' }} />
       {props.rightAdornments}
     </InputFieldWrapper>


### PR DESCRIPTION
Fixes #3638