### PR TITLE
🧑‍💻add 'use client' to relevant index files

### DIFF
--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/eds-core-react",
-  "version": "0.42.5",
+  "version": "0.43.0-dev-01062025",
   "description": "The React implementation of the Equinor Design System",
   "sideEffects": [
     "**/*.css"

--- a/packages/eds-core-react/src/components/Accordion/index.ts
+++ b/packages/eds-core-react/src/components/Accordion/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Accordion as BaseAccordion } from './Accordion'
 import { AccordionItem, AccordionItemProps } from './AccordionItem'
 import { AccordionHeader, AccordionHeaderProps } from './AccordionHeader'

--- a/packages/eds-core-react/src/components/Banner/index.ts
+++ b/packages/eds-core-react/src/components/Banner/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Banner as BaseBanner, BannerProps } from './Banner'
 import { BannerIcon, BannerIconProps } from './BannerIcon'
 import { BannerMessage, BannerMessageProps } from './BannerMessage'

--- a/packages/eds-core-react/src/components/Breadcrumbs/index.ts
+++ b/packages/eds-core-react/src/components/Breadcrumbs/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Breadcrumbs as BaseComponent, BreadcrumbsProps } from './Breadcrumbs'
 import { Breadcrumb, BreadcrumbProps } from './Breadcrumb'
 

--- a/packages/eds-core-react/src/components/Button/index.ts
+++ b/packages/eds-core-react/src/components/Button/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Button as ButtonWrapper, ButtonProps } from './Button'
 import { ButtonGroup, ButtonGroupProps } from './ButtonGroup/ButtonGroup'
 import { ToggleButton, ToggleButtonProps } from './ToggleButton/ToggleButton'

--- a/packages/eds-core-react/src/components/Card/index.ts
+++ b/packages/eds-core-react/src/components/Card/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Card as CardWrapper, CardProps } from './Card'
 import { CardActions, CardActionsProps } from './CardActions'
 import { CardContent, CardContentProps } from './CardContent'

--- a/packages/eds-core-react/src/components/Datepicker/index.ts
+++ b/packages/eds-core-react/src/components/Datepicker/index.ts
@@ -1,3 +1,4 @@
+'use client'
 export * from './DatePicker'
 export * from './DateRangePicker'
 export * from './props'

--- a/packages/eds-core-react/src/components/Dialog/index.ts
+++ b/packages/eds-core-react/src/components/Dialog/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Dialog as BaseComponent, DialogProps } from './Dialog'
 import { DialogActions, DialogActionsProps } from './DialogActions'
 import { DialogTitle, DialogTitleProps } from './DialogTitle'

--- a/packages/eds-core-react/src/components/List/index.ts
+++ b/packages/eds-core-react/src/components/List/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { List as BaseComponent, ListProps } from './List'
 import { ListItem, ListItemProps } from './ListItem'
 

--- a/packages/eds-core-react/src/components/Menu/index.tsx
+++ b/packages/eds-core-react/src/components/Menu/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { Menu as BaseMenu, MenuProps } from './Menu'
 import { MenuItem, MenuItemProps } from './MenuItem'
 import { MenuSection, MenuSectionProps } from './MenuSection'

--- a/packages/eds-core-react/src/components/Popover/index.ts
+++ b/packages/eds-core-react/src/components/Popover/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Popover as BaseComponent, PopoverProps } from './Popover'
 import { PopoverTitle, PopoverTitleProps } from './PopoverTitle'
 import { PopoverContent, PopoverContentProps } from './PopoverContent'

--- a/packages/eds-core-react/src/components/SideBar/index.ts
+++ b/packages/eds-core-react/src/components/SideBar/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { SideBar as BaseSideBar } from './SideBar'
 import { useSideBar } from './SideBar.context'
 import { SidebarLink, SidebarLinkProps } from './SidebarLink'

--- a/packages/eds-core-react/src/components/Snackbar/index.ts
+++ b/packages/eds-core-react/src/components/Snackbar/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { SnackbarAction, SnackbarActionProps } from './SnackbarAction'
 import { Snackbar as BaseComponent, SnackbarProps } from './Snackbar'
 

--- a/packages/eds-core-react/src/components/Table/index.tsx
+++ b/packages/eds-core-react/src/components/Table/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { Table as BaseTable, TableProps } from './Table'
 import { Body, BodyProps } from './Body'
 import { Cell, CellProps } from './Cell'

--- a/packages/eds-core-react/src/components/TableOfContents/index.ts
+++ b/packages/eds-core-react/src/components/TableOfContents/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import {
   TableOfContents as BaseComponent,
   TableOfContentsProps,

--- a/packages/eds-core-react/src/components/Tabs/index.ts
+++ b/packages/eds-core-react/src/components/Tabs/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { Tabs as BaseComponent, TabsProps } from './Tabs'
 import { TabList, TabListProps } from './TabList'
 import { Tab, TabProps } from './Tab'

--- a/packages/eds-core-react/src/components/TopBar/index.tsx
+++ b/packages/eds-core-react/src/components/TopBar/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { TopBar as BaseComponent, TopbarProps } from './TopBar'
 import { Actions, TopbarActionsProps } from './Actions'
 import { Header, TopbarHeaderProps } from './Header'


### PR DESCRIPTION
resolves #3702 

it was reported that 'use client' on the main index file did not "inherit" down to sub-components. This pr adds 'use client' to the index of components with sub-components. I don't have a test setup to check if this works so I'll make a dev release for  @sebastianvitterso to check