### PR TITLE
EDS Data Grid Feature: +onRowDoubleClick event

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.tsx
@@ -98,6 +98,7 @@ function EdsDataGridInner<T>(
     defaultColumn,
     onRowContextMenu,
     onRowClick,
+    onRowDoubleClick,
     onCellClick,
     enableFooter,
     enableSortingRemoval,
@@ -483,6 +484,11 @@ function EdsDataGridInner<T>(
                       onClick={
                         onRowClick
                           ? (event) => onRowClick(row, event)
+                          : undefined
+                      }
+                      onDoubleClick={
+                        onRowDoubleClick
+                          ? (event) => onRowDoubleClick(row, event)
                           : undefined
                       }
                       onCellClick={onCellClick}

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -230,6 +230,17 @@ type HandlersProps<T> = {
    */
   onRowClick?: (row: Row<T>, event: MouseEvent<HTMLTableRowElement>) => unknown
   /**
+   * Row double-click handler.
+   *
+   * @param row The current row
+   * @param event The click event
+   * @returns
+   */
+  onRowDoubleClick?: (
+    row: Row<T>,
+    event: MouseEvent<HTMLTableRowElement>
+  ) => unknown
+  /**
    * Cell click handler.
    *
    * @param cell The current cell

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -238,7 +238,7 @@ type HandlersProps<T> = {
    */
   onRowDoubleClick?: (
     row: Row<T>,
-    event: MouseEvent<HTMLTableRowElement>
+    event: MouseEvent<HTMLTableRowElement>,
   ) => unknown
   /**
    * Cell click handler.

--- a/packages/eds-data-grid-react/src/components/TableRow.tsx
+++ b/packages/eds-data-grid-react/src/components/TableRow.tsx
@@ -15,6 +15,7 @@ export function TableRow<T>({
   row,
   onCellClick,
   onClick,
+  onDoubleClick,
   onContextMenu,
 }: Props<T>) {
   const { rowClass, rowStyle } = useTableContext()
@@ -26,6 +27,7 @@ export function TableRow<T>({
       }}
       className={`${row.getIsSelected() ? 'selected' : ''} ${rowClass?.(row)}`}
       onClick={onClick}
+      onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}
     >
       {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION
I've added a new event to the EDS Data Grid: `onRowDoubleClick`
It propagates `onDoubleClick` event on the row. Works the same way as `onRowClick` event