### PR TITLE
feat: make TextField id optional

### DIFF
--- a/packages/eds-core-react/src/components/TextField/TextField.test.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.test.tsx
@@ -41,11 +41,7 @@ describe('TextField', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
   it('Should pas a11y test even if no id has been provided', async () => {
-    const { container } = render(
-      <TextField
-        label="textfield"
-      />,
-    )
+    const { container } = render(<TextField label="textfield" />)
     expect(await axe(container)).toHaveNoViolations()
   })
   it('Has correct label text', () => {

--- a/packages/eds-core-react/src/components/TextField/TextField.test.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.test.tsx
@@ -40,6 +40,14 @@ describe('TextField', () => {
     )
     expect(await axe(container)).toHaveNoViolations()
   })
+  it('Should pas a11y test even if no id has been provided', async () => {
+    const { container } = render(
+      <TextField
+        label="textfield"
+      />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
   it('Has correct label text', () => {
     const labelText = 'Some label'
     render(<TextField id="test-label" label={labelText} />)

--- a/packages/eds-core-react/src/components/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.tsx
@@ -81,7 +81,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     },
     ref,
   ) {
-    const id = useId(_id, "input");
+    const id = useId(_id, 'input')
     const helperTextId = useId(null, 'helpertext')
     const hasRightAdornments = Boolean(unit || inputIcon)
     let fieldProps = {

--- a/packages/eds-core-react/src/components/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.tsx
@@ -29,7 +29,7 @@ type SharedTextFieldProps = {
   /** Variants */
   variant?: Variants
   /** Input unique id. This is required to ensure accesibility */
-  id: string
+  id?: string
   /** Label text */
   label?: ReactNode
   /** Meta text */
@@ -61,7 +61,7 @@ export type TextFieldProps = SharedTextFieldProps &
 export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
   function TextField(
     {
-      id,
+      id: _id,
       label,
       meta,
       unit,
@@ -81,6 +81,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     },
     ref,
   ) {
+    const id = useId(_id, "input");
     const helperTextId = useId(null, 'helpertext')
     const hasRightAdornments = Boolean(unit || inputIcon)
     let fieldProps = {

--- a/packages/eds-core-react/src/components/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.tsx
@@ -28,7 +28,7 @@ const Field = forwardRef<HTMLTextAreaElement | HTMLInputElement, FieldProps>(
 type SharedTextFieldProps = {
   /** Variants */
   variant?: Variants
-  /** Input unique id. This is required to ensure accesibility */
+  /** Input unique id. If this is not provided, one will be generated */
   id?: string
   /** Label text */
   label?: ReactNode


### PR DESCRIPTION
* Allows users to omit creating their own Id for Textfield by falling back to a generated id