### PR TITLE
feat: adds loading state to Button controlled by loading prop

### DIFF
--- a/packages/eds-core-react/src/components/Button/Button.stories.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.stories.tsx
@@ -1,16 +1,16 @@
-import { useState, ChangeEvent } from 'react'
+import { add, menu, refresh, save } from '@equinor/eds-icons'
+import { Meta, StoryFn } from '@storybook/react'
+import { ChangeEvent, useState } from 'react'
 import {
   Button,
   ButtonProps,
-  Icon,
-  EdsProvider,
-  Progress,
   Checkbox,
+  EdsProvider,
+  Icon,
+  Progress,
   Snackbar,
   Tooltip,
 } from '../..'
-import { StoryFn, Meta } from '@storybook/react'
-import { menu, add, save, send, refresh } from '@equinor/eds-icons'
 import { Stack } from './../../../.storybook/components'
 import page from './Button.docs.mdx'
 
@@ -230,17 +230,11 @@ export const ProgressButton: StoryFn<ButtonProps> = () => {
       <Button
         aria-disabled={isSubmitting ? true : false}
         aria-label={isSubmitting ? 'loading data' : null}
+        loading={isSubmitting}
         color="secondary"
         onClick={!isSubmitting ? onSubmit : undefined}
       >
-        {isSubmitting ? (
-          <Progress.Circular size={16} color="primary" />
-        ) : (
-          <>
-            Send
-            <Icon data={send} size={16}></Icon>
-          </>
-        )}
+        Send
       </Button>
       <Button onClick={() => setIsSubmitting(false)}>
         <>

--- a/packages/eds-core-react/src/components/Button/Button.test.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.test.tsx
@@ -138,6 +138,14 @@ describe('Button', () => {
 
     expect(button).toBeInTheDocument()
   })
+  it('Renders with a progress when loading prop is true', () => {
+    render(<Button loading={true} />)
+    const button = screen.getByRole('button')
+    const progress = screen.getByRole('progressbar')
+
+    expect(button).toBeInTheDocument()
+    expect(progress).toBeInTheDocument()
+  })
   it('Can be cast as another component', () => {
     render(<Button as={LinkButton} to="/" />)
     const button = screen.getByRole('link')

--- a/packages/eds-core-react/src/components/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.tsx
@@ -1,17 +1,18 @@
-import { forwardRef, ButtonHTMLAttributes } from 'react'
-import styled, { css, ThemeProvider } from 'styled-components'
-import { token as buttonToken } from './tokens'
-import { ButtonTokenSet, ButtonToken } from './Button.types'
 import {
-  typographyTemplate,
   bordersTemplate,
   outlineTemplate,
-  spacingsTemplate,
-  useToken,
   OverridableComponent,
+  spacingsTemplate,
+  typographyTemplate,
+  useToken,
 } from '@equinor/eds-utils'
-import { InnerFullWidth } from './InnerFullWidth'
+import { ButtonHTMLAttributes, forwardRef } from 'react'
+import styled, { css, ThemeProvider } from 'styled-components'
 import { useEds } from '../EdsProvider'
+import { ButtonToken, ButtonTokenSet } from './Button.types'
+import { InnerFullWidth } from './InnerFullWidth'
+import { token as buttonToken } from './tokens'
+import { Progress } from '../Progress'
 
 type Colors = 'primary' | 'secondary' | 'danger'
 type Variants =
@@ -150,6 +151,8 @@ export type ButtonProps = {
   href?: string
   /** Is the button disabled */
   disabled?: boolean
+  /** Is the button loading */
+  loading?: boolean
   /** Type of button
    * @default 'button'
    */
@@ -165,6 +168,7 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
       variant = 'contained',
       children,
       disabled = false,
+      loading = false,
       href,
       tabIndex = 0,
       fullWidth = false,
@@ -191,14 +195,15 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
       ...other,
     }
 
+    const ButtonInner = fullWidth ? InnerFullWidth : Inner
+
     return (
       <ThemeProvider theme={token}>
         <ButtonBase {...buttonProps}>
-          {fullWidth ? (
-            <InnerFullWidth>{children}</InnerFullWidth>
-          ) : (
-            <Inner>{children}</Inner>
-          )}
+          <ButtonInner>
+            {!loading && children}
+            {loading && <Progress.Circular size={16} />}
+          </ButtonInner>
         </ButtonBase>
       </ThemeProvider>
     )


### PR DESCRIPTION
This PR enhances the Button component by adding a new `loading` prop.  

When `loading` is set to `true`, the button displays a `Progress.Circular` indicator, making it easier to show a loading state.
