### PR TITLE
🐛 DatePicker & DateRangePicker: Ensure consistent styling on state changes

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/fields/DateFieldSegments.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/DateFieldSegments.tsx
@@ -33,7 +33,14 @@ export const DateFieldSegments = forwardRef(
     )
 
     return (
-      <div {...fieldProps} style={{ display: 'flex' }} ref={ref}>
+      <div
+        {...fieldProps}
+        style={{
+          display: 'flex',
+          fontFamily: 'Equinor, Arial, sans-serif',
+        }}
+        ref={ref}
+      >
         {state.segments.map((segment, i) => (
           <DateSegment key={i} segment={segment} state={state} />
         ))}

--- a/packages/eds-core-react/src/components/Datepicker/fields/Toggle.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/Toggle.tsx
@@ -35,8 +35,8 @@ export const Toggle = ({
   valueString: string
   showClearButton: boolean
 }) => {
-  return readonly || disabled ? null : (
-    <>
+  return (
+    <div style={{ visibility: readonly || disabled ? 'hidden' : 'visible' }}>
       {showClearButton && (
         <StyledButton
           disabled={disabled}
@@ -69,6 +69,6 @@ export const Toggle = ({
       >
         <Icon data={icon} />
       </StyledButton>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
Resolves #3747 
This fixes the misalignment of the calendar icon in `DatePicker` when toggling between disabled and enabled states and ensures the correct font is applied consistently.

## Key Changes:
- Fixed icon offset: The calendar icon no longer shifts position when enabling `DatePicker` from a disabled state.
- Ensured consistent font-family: The date input now retains the correct font-family after state changes.

## Technical Implementation:
- Preserved `Toggle` in the DOM by applying `visibility: hidden` instead of removing it when `disabled={true}`.
- Explicitly set font-family in `DateFieldSegments` to prevent incorrect font inheritance after enabling `DatePicker`.
- Ensured layout stability by maintaining space for `Toggle`, preventing flexbox or grid shifts when re-enabling the component.

The fix has been manually tested in Storybook to verify that the icon remains correctly aligned and the font remains consistent across state transitions.