### PR TITLE
expose itemToKey, add deprecation notice to itemCompare

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -281,8 +281,8 @@ export const OptionComponent: StoryFn<AutocompleteProps<MyOptionType>> = (
         initialSelectedOptions={
           [JSON.parse(JSON.stringify(options[1]))] as MyOptionType[]
         }
-        itemCompare={(item, compare) => {
-          return item.label === compare.label
+        itemToKey={(item) => {
+          return item.label
         }}
         multiline
       />
@@ -294,8 +294,8 @@ export const OptionComponent: StoryFn<AutocompleteProps<MyOptionType>> = (
         initialSelectedOptions={
           JSON.parse(JSON.stringify([options[1], options[2]])) as MyOptionType[]
         }
-        itemCompare={(item, compare) => {
-          return item.label === compare.label
+        itemToKey={(item) => {
+          return item.label
         }}
         multiline
         multiple

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
@@ -218,7 +218,7 @@ describe('Autocomplete', () => {
     render(
       <Autocomplete
         optionLabel={(o) => o.label}
-        itemToKey={(o) => o.value}
+        itemToKey={(item) => item?.value}
         label={labelText}
         options={opts}
         data-testid="styled-autocomplete"

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
@@ -218,7 +218,7 @@ describe('Autocomplete', () => {
     render(
       <Autocomplete
         optionLabel={(o) => o.label}
-        itemCompare={(o1, o2) => o1.value === o2.value}
+        itemToKey={(o) => o.value}
         label={labelText}
         options={opts}
         data-testid="styled-autocomplete"

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -311,7 +311,13 @@ export type AutocompleteProps<T> = {
    *  @default 300
    */
   dropdownHeight?: number
+
   /**
+   * Method that is used to select a key that can be used for comparing items. If omitted, objects are matched by reference.
+   */
+  itemToKey?: (value: T) => any
+  /**
+   * @deprecated since version 0.45.0 - use itemToKey instead
    * Method that is used to compare objects by value. If omitted, objects are matched by reference.
    */
   itemCompare?: (value: T, compare: T) => boolean
@@ -340,7 +346,8 @@ function AutocompleteInner<T>(
     onInputChange,
     selectedOptions: _selectedOptions,
     multiple,
-    itemCompare,
+    itemToKey,
+    itemCompare: _itemCompare,
     allowSelectAll,
     initialSelectedOptions: _initialSelectedOptions = [],
     optionDisabled = defaultOptionDisabled,
@@ -359,6 +366,17 @@ function AutocompleteInner<T>(
     onClear,
     ...other
   } = props
+
+  const itemCompare = useMemo(() => {
+    if(_itemCompare && itemToKey) {
+      console.error("Error: Specifying both itemCompare and itemToKey. itemCompare is deprecated, while itemToKey should be used instead of it. Please only use one.")
+      return _itemCompare;
+    }
+    if(itemToKey) {
+      return (o1: T, o2: T) => (itemToKey(o1) === itemToKey(o2))
+    }
+    return _itemCompare
+  }, [_itemCompare, itemToKey])
 
   // MARK: initializing data/setup
   const selectedOptions = _selectedOptions
@@ -417,6 +435,7 @@ function AutocompleteInner<T>(
   let placeholderText = placeholder
 
   let multipleSelectionProps: UseMultipleSelectionProps<T> = {
+    itemToKey,
     initialSelectedItems: multiple
       ? initialSelectedOptions
       : initialSelectedOptions[0]
@@ -551,6 +570,7 @@ function AutocompleteInner<T>(
     isItemDisabled(item) {
       return optionDisabled(item)
     },
+    itemToKey,
     itemToString: getLabel,
     onInputValueChange: ({ inputValue }) => {
       onInputChange && onInputChange(inputValue)

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -315,7 +315,7 @@ export type AutocompleteProps<T> = {
   /**
    * Method that is used to select a key that can be used for comparing items. If omitted, objects are matched by reference.
    */
-  itemToKey?: (value: T) => unknown
+  itemToKey?: (value: T | null) => unknown
   /**
    * @deprecated since version 0.45.0 - use itemToKey instead
    * Method that is used to compare objects by value. If omitted, objects are matched by reference.
@@ -382,6 +382,7 @@ function AutocompleteInner<T>(
 
   const itemToKey = useCallback(
     (item: T) => {
+      console.log(`item is`, item)
       return _itemToKey ? _itemToKey(item) : item
     },
     [_itemToKey],

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -346,7 +346,7 @@ function AutocompleteInner<T>(
     onInputChange,
     selectedOptions: _selectedOptions,
     multiple,
-    itemToKey,
+    itemToKey: _itemToKey,
     itemCompare: _itemCompare,
     allowSelectAll,
     initialSelectedOptions: _initialSelectedOptions = [],
@@ -368,15 +368,24 @@ function AutocompleteInner<T>(
   } = props
 
   const itemCompare = useMemo(() => {
-    if(_itemCompare && itemToKey) {
-      console.error("Error: Specifying both itemCompare and itemToKey. itemCompare is deprecated, while itemToKey should be used instead of it. Please only use one.")
-      return _itemCompare;
+    if (_itemCompare && _itemToKey) {
+      console.error(
+        'Error: Specifying both itemCompare and itemToKey. itemCompare is deprecated, while itemToKey should be used instead of it. Please only use one.',
+      )
+      return _itemCompare
     }
-    if(itemToKey) {
-      return (o1: T, o2: T) => (itemToKey(o1) === itemToKey(o2))
+    if (_itemToKey) {
+      return (o1: T, o2: T) => itemToKey(o1) === itemToKey(o2)
     }
     return _itemCompare
-  }, [_itemCompare, itemToKey])
+  }, [_itemCompare, _itemToKey])
+
+  const itemToKey = useCallback(
+    (item) => {
+      return _itemToKey ? _itemToKey(item) : item
+    },
+    [_itemToKey],
+  )
 
   // MARK: initializing data/setup
   const selectedOptions = _selectedOptions

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -315,7 +315,7 @@ export type AutocompleteProps<T> = {
   /**
    * Method that is used to select a key that can be used for comparing items. If omitted, objects are matched by reference.
    */
-  itemToKey?: (value: T) => any
+  itemToKey?: (value: T) => unknown
   /**
    * @deprecated since version 0.45.0 - use itemToKey instead
    * Method that is used to compare objects by value. If omitted, objects are matched by reference.
@@ -375,7 +375,7 @@ function AutocompleteInner<T>(
       return _itemCompare
     }
     if (_itemToKey) {
-      return (o1: T, o2: T) => itemToKey(o1) === itemToKey(o2)
+      return (o1: T, o2: T) => _itemToKey(o1) === _itemToKey(o2)
     }
     return _itemCompare
   }, [_itemCompare, _itemToKey])

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -381,7 +381,7 @@ function AutocompleteInner<T>(
   }, [_itemCompare, _itemToKey])
 
   const itemToKey = useCallback(
-    (item) => {
+    (item: T) => {
       return _itemToKey ? _itemToKey(item) : item
     },
     [_itemToKey],


### PR DESCRIPTION
this is yet-another blind fix for issue #3259 - this time, intended to fix an issue where sometimes, downshift doesn't even trigger the onSelectedItemsChange function