### PR TITLE
fix(Autocomplete, TextField): moves refs from containers to input element to fix scroll to field error with react hook form

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import { Autocomplete, AutocompleteProps, AutocompleteChanges } from '.'
 import { Checkbox } from '../Checkbox'
+import { TextField } from '../TextField'
 import { StoryFn, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { useForm, Controller } from 'react-hook-form'
@@ -786,20 +787,20 @@ export const Async: StoryFn<AutocompleteProps<MyOptionType>> = () => {
 Async.storyName = 'Async search autocomplete'
 
 type MyFormValues = {
+  firstName: string | null
   origin: string | null
   favouriteCounty: string | null
   fruits: { label: string; emoji: string }[]
-  test: string | null
 }
 
 export const WithReactHookForm: StoryFn<
   AutocompleteProps<MyOptionType>
 > = () => {
   const defaultValues: MyFormValues = {
+    firstName: null,
     origin: null,
     favouriteCounty: null,
     fruits: [],
-    test: null,
   }
   const {
     handleSubmit,
@@ -849,6 +850,26 @@ export const WithReactHookForm: StoryFn<
             <Button variant="outlined" onClick={() => reset()}>
               Reset
             </Button>
+          </div>
+          <div style={{ margin: '16px 0' }}>
+            <Controller
+              control={control}
+              name="firstName"
+              rules={{ required: true }}
+              render={({ field: { onChange, ref } }) => (
+                <TextField
+                  label="First name"
+                  ref={ref}
+                  onChange={onChange}
+                  value={values.firstName}
+                />
+              )}
+            />
+            {errors.firstName && errors.firstName.type === 'required' && (
+              <FormError id="error-test-required">
+                This field is required
+              </FormError>
+            )}
           </div>
           <div style={{ margin: '16px 0' }}>
             <Controller

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -14,11 +14,31 @@ import {
   Card,
   Avatar,
   Icon,
-  TextField,
 } from '../..'
 import { Stack } from '../../../.storybook/components'
 import page from './Autocomplete.docs.mdx'
 import { error_filled, thumbs_up, warning_filled } from '@equinor/eds-icons'
+
+const FormError = ({
+  id,
+  children,
+}: {
+  id: string
+  children: React.ReactNode
+}) => (
+  <span
+    role="alert"
+    id={id}
+    style={{
+      color: 'red',
+      paddingTop: '0.5rem',
+      fontSize: '0.75rem',
+      display: 'block',
+    }}
+  >
+    {children}
+  </span>
+)
 
 const meta: Meta<typeof Autocomplete> = {
   title: 'Inputs/Autocomplete',
@@ -854,21 +874,11 @@ export const WithReactHookForm: StoryFn<
                 />
               )}
             />
-            <span
-              role="alert"
-              id="error-county-required"
-              style={{
-                color: 'red',
-                paddingTop: '0.5rem',
-                fontSize: '0.75rem',
-                display:
-                  errors.origin && errors.origin.type === 'required'
-                    ? 'block'
-                    : 'none',
-              }}
-            >
-              Hey you! This field is required
-            </span>
+            {errors.origin && errors.origin.type === 'required' && (
+              <FormError id="error-county-required">
+                This field is required
+              </FormError>
+            )}
           </div>
           <div style={{ margin: '16px 0' }}>
             <Controller
@@ -889,19 +899,14 @@ export const WithReactHookForm: StoryFn<
                 />
               )}
             />
+            {errors.favouriteCounty &&
+              errors.favouriteCounty.type === 'required' && (
+                <FormError id="error-county-required">
+                  This field is required
+                </FormError>
+              )}
           </div>
           <div style={{ margin: '16px 0' }}>
-            <Controller
-              control={control}
-              name="test"
-              rules={{ required: true }}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  label="Pick atleast two fruits (optional)"
-                />
-              )}
-            />
             <Controller
               control={control}
               name="fruits"
@@ -911,7 +916,7 @@ export const WithReactHookForm: StoryFn<
                     onChange(selectedItems)
                   }}
                   selectedOptions={values.fruits}
-                  label="Pick atleast two fruits (optional)"
+                  label="Pick at least two fruits"
                   options={[
                     { label: 'Banana', emoji: '🍌' },
                     { label: 'Apple', emoji: '🍎' },

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -212,7 +212,6 @@ export const ControlledSingleSelect: StoryFn<
   const [selectedOptions, setSelectedOptions] = useState([])
   const options = ['option 1', 'option 2', 'option 3', 'option 4']
   const ref2 = useRef<HTMLInputElement>(null)
-  console.log(ref2, 'component')
   const isOptionDisabled = (item: string) => item === 'option 3'
   return (
     <div>

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -14,6 +14,7 @@ import {
   Card,
   Avatar,
   Icon,
+  TextField,
 } from '../..'
 import { Stack } from '../../../.storybook/components'
 import page from './Autocomplete.docs.mdx'
@@ -163,7 +164,7 @@ Introduction.args = {
 
 export const Multiple: StoryFn<AutocompleteProps<MyOptionType>> = (args) => {
   const { options } = args
-
+  const [value, setValue] = useState<MyOptionType | null>(null)
   return (
     <>
       <Autocomplete
@@ -171,6 +172,12 @@ export const Multiple: StoryFn<AutocompleteProps<MyOptionType>> = (args) => {
         options={options}
         multiple
         optionLabel={optionLabel}
+        selectedOptions={[value]}
+        onOptionsChange={({ selectedItems }) => {
+          const selectedItem = selectedItems[0]
+          if (!selectedItem?.label) return setValue(null)
+          setValue(selectedItem)
+        }}
       />
     </>
   )
@@ -184,6 +191,8 @@ export const ControlledSingleSelect: StoryFn<
 > = () => {
   const [selectedOptions, setSelectedOptions] = useState([])
   const options = ['option 1', 'option 2', 'option 3', 'option 4']
+  const ref2 = useRef<HTMLInputElement>(null)
+  console.log(ref2, 'component')
   const isOptionDisabled = (item: string) => item === 'option 3'
   return (
     <div>
@@ -195,6 +204,7 @@ export const ControlledSingleSelect: StoryFn<
           setSelectedOptions(options)
         }
         optionDisabled={isOptionDisabled}
+        ref={ref2}
       />
       <Button
         onClick={() => {
@@ -760,6 +770,7 @@ type MyFormValues = {
   origin: string | null
   favouriteCounty: string | null
   fruits: { label: string; emoji: string }[]
+  test: string | null
 }
 
 export const WithReactHookForm: StoryFn<
@@ -769,6 +780,7 @@ export const WithReactHookForm: StoryFn<
     origin: null,
     favouriteCounty: null,
     fruits: [],
+    test: null,
   }
   const {
     handleSubmit,
@@ -791,6 +803,7 @@ export const WithReactHookForm: StoryFn<
         updateIsSubmitted(true)
         action('onSubmit')(data)
       })}
+      style={{ maxHeight: '40px' }}
     >
       {isSubmitted ? (
         <>
@@ -812,12 +825,18 @@ export const WithReactHookForm: StoryFn<
         </>
       ) : (
         <>
+          <div style={{ display: 'flex', gap: '16px' }}>
+            <Button type="submit">I have made my decisions!</Button>
+            <Button variant="outlined" onClick={() => reset()}>
+              Reset
+            </Button>
+          </div>
           <div style={{ margin: '16px 0' }}>
             <Controller
               control={control}
               name="origin"
               rules={{ required: true }}
-              render={({ field: { onChange } }) => (
+              render={({ field: { onChange, ref } }) => (
                 <Autocomplete
                   onOptionsChange={({ selectedItems }) => {
                     console.log('selected origin', selectedItems)
@@ -826,6 +845,7 @@ export const WithReactHookForm: StoryFn<
                   }}
                   selectedOptions={[values.origin]}
                   label="Where are you from?"
+                  ref={ref}
                   options={counties}
                   aria-invalid={errors.origin ? 'true' : 'false'}
                   aria-describedby="error-county-required"
@@ -854,8 +874,10 @@ export const WithReactHookForm: StoryFn<
             <Controller
               control={control}
               name="favouriteCounty"
-              render={({ field: { onChange } }) => (
+              rules={{ required: true }}
+              render={({ field: { onChange, ref } }) => (
                 <Autocomplete
+                  ref={ref}
                   onOptionsChange={({ selectedItems }) => {
                     const [selectedItem] = selectedItems
                     onChange(selectedItem)
@@ -869,6 +891,17 @@ export const WithReactHookForm: StoryFn<
             />
           </div>
           <div style={{ margin: '16px 0' }}>
+            <Controller
+              control={control}
+              name="test"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="Pick atleast two fruits (optional)"
+                />
+              )}
+            />
             <Controller
               control={control}
               name="fruits"
@@ -892,12 +925,6 @@ export const WithReactHookForm: StoryFn<
                 />
               )}
             />
-          </div>
-          <div style={{ display: 'flex', gap: '16px' }}>
-            <Button type="submit">I have made my decisions!</Button>
-            <Button variant="outlined" onClick={() => reset()}>
-              Reset
-            </Button>
           </div>
         </>
       )}

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import { Autocomplete, AutocompleteProps, AutocompleteChanges } from '.'
 import { Checkbox } from '../Checkbox'
-import { TextField } from '../TextField'
 import { StoryFn, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { useForm, Controller } from 'react-hook-form'
@@ -185,7 +184,6 @@ Introduction.args = {
 
 export const Multiple: StoryFn<AutocompleteProps<MyOptionType>> = (args) => {
   const { options } = args
-  const [value, setValue] = useState<MyOptionType | null>(null)
   return (
     <>
       <Autocomplete
@@ -193,12 +191,6 @@ export const Multiple: StoryFn<AutocompleteProps<MyOptionType>> = (args) => {
         options={options}
         multiple
         optionLabel={optionLabel}
-        selectedOptions={[value]}
-        onOptionsChange={({ selectedItems }) => {
-          const selectedItem = selectedItems[0]
-          if (!selectedItem?.label) return setValue(null)
-          setValue(selectedItem)
-        }}
       />
     </>
   )
@@ -212,7 +204,6 @@ export const ControlledSingleSelect: StoryFn<
 > = () => {
   const [selectedOptions, setSelectedOptions] = useState([])
   const options = ['option 1', 'option 2', 'option 3', 'option 4']
-  const ref2 = useRef<HTMLInputElement>(null)
   const isOptionDisabled = (item: string) => item === 'option 3'
   return (
     <div>
@@ -224,7 +215,6 @@ export const ControlledSingleSelect: StoryFn<
           setSelectedOptions(options)
         }
         optionDisabled={isOptionDisabled}
-        ref={ref2}
       />
       <Button
         onClick={() => {
@@ -845,32 +835,6 @@ export const WithReactHookForm: StoryFn<
         </>
       ) : (
         <>
-          <div style={{ display: 'flex', gap: '16px' }}>
-            <Button type="submit">I have made my decisions!</Button>
-            <Button variant="outlined" onClick={() => reset()}>
-              Reset
-            </Button>
-          </div>
-          <div style={{ margin: '16px 0' }}>
-            <Controller
-              control={control}
-              name="firstName"
-              rules={{ required: true }}
-              render={({ field: { onChange, ref } }) => (
-                <TextField
-                  label="First name"
-                  ref={ref}
-                  onChange={onChange}
-                  value={values.firstName}
-                />
-              )}
-            />
-            {errors.firstName && errors.firstName.type === 'required' && (
-              <FormError id="error-test-required">
-                This field is required
-              </FormError>
-            )}
-          </div>
           <div style={{ margin: '16px 0' }}>
             <Controller
               control={control}
@@ -950,6 +914,12 @@ export const WithReactHookForm: StoryFn<
                 />
               )}
             />
+          </div>
+          <div style={{ display: 'flex', gap: '16px' }}>
+            <Button type="submit">I have made my decisions!</Button>
+            <Button variant="outlined" onClick={() => reset()}>
+              Reset
+            </Button>
           </div>
         </>
       )}

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -11,6 +11,7 @@ import {
   SyntheticEvent,
   DOMAttributes,
   FocusEvent,
+  useImperativeHandle,
 } from 'react'
 import {
   useCombobox,
@@ -330,7 +331,7 @@ export type AutocompleteProps<T> = {
 // MARK: component
 function AutocompleteInner<T>(
   props: AutocompleteProps<T>,
-  ref: React.ForwardedRef<HTMLDivElement>,
+  ref: React.ForwardedRef<HTMLInputElement>,
 ) {
   const {
     options = [],
@@ -409,6 +410,7 @@ function AutocompleteInner<T>(
   const [_availableItems, setAvailableItems] = useState(inputOptions)
   const [typedInputValue, setTypedInputValue] = useState<string>('')
   const inputRef = useRef<HTMLInputElement>(null)
+  useImperativeHandle(ref, () => inputRef.current)
 
   const showSelectAll = useMemo(() => {
     if (!multiple && allowSelectAll) {
@@ -1028,7 +1030,7 @@ function AutocompleteInner<T>(
   // MARK: input
   return (
     <ThemeProvider theme={token}>
-      <Container className={className} style={style} ref={ref}>
+      <Container className={className} style={style}>
         <Label
           {...getLabelProps()}
           label={label}
@@ -1093,7 +1095,7 @@ function AutocompleteInner<T>(
 // MARK: exported component
 export const Autocomplete = forwardRef(AutocompleteInner) as <T>(
   props: AutocompleteProps<T> & {
-    ref?: React.ForwardedRef<HTMLDivElement>
+    ref?: React.ForwardedRef<HTMLInputElement>
     /** @ignore */
     displayName?: string | undefined
   },

--- a/packages/eds-core-react/src/components/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/TextField/TextField.tsx
@@ -58,7 +58,7 @@ export type TextFieldProps = SharedTextFieldProps &
     | InputHTMLAttributes<HTMLInputElement>
   )
 
-export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   function TextField(
     {
       id: _id,
@@ -97,7 +97,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
         </>
       ),
       rowsMax,
-      ref: inputRef || textareaRef,
+      ref: ref || inputRef || textareaRef,
       $multiline: multiline,
       ...other,
     }
@@ -110,7 +110,6 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     }
 
     const containerProps = {
-      ref,
       className,
       style: {
         width: '100%',


### PR DESCRIPTION
## Summary

This pull request addresses an issue with integrating the `Autocomplete` and `TextField` components with `react-hook-form`.

## Problem

When using these components, `react-hook-form`'s scroll-to-error functionality does not behave correctly. This is because `react-hook-form` expects refs to be attached directly to the underlying `<input>` elements. In the current implementation, the refs are attached to container elements instead, which breaks this behavior.

## Solution

Refs are now correctly forwarded to the input elements themselves. This ensures that `react-hook-form` can properly detect and scroll to fields with validation errors.

## Additional Notes

A quick demo has been added to the `Autocomplete` + `react-hook-form` story to help you test and verify the fix.
