### PR TITLE
fix(eds-core-react): allow button to become disabled when the as prop is used

### DIFF
--- a/packages/eds-core-react/src/components/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.tsx
@@ -138,6 +138,25 @@ const ButtonBase = styled.button(({ theme }: { theme: ButtonToken }) => {
   `
 })
 
+const getElementType = (
+  disabled: boolean,
+  customType?: React.ElementType,
+  href?: string,
+): React.ElementType => {
+  if (disabled) return 'button'
+  if (customType) return customType
+  if (href) return 'a'
+  return 'button'
+}
+
+const getButtonType = (
+  href?: string,
+  customElementType?: React.ElementType,
+): string | undefined => {
+  if (href || customElementType) return undefined
+  return 'button'
+}
+
 export type ButtonProps = {
   /**  Specifies color */
   color?: Colors
@@ -174,13 +193,8 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
   ) {
     const { density } = useEds()
     const token = useToken({ density }, getToken(variant, color))
-
-    let as: React.ElementType = 'button'
-    if (href) as = 'a'
-    if (other.as) as = other.as
-    if (disabled) as = 'button'
-
-    const type = href || other.as ? undefined : 'button'
+    const as = getElementType(disabled, other.as, href)
+    const type = getButtonType(href, other.as)
 
     tabIndex = disabled ? -1 : tabIndex
 

--- a/packages/eds-core-react/src/components/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/Button/Button.tsx
@@ -175,7 +175,10 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
     const { density } = useEds()
     const token = useToken({ density }, getToken(variant, color))
 
-    const as = href && !disabled ? 'a' : other.as ? other.as : 'button'
+    let as: React.ElementType = 'button'
+    if (href) as = 'a'
+    if (other.as) as = other.as
+    if (disabled) as = 'button'
 
     const type = href || other.as ? undefined : 'button'
 
@@ -183,22 +186,20 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
 
     const buttonProps = {
       ref,
-      as,
       href,
       type,
       disabled,
       tabIndex,
       ...other,
+      as,
     }
+
+    const Container = fullWidth ? InnerFullWidth : Inner
 
     return (
       <ThemeProvider theme={token}>
         <ButtonBase {...buttonProps}>
-          {fullWidth ? (
-            <InnerFullWidth>{children}</InnerFullWidth>
-          ) : (
-            <Inner>{children}</Inner>
-          )}
+          <Container>{children}</Container>
         </ButtonBase>
       </ThemeProvider>
     )


### PR DESCRIPTION
#### Summary
This pr make it so that when a `<Button />` is disabled, it always renders as a native `<button>`, even if it's using a link component like `react-router-dom`'s `<Link>` or `next/link`.

#### Why this matters
- Most navigation in modern apps uses internal links (`<Link>`) instead of standard `<a>` tags.
- Previously, a `<Button as={Link} disabled />` would still render as a clickable link, which isn’t actually disableable.
- This change ensures disabled buttons behave consistently and aren’t interactive, regardless of how routing is handled.

#### Benefit
Helps developers build more accessible apps by ensuring links remain links and disabled buttons behave correctly—no need for workarounds like `useNavigate`.
