### PR TITLE
fix: removes 'item is:' console log from autocomplete

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -383,7 +383,6 @@ function AutocompleteInner<T>(
 
   const itemToKey = useCallback(
     (item: T) => {
-      console.log(`item is`, item)
       return _itemToKey ? _itemToKey(item) : item
     },
     [_itemToKey],


### PR DESCRIPTION
This pr removes the "item is: " console.log from autocomplete as it is causing a lot of logging in out applications
![image](https://github.com/user-attachments/assets/3b141792-6275-419d-af60-d153c9b43edd)
