### PR TITLE
fix(eds-core-react): improvements to autocomplete placeholder text

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -235,6 +235,8 @@ export type AutocompleteChanges<T> = { selectedItems: T[] }
 export type AutocompleteProps<T> = {
   /** List of options in dropdown */
   options: readonly T[]
+  /** Total number of options */
+  totalOptions?: number
   /** Label for the select element */
   label: ReactNode
   /** Array of initial selected items
@@ -335,6 +337,7 @@ function AutocompleteInner<T>(
 ) {
   const {
     options = [],
+    totalOptions,
     label,
     meta,
     className,
@@ -740,10 +743,12 @@ function AutocompleteInner<T>(
   }
   // MARK: multiselect specific
   if (multiple) {
-    placeholderText =
-      typeof placeholderText !== 'undefined'
-        ? placeholderText
-        : `${selectedItems.length}/${inputOptions.length} selected`
+    const showPlaceholder = placeholderText && selectedItems.length === 0
+    const optionCount = totalOptions || inputOptions.length
+    placeholderText = showPlaceholder
+      ? placeholderText
+      : `${selectedItems.length}/${optionCount} selected`
+
     comboBoxProps = {
       ...comboBoxProps,
       selectedItem: null,


### PR DESCRIPTION
## Improvements to Autocomplete Component with Multi-Select

This PR introduces two enhancements to the autocomplete component when used in multi-select mode:

### 1. Placeholder Display Logic
Previously, the placeholder text would remain visible even after the user selected one or more options. In some cases, this could make it unclear whether any items had been selected.  

**Update:** The placeholder is now only shown when no items are selected. Once selections are made, the display changes to `x/y selected`, which can help clarify the selection state.

### 2. Support for Paginated API Results
Autocomplete options are often fetched from APIs that return paginated results. For instance, a page might return 50 results, while the actual number of available options could be much higher. Showing `x/50 selected` might give the impression that only 50 options exist.  

**Update:** A new prop, `totalOptions`, has been added. This allows developers to specify the total number of available options (commonly returned as `totalItems` from the API). When provided, this value replaces the default count in the `x/y selected` label, offering a more complete view of the available data.
