### PR TITLE
fix: 👷 Add missing checkout step to packages job

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
@@ -37,7 +39,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - name: Install dependencies
         run: pnpm install
       - name: Use "setup" cache
@@ -50,16 +52,16 @@ jobs:
           key: ${{ github.sha }}
       - name: Build packages
         id: build-packages
-        run: node_modules/.bin/pnpm run build
+        run: pnpm run build
       - name: Test packages
         id: test-packages
-        run: node_modules/.bin/pnpm run test
+        run: pnpm run test
       - name: Lint packages
         id: lint-packages
-        run: node_modules/.bin/pnpm run lint:all
+        run: pnpm run lint:all
       - name: Type check packages
         id: type-check-packages
-        run: node_modules/.bin/pnpm run types
+        run: pnpm run types
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:


### PR DESCRIPTION
The packages job was failing because it tried to run pnpm commands without first checking out the repository code. This worked previously but broke when triggered directly on develop branch.  (Guilty 😅 ) 
- Add checkout step before cache restore 
- Update pnpm version to 9 
- Remove unnecessary node_modules/.bin/ prefix from pnpm commands