### PR TITLE
ci(eds-core-react): 💚 Purge correct CDN endpoint after storybook deployment

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -150,3 +150,4 @@ jobs:
     secrets: inherit
     with:
       environment: production
+      endpoint: storybook


### PR DESCRIPTION
Resolves #3818 

## Problem
Storybook changes were taking days to appear after deployment due to incorrect CDN purging (it was only purging artefacts as it was set to default).. 

## Root cause
The `purge-cdn` job was using the default `artefacts` endpoint instead of the `storybook` endpoint, so the storybook CDN cache was never cleared.

## Solution
- Add explicit `endpoint: storybook` parameter to `purge-cdn` job in the publish core-react workflow
- This ensures storybook CDN cache is purged immediately after deployment

This explains why storybook changes in previous releases took days to appear while npm package changes were immediate 