### PR TITLE
fix(eds-core-react): allow menu to close without item onclick

### DIFF
--- a/packages/eds-core-react/src/components/Menu/MenuItem.tsx
+++ b/packages/eds-core-react/src/components/Menu/MenuItem.tsx
@@ -166,9 +166,9 @@ export const MenuItem: OverridableSubComponent = forwardRef<
       onClick={(e: MouseEvent<Element, globalThis.MouseEvent>) => {
         if (onClick) {
           onClick(e)
-          if (onClose !== null && closeMenuOnClick) {
-            onClose(e)
-          }
+        }
+        if (onClose !== null && closeMenuOnClick) {
+          onClose(e)
         }
       }}
     >


### PR DESCRIPTION
This PR fixes an issue where `MenuItem` components without an `onClick` handler don’t trigger `onClose`, which causes the menu to stay open. This is problematic when using `as={Link}` for accessibility.

example:
```jsx
<Menu anchorEl={anchorEl} open={isOpen} onClose={() => setIsOpen(false)}>
  <Menu.Item as={Link} to={`/new-project`}>
    Create well project
  </Menu.Item>
  <Menu.Item as={Link} to={`/new-maintenance-project`}>
    Create maintenance project
  </Menu.Item>
</Menu>
```

This PR ensures `onClose` is called even if `onClick` is not defined.
This could also be fixed locally in the project by just passing an empty function `() => {}` to the onClick, but that does seem a little hacky
