### PR TITLE
Add support for adding new options in Autocomplete

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/AddNewOption.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/AddNewOption.tsx
@@ -1,0 +1,51 @@
+import { add_box } from '@equinor/eds-icons'
+import { tokens } from '@equinor/eds-tokens'
+import { forwardRef, LiHTMLAttributes } from 'react'
+import styled, { css } from 'styled-components'
+import { Icon } from '../Icon'
+import { AutocompleteOptionLabel, StyledListItem } from './Option'
+
+const StyledAddItemIcon = styled(Icon)<{ multiple: boolean }>(({
+  multiple,
+}) => {
+  return css`
+    padding: ${multiple ? '0.75rem' : '0 0.75rem 0 0'};
+    color: ${tokens.colors.interactive.primary__resting.hex};
+  `
+})
+
+export type AutocompleteOptionProps = {
+  value: string
+  multiple: boolean
+  highlighted: string
+  multiline: boolean
+} & LiHTMLAttributes<HTMLLIElement>
+
+function AddNewOptionInner(
+  props: AutocompleteOptionProps,
+  ref: React.ForwardedRef<HTMLLIElement>,
+) {
+  const { value, multiline, multiple, highlighted, onClick, ...other } = props
+  return (
+    <StyledListItem
+      ref={ref}
+      $highlighted={highlighted}
+      onClick={(e) => {
+        onClick(e)
+      }}
+      {...other}
+    >
+      <StyledAddItemIcon multiple={multiple} data={add_box} />
+      <AutocompleteOptionLabel $multiline={multiline}>
+        {value}
+      </AutocompleteOptionLabel>
+    </StyledListItem>
+  )
+}
+
+export const AddNewOption = forwardRef(AddNewOptionInner) as (
+  props: AutocompleteOptionProps & {
+    ref?: React.ForwardedRef<HTMLLIElement>
+    displayName?: string | undefined
+  },
+) => ReturnType<typeof AddNewOptionInner>

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
@@ -209,6 +209,40 @@ describe('Autocomplete', () => {
     })
   })
 
+  it('Can add new options', async () => {
+    const onChange = jest.fn()
+    const onAddNewOption = jest.fn()
+    render(
+      <StyledAutocomplete
+        label={labelText}
+        options={items}
+        data-testid="styled-autocomplete"
+        onOptionsChange={onChange}
+        onAddNewOption={onAddNewOption}
+      />,
+    )
+
+    const labeledNodes = await screen.findAllByLabelText(labelText)
+    const input = labeledNodes[0]
+    const optionsList = labeledNodes[1]
+
+    const buttonNode = await screen.findByLabelText('toggle options', {
+      selector: 'button',
+    })
+
+    fireEvent.click(buttonNode)
+    fireEvent.change(input, {
+      target: { value: 'New option' },
+    })
+
+    const options = await within(optionsList).findAllByRole('option')
+    fireEvent.click(options[0])
+
+    await waitFor(() => {
+      expect(onAddNewOption).toHaveBeenNthCalledWith(1, 'New option')
+    })
+  })
+
   it('Can deselect complex options', async () => {
     const onChange = jest.fn()
     const opts = [

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -52,12 +52,15 @@ import {
   MiddlewareState,
 } from '@floating-ui/react'
 import { Variants } from '../types'
+import { AddNewOption } from './AddNewOption'
 
 const Container = styled.div`
   position: relative;
 `
 
 const AllSymbol = Symbol('Select all')
+const AddSymbol = Symbol('Add new')
+
 // MARK: styled components
 const StyledList = styled(List)(
   ({ theme }) => css`
@@ -284,6 +287,8 @@ export type AutocompleteProps<T> = {
    * Returns input value
    */
   onInputChange?: (text: string) => void
+  /** Callback for clicking the add new option button */
+  onAddNewOption?: (text: string) => void
   /** Enable multiselect */
   multiple?: boolean
   /** Add select-all option. Throws an error if true while multiple = false */
@@ -347,6 +352,7 @@ function AutocompleteInner<T>(
     loading = false,
     hideClearButton = false,
     onOptionsChange,
+    onAddNewOption,
     onInputChange,
     selectedOptions: _selectedOptions,
     multiple,
@@ -423,8 +429,9 @@ function AutocompleteInner<T>(
 
   const availableItems = useMemo(() => {
     if (showSelectAll) return [AllSymbol as T, ..._availableItems]
+    if (_availableItems.length === 0 && onAddNewOption) return [AddSymbol as T]
     return _availableItems
-  }, [_availableItems, showSelectAll])
+  }, [_availableItems, showSelectAll, onAddNewOption])
 
   //issue 2304, update dataset when options are added dynamically
   useEffect(() => {
@@ -463,7 +470,7 @@ function AutocompleteInner<T>(
       onSelectedItemsChange: (changes) => {
         if (onOptionsChange) {
           let selectedItems = changes.selectedItems.filter(
-            (item) => item !== AllSymbol,
+            (item) => item !== AllSymbol || item !== AddSymbol,
           )
           if (itemCompare) {
             selectedItems = inputOptions.filter((item) =>
@@ -637,6 +644,8 @@ function AutocompleteInner<T>(
           if (selectedItem != null && !optionDisabled(selectedItem)) {
             if (selectedItem === AllSymbol) {
               toggleAllSelected()
+            } else if (selectedItem === AddSymbol) {
+              onAddNewOption?.(typedInputValue)
             } else if (multiple) {
               const shouldRemove = itemCompare
                 ? selectedItems.some((i) => itemCompare(selectedItem, i))
@@ -682,12 +691,30 @@ function AutocompleteInner<T>(
               ...changes,
               isOpen: !(disabled || readOnly),
             }
+          case useCombobox.stateChangeTypes.InputKeyDownEnter:
+          case useCombobox.stateChangeTypes.ItemClick:
+            if (changes.selectedItem === AddSymbol) {
+              onAddNewOption(typedInputValue)
+              return {
+                ...changes,
+                inputValue: '',
+                selectedItem: null,
+              }
+            }
+            return {
+              ...changes,
+            }
           case useCombobox.stateChangeTypes.InputBlur:
             return {
               ...changes,
               inputValue: changes.selectedItem
                 ? getLabel(changes.selectedItem)
                 : '',
+            }
+          case useCombobox.stateChangeTypes.InputChange:
+            setTypedInputValue(changes.inputValue)
+            return {
+              ...changes,
             }
           case useCombobox.stateChangeTypes.InputKeyDownArrowDown:
           case useCombobox.stateChangeTypes.InputKeyDownHome:
@@ -984,6 +1011,36 @@ function AutocompleteInner<T>(
                       item,
                       index: index,
                     })}
+                  />
+                )
+              }
+              if (item === AddSymbol && onAddNewOption) {
+                return (
+                  <AddNewOption
+                    key={'add-item'}
+                    data-index={0}
+                    data-testid={'add-item'}
+                    aria-setsize={availableItems.length}
+                    multiple={multiple}
+                    highlighted={
+                      highlightedIndex === index && !isDisabled
+                        ? 'true'
+                        : 'false'
+                    }
+                    multiline={multiline}
+                    style={{
+                      position: 'sticky',
+                      top: 0,
+                      zIndex: 99,
+                    }}
+                    {...getItemProps({
+                      ...(multiline && {
+                        ref: rowVirtualizer.measureElement,
+                      }),
+                      item,
+                      index: index,
+                    })}
+                    value={`${typedInputValue}`}
                   />
                 )
               }

--- a/packages/eds-core-react/src/components/Autocomplete/Option.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Option.tsx
@@ -9,7 +9,7 @@ type StyledListItemType = {
   $isdisabled?: string
 }
 
-const StyledListItem = styled.li<StyledListItemType>(
+export const StyledListItem = styled.li<StyledListItemType>(
   ({ theme, $highlighted, $active, $isdisabled }) => {
     const backgroundColor =
       $highlighted === 'true'


### PR DESCRIPTION
This PR introduces a new feature for the Autocomplete component, enabling users to add custom, non-predefined items to the selection. This is particularly useful for use cases like "tagging," where users need to select from a predefined list but also have the flexibility to create and add new tags on the fly.

**Key Changes:**

*   **`onAddNewItem` Callback:** A new prop, `onAddNewItem: (inputValue: string) => void`, has been added to the Autocomplete component. This callback is invoked with the current `inputValue` of the autocomplete when the "Add" option is selected.
*   **"Add" Option Visibility:**
    *   Currently, the "Add" option appears only when there are no matching predefined options for the user's current search input.
    *   This behavior can be easily adjusted to always show the "Add" option (when `onAddNewItem` is provided) by modifying the condition on line 432 within the Autocomplete component.

When the "Add" option is clicked, only the `onAddNewItem` callback is called. Adding the new item to the autocomplete's options or selected items is the responsibility of the user. This is because the Autocomplete can accept a list of object with any shape.