### PR TITLE
fix: Disable back button in year range based on year, not month

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
@@ -76,6 +76,7 @@ export const Calendar = forwardRef(
               nextMonthDisabled={nextButtonProps.isDisabled}
               setShowYearPicker={setShowYearPicker}
               showYearPicker={showYearPicker}
+              yearPickerPage={yearPickerPage}
               setYearPickerPage={setYearPickerPage}
             />
           )}

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -11,6 +11,7 @@ import {
 import { CalendarDate } from '@internationalized/date'
 import { tokens } from '@equinor/eds-tokens'
 import { Dispatch, SetStateAction } from 'react'
+import { getPageYears } from '../utils/getPageYears'
 
 const HeaderWrapper = styled.div`
   display: flex;
@@ -65,6 +66,7 @@ export function CalendarHeader({
   showYearPicker,
   setShowYearPicker,
   setYearPickerPage,
+  yearPickerPage,
 }: {
   state: CalendarState | RangeCalendarState
   title: string
@@ -73,14 +75,26 @@ export function CalendarHeader({
   showYearPicker: boolean
   setShowYearPicker: (showYearPicker: boolean) => void
   setYearPickerPage?: Dispatch<SetStateAction<number>>
+  yearPickerPage: number
 }) {
+  const years = getPageYears(state.focusedDate.year, yearPickerPage)
+  const backButtonDisabled =
+    showYearPicker && state.minValue
+      ? years[0] < state.minValue.year
+      : previousMonthDisabled
+
+  const nextButtonDisabled =
+    showYearPicker && state.maxValue
+      ? years[years.length - 1] > state.maxValue.year
+      : nextMonthDisabled
+
   return (
     <HeaderWrapper>
       <HeaderActions>
         <Button
           variant={'ghost_icon'}
           aria-label={'Previous month'}
-          disabled={previousMonthDisabled}
+          disabled={backButtonDisabled}
           onClick={() =>
             showYearPicker
               ? setYearPickerPage((page) => page - 1)
@@ -115,7 +129,7 @@ export function CalendarHeader({
               ? setYearPickerPage((page) => page + 1)
               : state.focusNextPage()
           }
-          disabled={nextMonthDisabled}
+          disabled={nextButtonDisabled}
           aria-label={'Next month'}
         >
           <Icon data={chevron_right} />

--- a/packages/eds-core-react/src/components/Datepicker/calendars/RangeCalendar.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/RangeCalendar.tsx
@@ -67,6 +67,7 @@ export const RangeCalendar = forwardRef(
               setShowYearPicker={setShowYearPicker}
               showYearPicker={showYearPicker}
               setYearPickerPage={setYearPickerPage}
+              yearPickerPage={yearPickerPage}
             />
           )}
         </Popover.Header>

--- a/packages/eds-core-react/src/components/Datepicker/calendars/YearGrid.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/YearGrid.tsx
@@ -10,6 +10,7 @@ import {
   useEffect,
   useRef,
 } from 'react'
+import { getPageYears } from '../utils/getPageYears'
 
 const Grid = styled.div`
   display: grid;
@@ -44,9 +45,6 @@ const GridColumn = styled.button<{ $active: boolean }>`
   }
 `
 
-const TOTAL_VISIBLE_YEARS = 36
-const RANGE_OFFSET = 30 / 2
-
 const GridFocusManager = ({
   year: selectedYear,
   setFocusedYear,
@@ -63,12 +61,7 @@ const GridFocusManager = ({
   const prevYear = useRef<number | undefined>()
   const navByKeyboard = useRef<boolean>(false)
 
-  const page = yearPickerPage * TOTAL_VISIBLE_YEARS
-
-  const years = Array.from(
-    { length: TOTAL_VISIBLE_YEARS },
-    (_, i) => i + (selectedYear + page - RANGE_OFFSET),
-  )
+  const years = getPageYears(selectedYear, yearPickerPage)
 
   useEffect(() => {
     if (prevYear.current === undefined) {

--- a/packages/eds-core-react/src/components/Datepicker/utils/getPageYears.ts
+++ b/packages/eds-core-react/src/components/Datepicker/utils/getPageYears.ts
@@ -1,0 +1,11 @@
+const TOTAL_VISIBLE_YEARS = 36
+const RANGE_OFFSET = 30 / 2
+
+export const getPageYears = (selectedYear: number, yearPickerPage = 0) => {
+  const page = yearPickerPage * TOTAL_VISIBLE_YEARS
+
+  return Array.from(
+    { length: TOTAL_VISIBLE_YEARS },
+    (_, i) => i + (selectedYear + page - RANGE_OFFSET),
+  )
+}


### PR DESCRIPTION
This PR resolves an issue in the `DatePicker` where the **back/next buttons** was incorrectly disabled when `min`/`max` values were set.

The disabled state was previously based only on the currently selected **date**, which caused problems in **year selection mode**. Specifically, if the back/next button was disabled and the user navigated to a different years page, they could no longer go back to the previous/next page.

Fixes #3843

Before:
![Peek 2025-06-18 13-14](https://github.com/user-attachments/assets/0978c93c-3041-49c9-aaba-02baa4c2b95f)

Now: 
![Peek 2025-06-18 13-13](https://github.com/user-attachments/assets/4622765d-428a-424a-acab-9548c1aadaa8)
