### PR TITLE
feat(eds-data-grid-react): ✨ New `ClickableCell` component

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Card,
   Checkbox,
   Divider,
   EdsProvider,
@@ -40,6 +41,7 @@ import {
 import { data, summaryData } from './stories/data'
 import { Virtualizer } from './types'
 import { external_link } from '@equinor/eds-icons'
+import { ClickableCell } from './components/ClickableCell'
 
 const meta: Meta<typeof EdsDataGrid<Photo>> = {
   title: 'EDS Data grid',
@@ -298,6 +300,128 @@ export const RowSelection: StoryFn<EdsDataGridProps<Photo>> = (args) => {
 RowSelection.args = {
   columnResizeMode: 'onChange',
 } satisfies Partial<EdsDataGridProps<Photo>>
+
+export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
+  const [clickedCell, setClickedCell] = useState<string | null>(null)
+
+  const clickableColumns = [
+    helper.accessor('id', {
+      header: 'ID',
+      cell: ({ getValue }) => (
+        <ClickableCell
+          onClick={() => setClickedCell(`ID: ${getValue()}`)}
+          ariaLabel={`View details for ID ${getValue()}`}
+        >
+          {getValue()}
+        </ClickableCell>
+      ),
+      id: 'id',
+      size: 100,
+    }),
+    helper.accessor('title', {
+      header: 'Title',
+      cell: ({ getValue }) => (
+        <ClickableCell
+          onClick={() => setClickedCell(`Title: ${getValue()}`)}
+          ariaLabel={`Open ${getValue()}`}
+          // variant="subtle"
+        >
+          {getValue()}
+        </ClickableCell>
+      ),
+      id: 'title',
+      size: 300,
+    }),
+    helper.accessor('url', {
+      header: 'URL',
+      cell: ({ getValue }) => (
+        <ClickableCell
+          onClick={() => window.open(getValue(), '_blank')}
+          ariaLabel={`Open link ${getValue()}`}
+          // variant="ghost"
+        >
+          Open Link
+        </ClickableCell>
+      ),
+      id: 'url',
+      size: 150,
+    }),
+    // Regular columns
+    ...columns.slice(2, 4),
+  ]
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Card style={{ padding: '16px', backgroundColor: '#f8f9fa' }}>
+        <Typography variant="h6">🖱️ Clickable Cells Demo</Typography>
+        <Typography variant="body_short">
+          Click cells in the first three columns to see different interaction
+          patterns. Each variant shows different hover and focus behaviors.
+        </Typography>
+      </Card>
+
+      {clickedCell && (
+        <Card style={{ padding: '16px', backgroundColor: '#e3f2fd' }}>
+          <Typography variant="body_short">
+            <strong>Last clicked:</strong> {clickedCell}
+          </Typography>
+          <Button
+            variant="ghost"
+            onClick={() => setClickedCell(null)}
+            style={{ marginTop: '8px' }}
+          >
+            Clear
+          </Button>
+        </Card>
+      )}
+
+      <EdsDataGrid {...args} columns={clickableColumns} />
+    </div>
+  )
+}
+
+ClickableCells.args = {
+  ...Introduction.args,
+}
+
+ClickableCells.parameters = {
+  docs: {
+    description: {
+      story: `
+This example demonstrates the \`ClickableCell\` component for creating accessible, interactive table cells.
+
+**Features:**
+- **Accessibility first**: Proper button semantics, keyboard navigation, screen reader support
+- **Visual variants**: \`default\`, \`subtle\`, and \`ghost\` for different interaction styles
+- **EDS design tokens**: Consistent with EDS theming and density modes
+- **Flexible styling**: Hover effects, focus states, and responsive design
+
+**Usage Pattern:**
+\`\`\`typescript
+{
+  cell: ({ getValue }) => (
+    <ClickableCell
+      onClick={() => doSomething()}
+      ariaLabel="Descriptive action label"
+      variant="default"
+    >
+      {getValue()}
+    </ClickableCell>
+  )
+}
+\`\`\`
+
+**When to use:**
+- Navigation to detail views
+- Quick actions (edit, copy, share)
+- External links
+- Modal triggers
+
+Always provide descriptive \`ariaLabel\` props for accessibility!
+      `,
+    },
+  },
+}
 
 const SimpleMenu = ({
   text,

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -308,45 +308,61 @@ const StoryWrapper = styled.div`
 `
 
 export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
-  const [clickedCell, setClickedCell] = useState<string | null>(null)
+  const [selectedCell, setSelectedCell] = useState<string | null>(null)
+
+  const handleCellClick = (cellId: string) => {
+    setSelectedCell((prev) => (prev === cellId ? null : cellId))
+  }
 
   const clickableColumns = [
     helper.accessor('id', {
       header: 'ID',
-      cell: ({ getValue }) => (
-        <ClickableCell
-          onClick={() => setClickedCell(`ID: ${getValue()}`)}
-          ariaLabel={`View details for ID ${getValue()}`}
-        >
-          {getValue()}
-        </ClickableCell>
-      ),
+      cell: ({ getValue }) => {
+        const cellId = `id-${getValue()}`
+        return (
+          <ClickableCell
+            onClick={() => handleCellClick(cellId)}
+            isSelected={selectedCell === cellId}
+            ariaLabel={`View details for ID ${getValue()}`}
+          >
+            {getValue()}
+          </ClickableCell>
+        )
+      },
       id: 'clickable_id',
       size: 100,
     }),
     helper.accessor('title', {
       header: 'Title',
-      cell: ({ getValue }) => (
-        <ClickableCell
-          onClick={() => setClickedCell(`Title: ${getValue()}`)}
-          ariaLabel={`Edit ${getValue()}`}
-        >
-          {getValue()}
-        </ClickableCell>
-      ),
+      cell: ({ getValue }) => {
+        const cellId = `title-${getValue()}`
+        return (
+          <ClickableCell
+            onClick={() => handleCellClick(cellId)}
+            isSelected={selectedCell === cellId}
+            ariaLabel={`Edit ${getValue()}`}
+          >
+            {getValue()}
+          </ClickableCell>
+        )
+      },
       id: 'clickable_title',
       size: 300,
     }),
     helper.accessor('albumId', {
       header: 'Actions',
-      cell: ({ row }) => (
-        <ClickableCell
-          onClick={() => setClickedCell(`Actions for row ${row.original.id}`)}
-          ariaLabel={`More actions for ${row.original.title}`}
-        >
-          ⚙️ Actions
-        </ClickableCell>
-      ),
+      cell: ({ row }) => {
+        const cellId = `actions-${row.original.id}`
+        return (
+          <ClickableCell
+            onClick={() => handleCellClick(cellId)}
+            isSelected={selectedCell === cellId}
+            ariaLabel={`More actions for ${row.original.title}`}
+          >
+            ⚙️ Actions
+          </ClickableCell>
+        )
+      },
       id: 'clickable_actions',
       size: 150,
     }),
@@ -373,12 +389,11 @@ export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
 
   return (
     <StoryWrapper>
-      <Typography>Click a cell to select and deselect.</Typography>
+      <Typography>
+        Click cells to select/deselect. Only one cell can be selected at a time.
+      </Typography>
       <Divider />
-      <pre>
-        clickedCell=
-        {JSON.stringify(clickedCell, null, 2)}
-      </pre>
+      <pre>Selected cell: {JSON.stringify(selectedCell, null, 2)}</pre>
       <EdsDataGrid {...args} columns={clickableColumns} cellStyle={cellStyle} />
     </StoryWrapper>
   )

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -42,6 +42,7 @@ import { data, summaryData } from './stories/data'
 import { Virtualizer } from './types'
 import { external_link } from '@equinor/eds-icons'
 import { ClickableCell } from './components/ClickableCell'
+import styled from 'styled-components'
 
 const meta: Meta<typeof EdsDataGrid<Photo>> = {
   title: 'EDS Data grid',
@@ -350,78 +351,45 @@ export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
     ...columns.slice(2, 4),
   ]
 
+  const cellStyle = (row: Row<Photo>, columnId: string): CSSProperties => {
+    // Removes padding for cells using ClickableCell
+    if (['id', 'title', 'url'].includes(columnId)) {
+      return { padding: 0 }
+    }
+    return {}
+  }
+
+  const StoryWrapper = styled.div`
+    tr:hover {
+      background-color: transparent !important;
+    }
+  `
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-      <Card style={{ padding: '16px', backgroundColor: '#f8f9fa' }}>
-        <Typography variant="h6">🖱️ Clickable Cells Demo</Typography>
-        <Typography variant="body_short">
-          Click cells in the first three columns to see different interaction
-          patterns. Each variant shows different hover and focus behaviors.
-        </Typography>
-      </Card>
-
-      {clickedCell && (
-        <Card style={{ padding: '16px', backgroundColor: '#e3f2fd' }}>
-          <Typography variant="body_short">
-            <strong>Last clicked:</strong> {clickedCell}
-          </Typography>
-          <Button
-            variant="ghost"
-            onClick={() => setClickedCell(null)}
-            style={{ marginTop: '8px' }}
-          >
-            Clear
-          </Button>
-        </Card>
-      )}
-
-      <EdsDataGrid {...args} columns={clickableColumns} />
-    </div>
+    <StoryWrapper>
+      <Typography>Click a cell to select and deselect.</Typography>
+      <Divider />
+      <pre>
+        clickedCell=
+        {JSON.stringify(clickedCell, null, 2)}
+      </pre>
+      <EdsDataGrid {...args} columns={clickableColumns} cellStyle={cellStyle} />
+    </StoryWrapper>
   )
 }
 
 ClickableCells.args = {
-  ...Introduction.args,
+  rows: data,
+  onRowClick: undefined,
 }
 
-ClickableCells.parameters = {
-  docs: {
-    description: {
-      story: `
-This example demonstrates the \`ClickableCell\` component for creating accessible, interactive table cells.
-
-**Features:**
-- **Accessibility first**: Proper button semantics, keyboard navigation, screen reader support
-- **Visual variants**: \`default\`, \`subtle\`, and \`ghost\` for different interaction styles
-- **EDS design tokens**: Consistent with EDS theming and density modes
-- **Flexible styling**: Hover effects, focus states, and responsive design
-
-**Usage Pattern:**
-\`\`\`typescript
-{
-  cell: ({ getValue }) => (
-    <ClickableCell
-      onClick={() => doSomething()}
-      ariaLabel="Descriptive action label"
-      variant="default"
-    >
-      {getValue()}
-    </ClickableCell>
-  )
-}
-\`\`\`
-
-**When to use:**
-- Navigation to detail views
-- Quick actions (edit, copy, share)
-- External links
-- Modal triggers
-
-Always provide descriptive \`ariaLabel\` props for accessibility!
-      `,
-    },
-  },
-}
+// ClickableCells.parameters = {
+//   docs: {
+//     description: {
+//       story: ,
+//     },
+//   },
+// }
 
 const SimpleMenu = ({
   text,

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Card,
   Checkbox,
   Divider,
   EdsProvider,
@@ -302,6 +301,12 @@ RowSelection.args = {
   columnResizeMode: 'onChange',
 } satisfies Partial<EdsDataGridProps<Photo>>
 
+const StoryWrapper = styled.div`
+  tr:hover {
+    background-color: transparent !important;
+  }
+`
+
 export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
   const [clickedCell, setClickedCell] = useState<string | null>(null)
 
@@ -316,7 +321,7 @@ export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
           {getValue()}
         </ClickableCell>
       ),
-      id: 'id',
+      id: 'clickable_id',
       size: 100,
     }),
     helper.accessor('title', {
@@ -324,46 +329,47 @@ export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
       cell: ({ getValue }) => (
         <ClickableCell
           onClick={() => setClickedCell(`Title: ${getValue()}`)}
-          ariaLabel={`Open ${getValue()}`}
-          // variant="subtle"
+          ariaLabel={`Edit ${getValue()}`}
         >
           {getValue()}
         </ClickableCell>
       ),
-      id: 'title',
+      id: 'clickable_title',
       size: 300,
     }),
-    helper.accessor('url', {
-      header: 'URL',
-      cell: ({ getValue }) => (
+    helper.accessor('albumId', {
+      header: 'Actions',
+      cell: ({ row }) => (
         <ClickableCell
-          onClick={() => window.open(getValue(), '_blank')}
-          ariaLabel={`Open link ${getValue()}`}
-          // variant="ghost"
+          onClick={() => setClickedCell(`Actions for row ${row.original.id}`)}
+          ariaLabel={`More actions for ${row.original.title}`}
         >
-          Open Link
+          ⚙️ Actions
         </ClickableCell>
       ),
-      id: 'url',
+      id: 'clickable_actions',
       size: 150,
     }),
-    // Regular columns
-    ...columns.slice(2, 4),
+    {
+      ...columns[2],
+      id: `regular_${columns[2].id}_${Date.now()}`,
+    },
+    {
+      ...columns[3],
+      id: `regular_${columns[3].id}_${Date.now() + 1}`,
+    },
   ]
 
   const cellStyle = (row: Row<Photo>, columnId: string): CSSProperties => {
-    // Removes padding for cells using ClickableCell
-    if (['id', 'title', 'url'].includes(columnId)) {
+    if (
+      ['clickable_id', 'clickable_title', 'clickable_actions'].includes(
+        columnId,
+      )
+    ) {
       return { padding: 0 }
     }
     return {}
   }
-
-  const StoryWrapper = styled.div`
-    tr:hover {
-      background-color: transparent !important;
-    }
-  `
 
   return (
     <StoryWrapper>
@@ -382,14 +388,6 @@ ClickableCells.args = {
   rows: data,
   onRowClick: undefined,
 }
-
-// ClickableCells.parameters = {
-//   docs: {
-//     description: {
-//       story: ,
-//     },
-//   },
-// }
 
 const SimpleMenu = ({
   text,

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -373,15 +373,11 @@ export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
     }),
     {
       ...columns[2],
-      id: `regular_${columns[2].id}_${Date.now()}`,
+      id: `regular_${columns[2].id}_2`,
     },
     {
       ...columns[3],
-      id: `regular_${columns[2].id}_static1`,
-    },
-    {
-      ...columns[3],
-      id: `regular_${columns[3].id}_static2`,
+      id: `regular_${columns[3].id}_3`,
     },
   ]
 

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -302,7 +302,12 @@ RowSelection.args = {
 } satisfies Partial<EdsDataGridProps<Photo>>
 
 const StoryWrapper = styled.div`
+  table {
+    /* Gives space for cell outline on all sides */
+    margin: 4px;
+  }
   tr:hover {
+    /* Disable default row hover to let ClickableCell handle its own hover styling */
     background-color: transparent !important;
   }
 `

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -377,7 +377,11 @@ export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
     },
     {
       ...columns[3],
-      id: `regular_${columns[3].id}_${Date.now() + 1}`,
+      id: `regular_${columns[2].id}_static1`,
+    },
+    {
+      ...columns[3],
+      id: `regular_${columns[3].id}_static2`,
     },
   ]
 

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -394,8 +394,19 @@ export const ClickableCells: StoryFn<EdsDataGridProps<Photo>> = (args) => {
 
   return (
     <StoryWrapper>
+      <Typography>Enables accessible interactive cells in DataGrid.</Typography>
+      <br />
       <Typography>
-        Click cells to select/deselect. Only one cell can be selected at a time.
+        <strong>Requirements:</strong> Use <code>padding: 0</code> in{' '}
+        <code>cellStyle</code> for clickable columns. Selection state must be
+        managed externally via <code>isSelected</code> prop and{' '}
+        <code>ariaLabel</code> is required for accessibility.
+      </Typography>
+      <br />
+      <Typography>
+        <strong>Try it:</strong> Click ID/Title/Actions cells to select. Use Tab
+        + Enter/Space for keyboard navigation. Row hover is disabled in this
+        demo to showcase cell-level hover states.
       </Typography>
       <Divider />
       <pre>Selected cell: {JSON.stringify(selectedCell, null, 2)}</pre>

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.test.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.test.tsx
@@ -94,17 +94,12 @@ describe('ClickableCell', () => {
       })
       const otherButton = screen.getByTestId('other')
 
-      // Click to select
       await user.click(clickableButton)
 
-      // Focus other element to trigger blur
       await user.click(otherButton)
 
-      // Advance timer to trigger selection reset
       jest.advanceTimersByTime(200)
-
-      // The selection state should be reset (this would be visible in actual styling)
-      expect(clickableButton).toBeInTheDocument() // Basic check that component is still there
+      expect(clickableButton).toBeInTheDocument()
     })
 
     it('becomes selected when Enter is pressed', async () => {
@@ -117,7 +112,6 @@ describe('ClickableCell', () => {
       await user.keyboard('{Enter}')
 
       expect(defaultProps.onClick).toHaveBeenCalled()
-      // Selection state is managed internally for styling
     })
 
     it('handles multiple rapid interactions', async () => {
@@ -126,7 +120,6 @@ describe('ClickableCell', () => {
 
       const button = screen.getByRole('button')
 
-      // Multiple rapid clicks
       await user.click(button)
       await user.click(button)
       await user.keyboard('{Enter}')
@@ -187,12 +180,10 @@ describe('ClickableCell', () => {
 
       const [button1, button2] = screen.getAllByRole('button')
 
-      // Test first button
       await user.click(button1)
       expect(onClick1).toHaveBeenCalledTimes(1)
       expect(onClick2).not.toHaveBeenCalled()
 
-      // Test second button
       await user.click(button2)
       expect(onClick2).toHaveBeenCalledTimes(1)
     })
@@ -213,7 +204,6 @@ describe('ClickableCell', () => {
 
       const buttons = screen.getAllByRole('button')
 
-      // Tab through buttons
       await user.tab()
       expect(buttons[0]).toHaveFocus()
 
@@ -254,7 +244,11 @@ describe('ClickableCell', () => {
     })
 
     it('handles empty or minimal content', () => {
-      render(<ClickableCell onClick={jest.fn()}> </ClickableCell>)
+      render(
+        <ClickableCell ariaLabel="TEST" onClick={jest.fn()}>
+          {' '}
+        </ClickableCell>,
+      )
 
       expect(screen.getByRole('button')).toBeInTheDocument()
     })
@@ -274,7 +268,6 @@ describe('ClickableCell', () => {
       const button = screen.getByRole('button', { name: 'Test button' })
       const input = screen.getByTestId('input')
 
-      // Focus and blur multiple times
       await user.click(button)
       await user.click(input)
       await user.click(button)
@@ -291,7 +284,6 @@ describe('ClickableCell', () => {
 
       const button = screen.getByRole('button')
 
-      // Multiple interactions to test state stability
       await user.click(button)
       jest.advanceTimersByTime(200)
       await user.keyboard('{Enter}')

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.test.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.test.tsx
@@ -1,0 +1,329 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { ClickableCell } from './ClickableCell'
+
+describe('ClickableCell', () => {
+  const defaultProps = {
+    children: 'Test Content',
+    onClick: jest.fn(),
+    ariaLabel: 'Test button',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  describe('Basic functionality', () => {
+    it('renders with correct content and attributes', () => {
+      render(<ClickableCell {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      expect(button).toBeInTheDocument()
+      expect(button).toHaveTextContent('Test Content')
+      expect(button).toHaveAttribute('aria-label', 'Test button')
+      expect(button).toHaveAttribute('type', 'button')
+    })
+
+    it('calls onClick when clicked', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<ClickableCell {...defaultProps} />)
+
+      await user.click(screen.getByRole('button'))
+
+      expect(defaultProps.onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onClick when Enter is pressed', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<ClickableCell {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      await user.tab()
+      expect(button).toHaveFocus()
+      await user.keyboard('{Enter}')
+
+      expect(defaultProps.onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onClick when Space is pressed', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<ClickableCell {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      await user.tab()
+      expect(button).toHaveFocus()
+      await user.keyboard(' ')
+
+      expect(defaultProps.onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onClick for other keys', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<ClickableCell {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      await user.tab()
+      expect(button).toHaveFocus()
+      await user.keyboard('{Escape}')
+      await user.keyboard('a')
+
+      expect(defaultProps.onClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Selection state behavior', () => {
+    it('becomes selected when clicked and resets after blur', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(
+        <div>
+          <ClickableCell {...defaultProps} />
+          <button data-testid="other">Other button</button>
+        </div>,
+      )
+
+      const clickableButton = screen.getByRole('button', {
+        name: 'Test button',
+      })
+      const otherButton = screen.getByTestId('other')
+
+      // Click to select
+      await user.click(clickableButton)
+
+      // Focus other element to trigger blur
+      await user.click(otherButton)
+
+      // Advance timer to trigger selection reset
+      jest.advanceTimersByTime(200)
+
+      // The selection state should be reset (this would be visible in actual styling)
+      expect(clickableButton).toBeInTheDocument() // Basic check that component is still there
+    })
+
+    it('becomes selected when Enter is pressed', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<ClickableCell {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      await user.tab()
+      expect(button).toHaveFocus()
+      await user.keyboard('{Enter}')
+
+      expect(defaultProps.onClick).toHaveBeenCalled()
+      // Selection state is managed internally for styling
+    })
+
+    it('handles multiple rapid interactions', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<ClickableCell {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+
+      // Multiple rapid clicks
+      await user.click(button)
+      await user.click(button)
+      await user.keyboard('{Enter}')
+
+      expect(defaultProps.onClick).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('Keyboard navigation and accessibility', () => {
+    it('is focusable via keyboard navigation', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      render(<ClickableCell {...defaultProps} />)
+
+      await user.tab()
+
+      expect(screen.getByRole('button')).toHaveFocus()
+    })
+
+    // it('prevents default behavior for Enter and Space', async () => {
+    //   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+    //   const parentKeyDown = jest.fn()
+
+    //   render(
+    //     <button
+    //       type="button"
+    //       onKeyDown={parentKeyDown}
+    //       tabIndex={-1}
+    //       style={{ all: 'unset' }}
+    //     >
+    //       <ClickableCell {...defaultProps} />
+    //     </button>,
+    //   )
+
+    //   const button = screen.getByRole('button')
+    //   await user.tab()
+    //   expect(button).toHaveFocus()
+    //   await user.keyboard('{Enter}')
+    //   await user.keyboard(' ')
+
+    //   // Events should be prevented from bubbling
+    //   expect(parentKeyDown).not.toHaveBeenCalled()
+    // })
+
+    it('supports custom aria-label', () => {
+      const customLabel = 'Custom action button'
+      render(<ClickableCell {...defaultProps} ariaLabel={customLabel} />)
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        customLabel,
+      )
+    })
+  })
+
+  describe('Integration with DataGrid', () => {
+    it('works correctly in table context', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      const onClick1 = jest.fn()
+      const onClick2 = jest.fn()
+
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <ClickableCell onClick={onClick1} ariaLabel="Edit row 1">
+                  Edit
+                </ClickableCell>
+              </td>
+              <td>Regular content</td>
+            </tr>
+            <tr>
+              <td>
+                <ClickableCell onClick={onClick2} ariaLabel="Edit row 2">
+                  Edit
+                </ClickableCell>
+              </td>
+              <td>More content</td>
+            </tr>
+          </tbody>
+        </table>,
+      )
+
+      const [button1, button2] = screen.getAllByRole('button')
+
+      // Test first button
+      await user.click(button1)
+      expect(onClick1).toHaveBeenCalledTimes(1)
+      expect(onClick2).not.toHaveBeenCalled()
+
+      // Test second button
+      await user.click(button2)
+      expect(onClick2).toHaveBeenCalledTimes(1)
+    })
+
+    it('handles keyboard navigation between multiple cells', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+
+      render(
+        <div>
+          <ClickableCell onClick={jest.fn()} ariaLabel="First cell">
+            Cell 1
+          </ClickableCell>
+          <ClickableCell onClick={jest.fn()} ariaLabel="Second cell">
+            Cell 2
+          </ClickableCell>
+        </div>,
+      )
+
+      const buttons = screen.getAllByRole('button')
+
+      // Tab through buttons
+      await user.tab()
+      expect(buttons[0]).toHaveFocus()
+
+      await user.tab()
+      expect(buttons[1]).toHaveFocus()
+    })
+  })
+
+  describe('Props and customization', () => {
+    it('forwards additional props to button element', () => {
+      render(
+        <ClickableCell
+          {...defaultProps}
+          data-testid="custom-button"
+          disabled
+          className="custom-class"
+        />,
+      )
+
+      const button = screen.getByTestId('custom-button')
+      expect(button).toBeDisabled()
+      expect(button).toHaveClass('custom-class')
+    })
+
+    it('handles complex children content', () => {
+      const complexChildren = (
+        <div>
+          <span data-testid="icon">📝</span>
+          <strong data-testid="text">Edit Item</strong>
+        </div>
+      )
+
+      render(<ClickableCell {...defaultProps}>{complexChildren}</ClickableCell>)
+
+      expect(screen.getByTestId('icon')).toBeInTheDocument()
+      expect(screen.getByTestId('text')).toBeInTheDocument()
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('handles empty or minimal content', () => {
+      render(<ClickableCell onClick={jest.fn()}> </ClickableCell>)
+
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+  })
+
+  describe('Error handling and edge cases', () => {
+    it('handles focus/blur without errors', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+
+      render(
+        <div>
+          <ClickableCell {...defaultProps} />
+          <input data-testid="input" />
+        </div>,
+      )
+
+      const button = screen.getByRole('button', { name: 'Test button' })
+      const input = screen.getByTestId('input')
+
+      // Focus and blur multiple times
+      await user.click(button)
+      await user.click(input)
+      await user.click(button)
+      await user.tab()
+
+      // Should not throw any errors
+      expect(button).toBeInTheDocument()
+    })
+
+    it('continues to work after multiple state changes', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+
+      render(<ClickableCell {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+
+      // Multiple interactions to test state stability
+      await user.click(button)
+      jest.advanceTimersByTime(200)
+      await user.keyboard('{Enter}')
+      jest.advanceTimersByTime(200)
+      await user.click(button)
+
+      expect(defaultProps.onClick).toHaveBeenCalledTimes(3)
+    })
+  })
+})

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.test.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.test.tsx
@@ -145,31 +145,6 @@ describe('ClickableCell', () => {
       expect(screen.getByRole('button')).toHaveFocus()
     })
 
-    // it('prevents default behavior for Enter and Space', async () => {
-    //   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
-    //   const parentKeyDown = jest.fn()
-
-    //   render(
-    //     <button
-    //       type="button"
-    //       onKeyDown={parentKeyDown}
-    //       tabIndex={-1}
-    //       style={{ all: 'unset' }}
-    //     >
-    //       <ClickableCell {...defaultProps} />
-    //     </button>,
-    //   )
-
-    //   const button = screen.getByRole('button')
-    //   await user.tab()
-    //   expect(button).toHaveFocus()
-    //   await user.keyboard('{Enter}')
-    //   await user.keyboard(' ')
-
-    //   // Events should be prevented from bubbling
-    //   expect(parentKeyDown).not.toHaveBeenCalled()
-    // })
-
     it('supports custom aria-label', () => {
       const customLabel = 'Custom action button'
       render(<ClickableCell {...defaultProps} ariaLabel={customLabel} />)

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
@@ -31,26 +31,9 @@ export const clickableCell: ClickableCellToken = {
     vertical: 'inherit',
     horizontal: 'inherit',
   },
-  //  states: {
-  //   hover: {
-  //     border: {
-  //       type: 'border',
-  //       width: '1px',
-  //       color: 'transparent',
-  //       style: 'solid',
-  //     },
-  //   },
-  //   focus: {
-  //     outline: {
-  //       type: 'outline',
-  //       offset: '3px',
-  //       style: 'dashed',
-  //       color: outline.color,
-  //       width: outline.width,
-  //     },
-  //   },
   states: {
     hover: {
+      background: 'rgba(220, 220, 220, 0.4)',
       outline: {
         type: 'outline',
         offset: '-1px',
@@ -67,6 +50,9 @@ export const clickableCell: ClickableCellToken = {
         color: outline.color,
         width: outline.width,
       },
+    },
+    active: {
+      background: 'rgba(200, 200, 200, 0.5)',
     },
   },
 }

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
@@ -11,7 +11,7 @@ const {
     },
     interactive: {
       table__cell__fill_hover: { rgba: hoverBackgroundColor },
-      focus: { rgba: focusColor },
+      table__cell__fill_activated: { rgba: activeBackgroundColor },
     },
   },
   interactions: { focused: outline },
@@ -37,7 +37,7 @@ export const clickableCell: ClickableCellToken = {
       outline: {
         type: 'outline',
         offset: '-1px',
-        style: 'dashed',
+        style: 'solid',
         color: outline.color,
         width: outline.width,
       },
@@ -46,13 +46,20 @@ export const clickableCell: ClickableCellToken = {
       outline: {
         type: 'outline',
         offset: '-1px',
-        style: 'dashed',
+        style: 'solid',
         color: outline.color,
         width: outline.width,
       },
     },
     active: {
-      background: focusColor,
+      background: activeBackgroundColor,
+      outline: {
+        type: 'outline',
+        offset: '-1px',
+        style: 'solid',
+        color: outline.color,
+        width: outline.width,
+      },
     },
   },
 }

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
@@ -11,6 +11,7 @@ const {
     },
     interactive: {
       table__cell__fill_hover: { rgba: hoverBackgroundColor },
+      table__cell__fill_hover: { rgba: focusBackgroundColor },
       table__cell__fill_activated: { rgba: activeBackgroundColor },
     },
   },
@@ -27,30 +28,12 @@ export const clickableCell: ClickableCellToken = {
     ...cellTypography,
     color: typographyColor,
   },
-  align: {
-    vertical: 'inherit',
-    horizontal: 'inherit',
-  },
   states: {
     hover: {
       background: hoverBackgroundColor,
-      outline: {
-        type: 'outline',
-        offset: '-1px',
-        style: 'solid',
-        color: outline.color,
-        width: outline.width,
-      },
     },
     focus: {
-      background: hoverBackgroundColor,
-      outline: {
-        type: 'outline',
-        offset: '-1px',
-        style: 'solid',
-        color: outline.color,
-        width: outline.width,
-      },
+      background: focusBackgroundColor,
     },
     active: {
       background: activeBackgroundColor,

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
@@ -33,7 +33,7 @@ export const clickableCell: ClickableCellToken = {
   },
   states: {
     hover: {
-      background: 'rgba(220, 220, 220, 0.4)',
+      background: hoverBackgroundColor,
       outline: {
         type: 'outline',
         offset: '-1px',
@@ -52,7 +52,7 @@ export const clickableCell: ClickableCellToken = {
       },
     },
     active: {
-      background: 'rgba(200, 200, 200, 0.5)',
+      background: focusColor,
     },
   },
 }

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
@@ -14,6 +14,7 @@ const {
       focus: { rgba: focusColor },
     },
   },
+  interactions: { focused: outline },
 } = tokens
 
 export type ClickableCellToken = ComponentToken
@@ -30,17 +31,41 @@ export const clickableCell: ClickableCellToken = {
     vertical: 'inherit',
     horizontal: 'inherit',
   },
+  //  states: {
+  //   hover: {
+  //     border: {
+  //       type: 'border',
+  //       width: '1px',
+  //       color: 'transparent',
+  //       style: 'solid',
+  //     },
+  //   },
+  //   focus: {
+  //     outline: {
+  //       type: 'outline',
+  //       offset: '3px',
+  //       style: 'dashed',
+  //       color: outline.color,
+  //       width: outline.width,
+  //     },
+  //   },
   states: {
     hover: {
-      background: hoverBackgroundColor,
+      outline: {
+        type: 'outline',
+        offset: '-1px',
+        style: 'dashed',
+        color: outline.color,
+        width: outline.width,
+      },
     },
     focus: {
       outline: {
         type: 'outline',
-        color: focusColor,
-        width: '2px',
-        style: 'solid',
-        offset: '-2px',
+        offset: '-1px',
+        style: 'dashed',
+        color: outline.color,
+        width: outline.width,
       },
     },
   },

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
@@ -43,6 +43,7 @@ export const clickableCell: ClickableCellToken = {
       },
     },
     focus: {
+      background: hoverBackgroundColor,
       outline: {
         type: 'outline',
         offset: '-1px',

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tokens.tsx
@@ -1,0 +1,47 @@
+import { tokens } from '@equinor/eds-tokens'
+import type { ComponentToken } from '@equinor/eds-tokens'
+
+const {
+  typography: {
+    table: { cell_text: cellTypography },
+  },
+  colors: {
+    text: {
+      static_icons__default: { rgba: typographyColor },
+    },
+    interactive: {
+      table__cell__fill_hover: { rgba: hoverBackgroundColor },
+      focus: { rgba: focusColor },
+    },
+  },
+} = tokens
+
+export type ClickableCellToken = ComponentToken
+
+export const clickableCell: ClickableCellToken = {
+  width: '100%',
+  height: '100%',
+  background: 'transparent',
+  typography: {
+    ...cellTypography,
+    color: typographyColor,
+  },
+  align: {
+    vertical: 'inherit',
+    horizontal: 'inherit',
+  },
+  states: {
+    hover: {
+      background: hoverBackgroundColor,
+    },
+    focus: {
+      outline: {
+        type: 'outline',
+        color: focusColor,
+        width: '2px',
+        style: 'solid',
+        offset: '-2px',
+      },
+    },
+  },
+}

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -1,5 +1,12 @@
-import React, { ButtonHTMLAttributes } from 'react'
-import styled from 'styled-components'
+import React, { ButtonHTMLAttributes, useState } from 'react'
+import styled, { css } from 'styled-components'
+import {
+  bordersTemplate,
+  outlineTemplate,
+  // spacingsTemplate,
+  // useToken,
+  // OverridableComponent,
+} from '@equinor/eds-utils'
 import { clickableCell, type ClickableCellToken } from './ClickableCell.tokens'
 
 export type ClickableCellProps = {
@@ -11,50 +18,84 @@ export type ClickableCellProps = {
   ariaLabel?: string
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'children'>
 
-const StyledButton = styled.button<{ $token: ClickableCellToken }>`
-  /* Fill entire cell completely */
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
+interface StyledButtonProps {
+  $token: ClickableCellToken
+  $isSelected: boolean
+}
 
-  background: transparent;
-  border: none;
-  padding: 8px; /* Add back the cell padding inside the button */
-  margin: 0;
-  cursor: pointer;
-  outline: none;
+const StyledButton = styled.button<StyledButtonProps>(
+  ({ $token, $isSelected }) => {
+    const { states } = $token
+    const { focus, hover, active } = states
 
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
-  color: inherit;
-  text-align: inherit;
+    return css`
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
 
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+      background: ${$isSelected ? active?.background : 'transparent'};
+      border: none;
+      padding: 8px;
+      margin: 0;
+      cursor: pointer;
+      outline: none;
 
-  &:hover {
-    background: ${({ $token }) => $token.states?.hover?.background};
-  }
+      font-family: inherit;
+      font-size: inherit;
+      font-weight: inherit;
+      line-height: inherit;
+      color: inherit;
+      text-align: inherit;
 
-  &:focus-visible {
-    background: ${({ $token }) => $token.states?.hover?.background};
-    outline: ${({ $token }) =>
-      `${$token.states?.focus?.outline?.width} ${$token.states?.focus?.outline?.style} ${$token.states?.focus?.outline?.color}`};
-    outline-offset: ${({ $token }) =>
-      $token.states?.focus?.outline?.offset || 0};
-  }
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
 
-  &:active {
-    background: ${({ $token }) => $token.states?.active?.background};
-  }
-`
+      ${bordersTemplate($token.border)}
+
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          background: ${$isSelected ? active?.background : hover?.background};
+        }
+      }
+
+      &:focus {
+        outline: none;
+      }
+
+      &[data-focus-visible-added]:focus {
+        ${outlineTemplate(focus?.outline)}
+      }
+
+      &:focus-visible {
+        background: ${$isSelected ? active?.background : hover?.background};
+        ${outlineTemplate(focus?.outline)}
+      }
+
+      &:active {
+        background: ${active?.background};
+        outline: ${focus?.outline?.width} solid ${focus?.outline?.color};
+        outline-offset: ${focus?.outline?.offset || 0};
+      }
+
+      &:focus:active {
+        background: ${active?.background};
+        outline: ${focus?.outline?.width} solid ${focus?.outline?.color};
+        outline-offset: ${focus?.outline?.offset || 0};
+      }
+
+      ${$isSelected &&
+      css`
+        outline: ${focus?.outline?.width} solid ${focus?.outline?.color};
+        outline-offset: ${focus?.outline?.offset || 0};
+      `}
+    `
+  },
+)
 
 const CellWrapper = styled.div`
   position: relative;
@@ -69,13 +110,36 @@ export function ClickableCell({
   ariaLabel,
   ...rest
 }: ClickableCellProps) {
+  const [isSelected, setIsSelected] = useState(false)
+
+  const handleClick = () => {
+    setIsSelected(true)
+    onClick()
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      setIsSelected(true)
+      onClick()
+    }
+  }
+
+  const handleBlur = () => {
+    // Reset selection when button loses focus
+    setIsSelected(false)
+  }
+
   return (
     <CellWrapper>
       <StyledButton
-        onClick={onClick}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
         aria-label={ariaLabel}
         type="button"
         $token={clickableCell}
+        $isSelected={isSelected}
         {...rest}
       >
         {children}

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -1,12 +1,6 @@
 import React, { ButtonHTMLAttributes, useState } from 'react'
 import styled, { css } from 'styled-components'
-import {
-  bordersTemplate,
-  outlineTemplate,
-  // spacingsTemplate,
-  // useToken,
-  // OverridableComponent,
-} from '@equinor/eds-utils'
+import { bordersTemplate, outlineTemplate } from '@equinor/eds-utils'
 import { clickableCell, type ClickableCellToken } from './ClickableCell.tokens'
 
 export type ClickableCellProps = {
@@ -57,10 +51,8 @@ const StyledButton = styled.button<StyledButtonProps>(
 
       ${bordersTemplate($token.border)}
 
-      @media (hover: hover) and (pointer: fine) {
-        &:hover {
-          background: ${$isSelected ? active?.background : hover?.background};
-        }
+      &:hover {
+        background: ${$isSelected ? active?.background : hover?.background};
       }
 
       &:focus {
@@ -78,20 +70,16 @@ const StyledButton = styled.button<StyledButtonProps>(
 
       &:active {
         background: ${active?.background};
-        outline: ${focus?.outline?.width} solid ${focus?.outline?.color};
-        outline-offset: ${focus?.outline?.offset || 0};
       }
 
       &:focus:active {
         background: ${active?.background};
-        outline: ${focus?.outline?.width} solid ${focus?.outline?.color};
-        outline-offset: ${focus?.outline?.offset || 0};
       }
 
       ${$isSelected &&
       css`
-        outline: ${focus?.outline?.width} solid ${focus?.outline?.color};
-        outline-offset: ${focus?.outline?.offset || 0};
+        background: ${active?.background};
+        ${outlineTemplate(focus?.outline)}
       `}
     `
   },
@@ -101,7 +89,7 @@ const CellWrapper = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
-  padding: 0; /* Remove padding from wrapper */
+  padding: 0;
 `
 
 export function ClickableCell({
@@ -126,8 +114,8 @@ export function ClickableCell({
   }
 
   const handleBlur = () => {
-    // Reset selection when button loses focus
-    setIsSelected(false)
+    // Reset selection when button loses focus, but keep for a short time to see the effect
+    setTimeout(() => setIsSelected(false), 150)
   }
 
   return (

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -33,10 +33,11 @@ const StyledButton = styled.button<StyledButtonProps>(
 
       background: ${$isSelected ? active?.background : 'transparent'};
       border: none;
-      padding: 8px;
+      padding: var(--eds_table__cell__padding_x, 16px);
       margin: 0;
       cursor: pointer;
       outline: none;
+      z-index: 1;
 
       font-family: inherit;
       font-size: inherit;
@@ -70,6 +71,7 @@ const StyledButton = styled.button<StyledButtonProps>(
 
       &:active {
         background: ${active?.background};
+        ${outlineTemplate(focus?.outline)}
       }
 
       &:focus:active {

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -62,13 +62,15 @@ const StyledButton = styled.button<StyledButtonProps>(
 
       &:focus-visible {
         background: ${focus?.background};
+        ${outlineTemplate(focus?.outline)}
+        z-index: 2; // Avoids outline overlap when hovering adjacent cell
       }
 
       ${$isSelected &&
       css`
         background: ${active?.background};
         ${outlineTemplate(active?.outline)}
-        z-index: 10; // Avoids outline overlap when hovering adjacent cell
+        z-index: 3; // Avoids outline overlap when hovering adjacent cell
       `}
     `
   },

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -9,7 +9,7 @@ export type ClickableCellProps = {
   /** Click handler */
   onClick: () => void
   /** Accessible label for screen readers */
-  ariaLabel?: string
+  ariaLabel: string
   /** Indicates if the cell is selected */
   isSelected?: boolean
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'children'>
@@ -62,7 +62,6 @@ const StyledButton = styled.button<StyledButtonProps>(
 
       &:focus-visible {
         background: ${focus?.background};
-        ${outlineTemplate(focus?.outline)}
         z-index: 2; // Avoids outline overlap when hovering adjacent cell
       }
 

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -1,6 +1,6 @@
 import React, { ButtonHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
-import { bordersTemplate, outlineTemplate } from '@equinor/eds-utils'
+import { outlineTemplate } from '@equinor/eds-utils'
 import { clickableCell, type ClickableCellToken } from './ClickableCell.tokens'
 
 export type ClickableCellProps = {
@@ -52,8 +52,6 @@ const StyledButton = styled.button<StyledButtonProps>(
       align-items: center;
       justify-content: flex-start;
 
-      ${bordersTemplate($token.border)}
-
       &:hover {
         background: ${hover?.background};
       }
@@ -63,18 +61,14 @@ const StyledButton = styled.button<StyledButtonProps>(
       }
 
       &:focus-visible {
-        background: ${hover?.background};
+        background: ${focus?.background};
       }
-
-      // &:active {
-      //   background: ${active?.background};
-      //   ${outlineTemplate(focus?.outline)}
-      // }
 
       ${$isSelected &&
       css`
-        background: ${active?.background}; // Grønn bakgrunn
-        ${outlineTemplate(focus?.outline)}// Med outline
+        background: ${active?.background};
+        ${outlineTemplate(active?.outline)}
+        z-index: 10; // Avoids outline overlap when hovering adjacent cell
       `}
     `
   },
@@ -99,6 +93,7 @@ export function ClickableCell({
       <StyledButton
         onClick={onClick}
         aria-label={ariaLabel}
+        aria-pressed={isSelected}
         type="button"
         $token={clickableCell}
         $isSelected={isSelected}

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -1,0 +1,85 @@
+import React, { ButtonHTMLAttributes } from 'react'
+import styled from 'styled-components'
+import { clickableCell, type ClickableCellToken } from './ClickableCell.tokens'
+
+export type ClickableCellProps = {
+  /** Cell content */
+  children: React.ReactNode
+  /** Click handler */
+  onClick: () => void
+  /** Accessible label for screen readers */
+  ariaLabel?: string
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'children'>
+
+const StyledButton = styled.button<{ $token: ClickableCellToken }>`
+  /* Fill entire cell completely */
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+
+  background: transparent;
+  border: none;
+  padding: 8px; /* Add back the cell padding inside the button */
+  margin: 0;
+  cursor: pointer;
+  outline: none;
+
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+  text-align: inherit;
+
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+
+  &:hover {
+    background: ${({ $token }) => $token.states?.hover?.background};
+  }
+
+  &:focus-visible {
+    background: ${({ $token }) => $token.states?.hover?.background};
+    outline: ${({ $token }) =>
+      `${$token.states?.focus?.outline?.width} ${$token.states?.focus?.outline?.style} ${$token.states?.focus?.outline?.color}`};
+    outline-offset: ${({ $token }) =>
+      $token.states?.focus?.outline?.offset || 0};
+  }
+
+  &:active {
+    background: ${({ $token }) => $token.states?.active?.background};
+  }
+`
+
+const CellWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  padding: 0; /* Remove padding from wrapper */
+`
+
+export function ClickableCell({
+  children,
+  onClick,
+  ariaLabel,
+  ...rest
+}: ClickableCellProps) {
+  return (
+    <CellWrapper>
+      <StyledButton
+        onClick={onClick}
+        aria-label={ariaLabel}
+        type="button"
+        $token={clickableCell}
+        {...rest}
+      >
+        {children}
+      </StyledButton>
+    </CellWrapper>
+  )
+}

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -10,65 +10,75 @@ export type ClickableCellProps = {
   onClick: () => void
   /** Accessible label for screen readers */
   ariaLabel?: string
+  /** Indicates if the cell is selected */
+  isSelected?: boolean
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'children'>
 
 interface StyledButtonProps {
+  $isSelected?: boolean
   $token: ClickableCellToken
 }
 
-const StyledButton = styled.button<StyledButtonProps>(({ $token }) => {
-  const { states } = $token
-  const { focus, hover, active } = states
+const StyledButton = styled.button<StyledButtonProps>(
+  ({ $token, $isSelected }) => {
+    const { states } = $token
+    const { focus, hover, active } = states
 
-  return css`
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    width: 100%;
-    height: 100%;
+    return css`
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
 
-    background: transparent;
-    border: none;
-    padding: var(--eds_table__cell__padding_x, 16px);
-    margin: 0;
-    cursor: pointer;
-    outline: none;
-    z-index: 1;
-
-    font-family: inherit;
-    font-size: inherit;
-    font-weight: inherit;
-    line-height: inherit;
-    color: inherit;
-    text-align: inherit;
-
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-
-    ${bordersTemplate($token.border)}
-
-    &:hover {
-      background: ${hover?.background};
-    }
-
-    &:focus {
+      background: transparent;
+      border: none;
+      padding: var(--eds_table__cell__padding_x, 16px);
+      margin: 0;
+      cursor: pointer;
       outline: none;
-    }
+      z-index: 1;
 
-    &:focus-visible {
-      background: ${hover?.background};
-      ${outlineTemplate(focus?.outline)}
-    }
+      font-family: inherit;
+      font-size: inherit;
+      font-weight: inherit;
+      line-height: inherit;
+      color: inherit;
+      text-align: inherit;
 
-    &:active {
-      background: ${active?.background};
-      ${outlineTemplate(focus?.outline)}
-    }
-  `
-})
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+
+      ${bordersTemplate($token.border)}
+
+      &:hover {
+        background: ${hover?.background};
+      }
+
+      &:focus {
+        outline: none;
+      }
+
+      &:focus-visible {
+        background: ${hover?.background};
+      }
+
+      // &:active {
+      //   background: ${active?.background};
+      //   ${outlineTemplate(focus?.outline)}
+      // }
+
+      ${$isSelected &&
+      css`
+        background: ${active?.background}; // Grønn bakgrunn
+        ${outlineTemplate(focus?.outline)}// Med outline
+      `}
+    `
+  },
+)
 
 const CellWrapper = styled.div`
   position: relative;
@@ -81,6 +91,7 @@ export function ClickableCell({
   children,
   onClick,
   ariaLabel,
+  isSelected = false,
   ...rest
 }: ClickableCellProps) {
   return (
@@ -90,6 +101,7 @@ export function ClickableCell({
         aria-label={ariaLabel}
         type="button"
         $token={clickableCell}
+        $isSelected={isSelected}
         {...rest}
       >
         {children}

--- a/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/ClickableCell.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, useState } from 'react'
+import React, { ButtonHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { bordersTemplate, outlineTemplate } from '@equinor/eds-utils'
 import { clickableCell, type ClickableCellToken } from './ClickableCell.tokens'
@@ -14,78 +14,61 @@ export type ClickableCellProps = {
 
 interface StyledButtonProps {
   $token: ClickableCellToken
-  $isSelected: boolean
 }
 
-const StyledButton = styled.button<StyledButtonProps>(
-  ({ $token, $isSelected }) => {
-    const { states } = $token
-    const { focus, hover, active } = states
+const StyledButton = styled.button<StyledButtonProps>(({ $token }) => {
+  const { states } = $token
+  const { focus, hover, active } = states
 
-    return css`
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      width: 100%;
-      height: 100%;
+  return css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
 
-      background: ${$isSelected ? active?.background : 'transparent'};
-      border: none;
-      padding: var(--eds_table__cell__padding_x, 16px);
-      margin: 0;
-      cursor: pointer;
+    background: transparent;
+    border: none;
+    padding: var(--eds_table__cell__padding_x, 16px);
+    margin: 0;
+    cursor: pointer;
+    outline: none;
+    z-index: 1;
+
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    color: inherit;
+    text-align: inherit;
+
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+
+    ${bordersTemplate($token.border)}
+
+    &:hover {
+      background: ${hover?.background};
+    }
+
+    &:focus {
       outline: none;
-      z-index: 1;
+    }
 
-      font-family: inherit;
-      font-size: inherit;
-      font-weight: inherit;
-      line-height: inherit;
-      color: inherit;
-      text-align: inherit;
+    &:focus-visible {
+      background: ${hover?.background};
+      ${outlineTemplate(focus?.outline)}
+    }
 
-      display: flex;
-      align-items: center;
-      justify-content: flex-start;
-
-      ${bordersTemplate($token.border)}
-
-      &:hover {
-        background: ${$isSelected ? active?.background : hover?.background};
-      }
-
-      &:focus {
-        outline: none;
-      }
-
-      &[data-focus-visible-added]:focus {
-        ${outlineTemplate(focus?.outline)}
-      }
-
-      &:focus-visible {
-        background: ${$isSelected ? active?.background : hover?.background};
-        ${outlineTemplate(focus?.outline)}
-      }
-
-      &:active {
-        background: ${active?.background};
-        ${outlineTemplate(focus?.outline)}
-      }
-
-      &:focus:active {
-        background: ${active?.background};
-      }
-
-      ${$isSelected &&
-      css`
-        background: ${active?.background};
-        ${outlineTemplate(focus?.outline)}
-      `}
-    `
-  },
-)
+    &:active {
+      background: ${active?.background};
+      ${outlineTemplate(focus?.outline)}
+    }
+  `
+})
 
 const CellWrapper = styled.div`
   position: relative;
@@ -100,36 +83,13 @@ export function ClickableCell({
   ariaLabel,
   ...rest
 }: ClickableCellProps) {
-  const [isSelected, setIsSelected] = useState(false)
-
-  const handleClick = () => {
-    setIsSelected(true)
-    onClick()
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      setIsSelected(true)
-      onClick()
-    }
-  }
-
-  const handleBlur = () => {
-    // Reset selection when button loses focus, but keep for a short time to see the effect
-    setTimeout(() => setIsSelected(false), 150)
-  }
-
   return (
     <CellWrapper>
       <StyledButton
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        onBlur={handleBlur}
+        onClick={onClick}
         aria-label={ariaLabel}
         type="button"
         $token={clickableCell}
-        $isSelected={isSelected}
         {...rest}
       >
         {children}

--- a/packages/eds-data-grid-react/src/components/ClickableCell/index.ts
+++ b/packages/eds-data-grid-react/src/components/ClickableCell/index.ts
@@ -1,0 +1,1 @@
+export { ClickableCell, type ClickableCellProps } from './ClickableCell'


### PR DESCRIPTION
## ✨ New ClickableCell Component
This PR introduces a new ClickableCell component that enables interactive cells within the EDS DataGrid, following the design specifications from [Figma Desktop Design](https://www.figma.com/design/luNobpDIWTuQ9rhyovGLBI/Desktop?node-id=5112-91759&t=RrxLyUDIlm1EqiMe-4).

### 🎯 What this adds:

- Accessible clickable cells with proper ARIA labels (required) and button semantics
- Full keyboard navigation support (Enter, Space, Tab)
- Visual feedback states using EDS design tokens
- Seamless DataGrid integration with proper styling coordination

### 💻 Usage example:

```jsx
const clickableColumns = [
    helper.accessor('id', {
      header: 'ID',
      cell: ({ getValue }) => {
        const cellId = `id-${getValue()}`
        return (
          <ClickableCell
            onClick={() => handleCellClick(cellId)}
            isSelected={selectedCell === cellId}
            ariaLabel={`View details for ID ${getValue()}`}
          >
            {getValue()}
          </ClickableCell>
        )
      },
      id: 'clickable_id',
      size: 100,
    }),
    ....continue];
    
    const cellStyle = (row: Row<Photo>, columnId: string): CSSProperties => {
    if (
      ['clickable_id', 'clickable_title', 'clickable_actions'].includes(
        columnId,
      )
    ) {
      return { padding: 0 }
    }
    return {}
  }

    <EdsDataGrid {...args} columns={clickableColumns} cellStyle={cellStyle} />
    
```

### 📋 Integration notes:
- Should be used with column cell renderers as shown above (normal pattern for EdsDataGrid)
- Required: Parent cells must use padding: 0 in cellStyle to avoid double padding
- Component provides hover and focus styling automatically through the browser
- Selection state (`isSelected`) must be managed by parent component as shown in story

This component addresses the need for interactive cells while maintaining EDS design consistency and accessibility standards.

resolves #3839