### PR TITLE
fix: Tabs now allow 'null' value as child element 'Tabs.List' and 'Tabs.Panel'

### DIFF
--- a/packages/eds-core-react/src/components/Tabs/TabList.tsx
+++ b/packages/eds-core-react/src/components/Tabs/TabList.tsx
@@ -10,6 +10,7 @@ import {
   RefAttributes,
   cloneElement,
   Children as ReactChildren,
+  isValidElement,
 } from 'react'
 import styled from 'styled-components'
 import { mergeRefs } from '@equinor/eds-utils'
@@ -96,22 +97,25 @@ const TabList = forwardRef<HTMLDivElement, TabListProps>(function TabsList(
     [arrowNavigating, tabsFocused],
   )
 
-  const Tabs = ReactChildren.map(
-    children,
-    (child: TabChild, $index: number) => {
-      const childProps = child.props as TabChild
+  const Tabs =
+    ReactChildren.map(children, (child, $index) => {
+      if (!isValidElement(child)) {
+        return null
+      }
+      const tabChild = child as TabChild
+      const childProps = tabChild.props as TabChild
       const controlledActive = childProps.value
       const isActive = controlledActive
         ? controlledActive === activeTab
         : $index === activeTab
 
       const tabRef = isActive
-        ? mergeRefs<HTMLButtonElement>(child.ref, selectedTabRef)
-        : child.ref
+        ? mergeRefs<HTMLButtonElement>(tabChild.ref, selectedTabRef)
+        : tabChild.ref
 
       if (isActive) currentTab.current = $index
 
-      return cloneElement(child, {
+      return cloneElement(tabChild, {
         id: `${tabsId}-tab-${$index + 1}`,
         'aria-controls': `${tabsId}-panel-${$index + 1}`,
         active: isActive,
@@ -119,8 +123,7 @@ const TabList = forwardRef<HTMLDivElement, TabListProps>(function TabsList(
         onClick: () => handleChange($index),
         ref: tabRef,
       })
-    },
-  )
+    }) ?? []
 
   const focusableChildren: number[] = Tabs.filter((child: TabChild) => {
     const childProps = child.props as TabChild

--- a/packages/eds-core-react/src/components/Tabs/TabPanels.tsx
+++ b/packages/eds-core-react/src/components/Tabs/TabPanels.tsx
@@ -5,6 +5,7 @@ import {
   HTMLAttributes,
   cloneElement,
   Children as ReactChildren,
+  isValidElement,
 } from 'react'
 import { TabsContext } from './Tabs.context'
 
@@ -18,9 +19,10 @@ const TabPanels = forwardRef<HTMLDivElement, TabPanelsProps>(function TabPanels(
 ) {
   const { activeTab, tabsId } = useContext(TabsContext)
 
-  const Panels = ReactChildren.map(children, (child: ReactElement, $index) => {
-    if (conditionalRender && activeTab !== $index) return null
-    return cloneElement(child, {
+  const Panels = ReactChildren.map(children, (child, $index) => {
+    if (!isValidElement(child) || (conditionalRender && activeTab !== $index))
+      return null
+    return cloneElement(child as ReactElement, {
       id: `${tabsId}-panel-${$index + 1}`,
       'aria-labelledby': `${tabsId}-tab-${$index + 1}`,
       hidden: activeTab !== $index,

--- a/packages/eds-core-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/eds-core-react/src/components/Tabs/Tabs.test.tsx
@@ -175,4 +175,34 @@ describe('Tabs', () => {
     expect(screen.getByTestId(tablist)).toBeDefined()
     expect(screen.getByTestId(tabpanels)).toBeDefined()
   })
+  it("Doesn't crash if null-child is provided to Tabs.List or Tabs.Panels", () => {
+    const tablist = 'tablist'
+    const tabpanels = 'tabpanels'
+    render(
+      <Tabs>
+        <Tabs.List data-testid={tablist}>
+          <Tabs.Tab>First</Tabs.Tab>
+          {null}
+        </Tabs.List>
+        <Tabs.Panels data-testid={tabpanels}>
+          <Tabs.Panel>Second</Tabs.Panel>
+          {null}
+        </Tabs.Panels>
+      </Tabs>,
+    )
+    expect(screen.getByTestId(tablist)).toBeDefined()
+    expect(screen.getByTestId(tabpanels)).toBeDefined()
+  })
+  it("Doesn't crash if only null-child is provided to Tabs.List or Tabs.Panels", () => {
+    const tablist = 'tablist'
+    const tabpanels = 'tabpanels'
+    render(
+      <Tabs>
+        <Tabs.List data-testid={tablist}>{null}</Tabs.List>
+        <Tabs.Panels data-testid={tabpanels}>{null}</Tabs.Panels>
+      </Tabs>,
+    )
+    expect(screen.getByTestId(tablist)).toBeDefined()
+    expect(screen.getByTestId(tabpanels)).toBeDefined()
+  })
 })


### PR DESCRIPTION
Null-children will be ignored and removed.

Primary motivation for this is to allow conditional rendering if tabs alongside new [biome](https://biomejs.dev/) linting rule.

We used to the the following to conditionally render tabs:
```
<Tabs>
  <Tabs.List>
    {someConditional ? <Tabs.Tab>My Tab</Tabs.Tab> : <></>}
  </Tabs.List>
  <Tabs.Panels>
    {someConditional ? <Tabs.Panel>My Panel</Tabs.Panel> : <></>}
  </Tabs.Panels>
</Tabs>
```
In the above solution we would render out an empty `<></>` which would work without a problem with EDS Tabs.

The Biome rule https://biomejs.dev/linter/rules/no-useless-fragments/ now consideres the `<></>` to be redundant. Following this new rule we changed our code to the following:
```
<Tabs>
  <Tabs.List>
    {someConditional && <Tabs.Tab>My Tab</Tabs.Tab>}
  </Tabs.List>
  <Tabs.Panels>
    {someConditional && <Tabs.Panel>My Panel</Tabs.Panel>}
  </Tabs.Panels>
</Tabs>
```
This would comply with the new biome rule, but would cause EDS to break, since it does not accept a nullish value (null/undefined) as the child.

The proposed change will allow 'null/undefined' values to be passed as children to both Tabs.List and Tabs.Panels and should cause no further behavioral change.