### PR TITLE
feat(eds-data-grid-react): add detail panel to data grid

### DIFF
--- a/packages/eds-data-grid-react/src/EdsDataGrid.docs.mdx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.docs.mdx
@@ -86,6 +86,12 @@ The grid can be used as a tree-grid by using expansionState, which allows for a 
 
 <Canvas of={ComponentStories.ExpandRows} />
 
+### Row Detail Panel
+
+Render a detail panel for expanded rows using the `renderDetailPanel` prop. This allows rendering context information about a row. Toggle the rows using the `row.toggleExpanded()`.
+
+<Canvas of={ComponentStories.RowDetailPanel} />
+
 ### Toggleable columns
 
 Allows the user to hide/show columns.

--- a/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
+++ b/packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx
@@ -36,6 +36,7 @@ import {
   expandColumns,
   groupedColumns,
   helper,
+  rowDetailPanelColumns,
 } from './stories/columns'
 import { data, summaryData } from './stories/data'
 import { Virtualizer } from './types'
@@ -1162,6 +1163,54 @@ export const ExpandRows: StoryFn<EdsDataGridProps<PostComment>> = (args) => {
 }
 
 ExpandRows.args = {
+  stickyHeader: true,
+  enableVirtual: true,
+  height: 500,
+}
+
+export const RowDetailPanel: StoryFn<EdsDataGridProps<PostComment>> = (
+  args,
+) => {
+  const [data, setData] = useState<Array<PostComment>>([])
+  const [expansionState, setExpansionState] = useState<ExpandedState>({})
+
+  useEffect(() => {
+    const abortController = new AbortController()
+    const signal = abortController.signal
+
+    fetch(`https://jsonplaceholder.typicode.com/posts`, { signal })
+      .then((r) => r.json() as Promise<Array<PostComment>>)
+      .then((posts) => setData(posts))
+      .catch(console.error)
+
+    return () => {
+      abortController.abort()
+    }
+  }, [])
+
+  return (
+    <EdsDataGrid
+      {...args}
+      columns={rowDetailPanelColumns}
+      rows={data}
+      expansionState={expansionState}
+      setExpansionState={setExpansionState}
+      getSubRows={(r) => r.comments}
+      renderDetailPanel={(row) => {
+        return (
+          <div>
+            Custom content for row{' '}
+            <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {JSON.stringify(row.original, null, 2)}
+            </pre>
+          </div>
+        )
+      }}
+    />
+  )
+}
+
+RowDetailPanel.args = {
   stickyHeader: true,
   enableVirtual: true,
   height: 500,

--- a/packages/eds-data-grid-react/src/EdsDataGridProps.ts
+++ b/packages/eds-data-grid-react/src/EdsDataGridProps.ts
@@ -20,6 +20,7 @@ import {
   MouseEvent,
   MutableRefObject,
   ReactElement,
+  ReactNode,
 } from 'react'
 
 type BaseProps<T> = {
@@ -342,6 +343,28 @@ type ExpansionProps<T> = {
   expansionState?: ExpandedState
   setExpansionState?: React.Dispatch<React.SetStateAction<ExpandedState>>
   getSubRows?: (row: T, rowIndex: number) => Array<T>
+  /**
+   * Function returning JSX to render a detail panel for a row. The detail panel is rendered
+   * below the row when it is expanded.
+   *
+   * Expansion is toggled by calling `row.toggleExpanded()`.
+   *
+   * @example
+   * return (
+   *   <EdsDataGrid
+   *    renderDetailPanel={(context) => (
+   *      <div>
+   *        <h3>Detail Panel</h3>
+   *        <pre>{JSON.stringify(context.original, null, 2)}</pre>
+   *      </div>
+   *    )}
+   *   />
+   * )
+   *
+   * @param context The row context containing the row data and other information
+   * @returns ReactNode to render in the detail panel
+   */
+  renderDetailPanel?: (context: Row<T>) => ReactNode
 }
 
 export type EdsDataGridProps<T> = BaseProps<T> &

--- a/packages/eds-data-grid-react/src/components/DetailsPanelRow.tsx
+++ b/packages/eds-data-grid-react/src/components/DetailsPanelRow.tsx
@@ -1,0 +1,32 @@
+import { Table as EdsTable } from '@equinor/eds-core-react'
+import { tokens } from '@equinor/eds-tokens'
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+import { Row } from '../types'
+
+interface DetailsPanelRowProps<T> {
+  row: Row<T>
+  getColSpan: () => number
+  renderDetailPanel?: (row: Row<T>) => ReactNode
+}
+
+export function DetailsPanelRow<T>({
+  row,
+  getColSpan,
+  renderDetailPanel,
+}: DetailsPanelRowProps<T>) {
+  if (!renderDetailPanel || !row.getIsExpanded()) {
+    return null
+  }
+
+  return (
+    <EdsTable.Row>
+      <StyledCell colSpan={getColSpan()}>{renderDetailPanel(row)}</StyledCell>
+    </EdsTable.Row>
+  )
+}
+
+const StyledCell = styled(EdsTable.Cell)`
+  padding-top: ${tokens.spacings.comfortable.small};
+  padding-bottom: ${tokens.spacings.comfortable.small};
+`

--- a/packages/eds-data-grid-react/src/stories/columns.tsx
+++ b/packages/eds-data-grid-react/src/stories/columns.tsx
@@ -1,8 +1,8 @@
-import { ColumnDef, createColumnHelper } from '@tanstack/react-table'
-import styled from 'styled-components'
-import { tokens } from '@equinor/eds-tokens'
 import { Button, Icon, Typography } from '@equinor/eds-core-react'
 import { chevron_down, chevron_right } from '@equinor/eds-icons'
+import { tokens } from '@equinor/eds-tokens'
+import { ColumnDef, createColumnHelper } from '@tanstack/react-table'
+import styled from 'styled-components'
 
 export type Photo = {
   albumId: number
@@ -152,6 +152,59 @@ export const expandColumns: Array<ColumnDef<PostComment>> = [
           </Button>
         )}{' '}
         {getValue()}
+      </div>
+    ),
+  }),
+  postHelper.accessor('userId', {
+    header: 'User#',
+    id: 'userId',
+    size: 150,
+  }),
+  postHelper.accessor('title', {
+    header: 'Title',
+    id: 'title',
+    size: 250,
+  }),
+  postHelper.accessor('body', {
+    header: 'Body',
+    cell: (cell) => (
+      <Typography
+        variant={'cell_text'}
+        group={'table'}
+        style={{ overflow: 'hidden', whiteSpace: 'nowrap' }}
+      >
+        {cell.getValue().substring(0, 60)}...
+      </Typography>
+    ),
+    id: 'body',
+    size: 250,
+  }),
+]
+
+export const rowDetailPanelColumns: Array<ColumnDef<PostComment>> = [
+  postHelper.display({
+    id: 'expand',
+    size: 200,
+    header: ({ table }) => (
+      <Button
+        variant={'ghost_icon'}
+        onClick={table.getToggleAllRowsExpandedHandler()}
+      >
+        <Icon
+          data={table.getIsAllRowsExpanded() ? chevron_down : chevron_right}
+        />
+      </Button>
+    ),
+    cell: ({ row }) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Button variant="ghost_icon" onClick={() => row.toggleExpanded()}>
+          <Icon data={row.getIsExpanded() ? chevron_down : chevron_right} />
+        </Button>
       </div>
     ),
   }),


### PR DESCRIPTION
## What does this pull request change?

This pull request expands the `EdsDataGrid` props API by adding a `renderDetailPanel` prop.

This is a suggested implementation of #3896

