### PR TITLE
feat(eds-core-react): add disabled prop to Tooltip

### DIFF
--- a/packages/eds-core-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/eds-core-react/src/components/Tooltip/Tooltip.test.tsx
@@ -93,6 +93,21 @@ describe('Tooltip', () => {
     const tooltip = await screen.findByRole('tooltip')
     expect(tooltip).toBeInTheDocument()
   })
+  it('is not rendered when diabled', async () => {
+    render(
+      <Tooltip title="Tooltip" placement="right-start" disabled>
+        <div>Test</div>
+      </Tooltip>,
+    )
+
+    const content = screen.getByText('Test')
+
+    fireEvent.mouseEnter(content)
+    await act(() => new Promise((r) => setTimeout(r, openDelay)))
+
+    const tooltip = screen.queryByRole('tooltip')
+    expect(tooltip).not.toBeInTheDocument()
+  })
   it('renders with a correct title', async () => {
     render(
       <Tooltip title="Tooltip" placement="right-start">

--- a/packages/eds-core-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/eds-core-react/src/components/Tooltip/Tooltip.tsx
@@ -83,6 +83,8 @@ export type TooltipProps = {
   placement?: Placement
   /** Tooltip title */
   title?: ReactNode
+  /** Disable the tooltip */
+  disabled?: boolean
   /** Tooltip anchor element */
   children: React.ReactElement & React.RefAttributes<HTMLElement>
   /** Delay in ms, default 100 */
@@ -101,6 +103,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       children,
       style,
       enterDelay = 100,
+      disabled = false,
       portalContainer,
       ...rest
     },
@@ -226,6 +229,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       <>
         {shouldOpen &&
           open &&
+          !disabled &&
           createPortal(
             TooltipEl,
             portalContainer ?? rootElement ?? document.body,


### PR DESCRIPTION
## Summary
This PR adds a `disabled` prop to the **Tooltip** component, making it possible to turn off tooltips programmatically.  
Without this, developers need to wrap tooltips in conditional logic, which can add extra noise especially in larger JSX blocks:

```jsx
{isDisabled ? (
  <button>Save</button>
) : (
  <Tooltip content="Save changes">
    <button>Save</button>
  </Tooltip>
)}
```

This approach works, but it makes the code a bit harder to scan at a glance. With the new prop, the intent is clearer and the code stays more concise:

```jsx
<Tooltip content="Save changes" disabled={isDisabled}>
  <button>Save</button>
</Tooltip>
```