### PR TITLE
feat: allow option-label prop to be used without type of object

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -543,14 +543,12 @@ function AutocompleteInner<T>(
         return ''
       }
 
-      if (typeof item === 'object') {
-        if (optionLabel) {
-          return optionLabel(item)
-        } else {
-          throw new Error(
-            'Missing label. When using objects for options make sure to define the `optionLabel` property',
-          )
-        }
+      if (optionLabel) {
+        return optionLabel(item)
+      } else if (typeof item === 'object') {
+        throw new Error(
+          'Missing label. When using objects for options make sure to define the `optionLabel` property',
+        )
       }
 
       if (typeof item === 'string') {


### PR DESCRIPTION
## What does this pull request change?

This pull request changes the internal behaviour of the `Autocomplete` component so that the `optionLabel` callback is called even though the options are typeof `number` or `string` and not only `object`.

## Why is this pull request necessary?

This would allow formatting the label without having to map from/to objects.