### PR TITLE
Don't call onOptionsChange when clicking "Add new"

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.tsx
@@ -669,6 +669,7 @@ function AutocompleteInner<T>(
     comboBoxProps = {
       ...comboBoxProps,
       onSelectedItemChange: (changes) => {
+        if (changes.selectedItem === AddSymbol) return
         if (onOptionsChange) {
           let { selectedItem } = changes
           if (itemCompare) {


### PR DESCRIPTION
This PR fixes a bug where the `onOptionsChange` callback was incorrectly triggered in single-select mode when the "Add new option" button was clicked.
