### PR TITLE
ci: fix CI workflow for new apps/ directory

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
     with:
       cacheKey: ${{ github.sha }}
-      checkout_paths: packages
+      checkout_paths: packages apps
   packages:
     name: Process packages
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,13 +5,8 @@ on:
     branches:
       - develop
     paths:
-      - 'packages/eds-core-react/**'
-      - 'packages/eds-lab-react/**'
-      - 'packages/eds-data-grid-react/**'
-      - 'packages/eds-tokens-sync/**'
-      - 'packages/eds-tokens-build/**'
-      - 'packages/eds-tokens/**'
-      - 'packages/eds-icons/**'
+      - 'apps/**'
+      - 'packages/**'
   push:
     branches:
       - develop


### PR DESCRIPTION
Updates GitHub Actions to trigger on changes in the new `apps/` folder.

**Changes:**
- Add `apps/**` to workflow trigger paths
- Simplify package paths from specific packages to `packages/**`
- Update checkout configuration to include both `packages` and `apps`

Ensures all PR checks run properly for both existing packages and new apps.

resolves #3949 