### PR TITLE
fix(eds-core-react): 🐛 add Banner.Content to resolve HTML nesting warnings

### DIFF
--- a/packages/eds-core-react/src/components/Banner/Banner.docs.mdx
+++ b/packages/eds-core-react/src/components/Banner/Banner.docs.mdx
@@ -67,19 +67,19 @@ Banners can supplement their message using a supporting icon.
 
 <Canvas of={ComponentStories.TextAndIconAndAction} />
 
-### Complex Banner Message (special cases)
+### Complex Banner Content (special cases)
 
-While using string content for Banner.Message is the recommended approach for most use cases, there are situations where more complex content might be necessary. For these special cases, Banner.Message now supports ReactNode children.
+While using string content for Banner.Message is the recommended approach for most use cases, there are situations where more complex content might be necessary. For these special cases, Banner.Content is created to support ReactNode children.
 
 <ul>
   <li>Use string content for Banner.Message whenever possible to maintain consistency and proper styling.</li>
-  <li>Only use ReactNode when you have specific requirements that cannot be met with string content.</li>
-  <li>When using ReactNode content, be mindful of accessibility, responsive behavior, and Equinor design guidelines.</li>
+  <li>Only use Banner.Content when you have specific requirements that cannot be met with string content.</li>
+  <li>When using Banner.Content, be mindful of accessibility, responsive behavior, and Equinor design guidelines.</li>
 </ul>
 
-Some examples where ReactNode might be appropriate:
+Some examples where Banner.Content might be appropriate:
 - Content requiring specific formatting (bold text, code elements)
 - Content with structured information that benefits from hierarchical display
 - Content with links
 
-<Canvas of={ComponentStories.ComplexBannerMessage} />
+<Canvas of={ComponentStories.ComplexBannerContent} />

--- a/packages/eds-core-react/src/components/Banner/Banner.stories.tsx
+++ b/packages/eds-core-react/src/components/Banner/Banner.stories.tsx
@@ -1,6 +1,6 @@
 import { StoryFn, Meta } from '@storybook/react'
 import { Stack } from '../../../.storybook/components/'
-import { Banner, Icon, Button, BannerProps } from '../..'
+import { Banner, Icon, Button, BannerProps, Typography } from '../..'
 import { save, thumbs_up, thumbs_down, mood_sad } from '@equinor/eds-icons'
 import page from './Banner.docs.mdx'
 
@@ -51,8 +51,7 @@ export const Introduction: StoryFn<BannerProps> = (args) => {
   return (
     <Banner {...args}>
       <Banner.Message>
-        This tag is not being preserved yet. Click start preservation to enable
-        writing preservation records.
+        <Typography variant="h6">This is a test</Typography>
       </Banner.Message>
     </Banner>
   )
@@ -134,33 +133,34 @@ export const TextAndIconAndAction: StoryFn<BannerProps> = () => (
   </>
 )
 TextAndIconAndAction.storyName = 'Text and icon and actions'
-
-export const ComplexBannerMessage: StoryFn<BannerProps> = () => (
+export const ComplexBannerContent: StoryFn<BannerProps> = () => (
   <>
     <Banner>
       <Banner.Icon variant="warning">
         <Icon name="thumbs_down" />
       </Banner.Icon>
-      <Banner.Message>
-        <div>
-          <strong>Important update required</strong>
-          <p style={{ margin: '4px 0' }}>
-            Your project contains{' '}
-            <a href="#deprecated">3 deprecated components</a> that need to be
-            updated before June 2025.
-          </p>
-          <code
-            style={{
-              background: '#f5f5f5',
-              padding: '2px 4px',
-              borderRadius: '2px',
-              fontSize: '0.9em',
-            }}
-          >
-            ComponentA, ComponentB, ComponentC
-          </code>
-        </div>
-      </Banner.Message>
+      <Banner.Content>
+        <Typography variant="body_short" style={{ fontWeight: 'bold' }}>
+          Important update required
+        </Typography>
+        <Typography variant="body_long" style={{ margin: '4px 0' }}>
+          Your project contains{' '}
+          <a href="#deprecated">3 deprecated components</a> that need to be
+          updated before June 2025.
+        </Typography>
+        <Typography
+          variant="caption"
+          style={{
+            background: '#f5f5f5',
+            padding: '2px 4px',
+            borderRadius: '2px',
+            display: 'inline-block',
+            fontFamily: 'monospace',
+          }}
+        >
+          ComponentA, ComponentB, ComponentC
+        </Typography>
+      </Banner.Content>
       <Banner.Actions>
         <Button>View details</Button>
       </Banner.Actions>
@@ -170,19 +170,40 @@ export const ComplexBannerMessage: StoryFn<BannerProps> = () => (
       <Banner.Icon>
         <Icon name="thumbs_up" />
       </Banner.Icon>
-      <Banner.Message>
-        <div>
+      <Banner.Content>
+        <Typography variant="body_long">
           Project status:{' '}
-          <span style={{ color: 'green', fontWeight: 'bold' }}>Active</span>
-          <ul style={{ margin: '4px 0', paddingLeft: '20px' }}>
-            <li>Last updated: May 15, 2025</li>
-            <li>Contributors: 8</li>
-            <li>
-              Health check: <span style={{ color: 'green' }}>Passing</span>
-            </li>
-          </ul>
-        </div>
-      </Banner.Message>
+          <Typography
+            variant="body_long"
+            as="span"
+            style={{ color: 'green', fontWeight: 'bold' }}
+          >
+            Active
+          </Typography>
+        </Typography>
+        <Typography
+          variant="body_long"
+          as="ul"
+          style={{ margin: '4px 0', paddingLeft: '20px' }}
+        >
+          <Typography variant="body_long" as="li">
+            Last updated: May 15, 2025
+          </Typography>
+          <Typography variant="body_long" as="li">
+            Contributors: 8
+          </Typography>
+          <Typography variant="body_long" as="li">
+            Health check:{' '}
+            <Typography
+              variant="body_long"
+              as="span"
+              style={{ color: 'green' }}
+            >
+              Passing
+            </Typography>
+          </Typography>
+        </Typography>
+      </Banner.Content>
       <Banner.Actions>
         <Button>View dashboard</Button>
         <Button variant="outlined">Export report</Button>
@@ -190,4 +211,4 @@ export const ComplexBannerMessage: StoryFn<BannerProps> = () => (
     </Banner>
   </>
 )
-ComplexBannerMessage.storyName = 'Complex Banner Message'
+ComplexBannerContent.storyName = 'Complex Banner Content'

--- a/packages/eds-core-react/src/components/Banner/Banner.stories.tsx
+++ b/packages/eds-core-react/src/components/Banner/Banner.stories.tsx
@@ -51,7 +51,8 @@ export const Introduction: StoryFn<BannerProps> = (args) => {
   return (
     <Banner {...args}>
       <Banner.Message>
-        <Typography variant="h6">This is a test</Typography>
+        This tag is not being preserved yet. Click start preservation to enable
+        writing preservation records.
       </Banner.Message>
     </Banner>
   )

--- a/packages/eds-core-react/src/components/Banner/BannerContent.tsx
+++ b/packages/eds-core-react/src/components/Banner/BannerContent.tsx
@@ -1,0 +1,16 @@
+import { forwardRef, ReactNode } from 'react'
+
+export type BannerContentProps = {
+  /** Complex content with any HTML elements */
+  children: ReactNode
+} & React.HTMLAttributes<HTMLDivElement>
+
+export const BannerContent = forwardRef<HTMLDivElement, BannerContentProps>(
+  function BannerContent({ children, ...rest }, ref) {
+    return (
+      <div ref={ref} {...rest}>
+        {children}
+      </div>
+    )
+  },
+)

--- a/packages/eds-core-react/src/components/Banner/index.ts
+++ b/packages/eds-core-react/src/components/Banner/index.ts
@@ -2,26 +2,31 @@ import { Banner as BaseBanner, BannerProps } from './Banner'
 import { BannerIcon, BannerIconProps } from './BannerIcon'
 import { BannerMessage, BannerMessageProps } from './BannerMessage'
 import { BannerActions, BannerActionsProps } from './BannerActions'
+import { BannerContent, BannerContentProps } from './BannerContent'
 
 type BannerCompoundProps = typeof BaseBanner & {
   Icon: typeof BannerIcon
   Message: typeof BannerMessage
   Actions: typeof BannerActions
+  Content: typeof BannerContent
 }
 
 const Banner = BaseBanner as BannerCompoundProps
 Banner.Icon = BannerIcon
 Banner.Message = BannerMessage
 Banner.Actions = BannerActions
+Banner.Content = BannerContent
 
 Banner.Icon.displayName = 'Banner.Icon'
 Banner.Message.displayName = 'Banner.Message'
 Banner.Actions.displayName = 'Banner.Actions'
+Banner.Content.displayName = 'Banner.Content'
 
-export { Banner, BannerIcon, BannerMessage, BannerActions }
+export { Banner, BannerIcon, BannerMessage, BannerActions, BannerContent }
 export type {
   BannerProps,
   BannerMessageProps,
   BannerIconProps,
   BannerActionsProps,
+  BannerContentProps,
 }


### PR DESCRIPTION
resolves #3888 

- Creates `Banner.Content` component for complex content with headers, lists etc. 
- `Banner.Message` unchanged, maintains backward compatibility
- Resolves validateDOMNesting errors