### PR TITLE
add markdown-mermaid extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,7 +53,8 @@
         "ionutvmi.path-autocomplete",
         "jock.svg",
         "github.vscode-pull-request-github",
-        "ms-azuretools.vscode-bicep"
+        "ms-azuretools.vscode-bicep",
+        "bierner.markdown-mermaid"
       ]
     }
   },


### PR DESCRIPTION
For enhanced diagram support. Extension enables working with and reading mermaid diagrams in markdown previews (mermaid codeblocks).