### PR TITLE
Improve nginx SPA fallback for docs deep links

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,12 +13,12 @@ server {
 
     # SPA routing: serve index.html for all non-file paths
     location / {
-        try_files $uri $uri/ /index.html;
-        
-        # Don't cache index.html to ensure updates are reflected
-        location = /index.html {
-            add_header Cache-Control "no-store, no-cache, must-revalidate";
-        }
+        try_files $uri $uri/ $uri.html /index.html;
+    }
+
+    # Don't cache index.html to ensure updates are reflected
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
     # Cache other static assets (images, fonts, etc.)


### PR DESCRIPTION
## Summary
- update the nginx SPA fallback to also check for `$uri.html`
- move the `index.html` cache-control rule out of the nested `location` block so nginx applies it correctly

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c90a7d26148324b90efd987db0f7f2