### PR TITLE
Avoid leaking container port in nginx redirects

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,13 @@ server {
     listen 3000;
     server_name _;
 
+    # Ensure redirects (like the automatic trailing slash redirects) stay on
+    # the public origin instead of pointing clients back to the internal
+    # container port. Without this Radix would issue redirects to
+    # `:3000`, and browsers would time out because that port isn't exposed.
+    absolute_redirect off;
+    port_in_redirect off;
+
     root /usr/share/nginx/html;
     index index.html index.htm;
 
@@ -13,12 +20,12 @@ server {
 
     # SPA routing: serve index.html for all non-file paths
     location / {
-        try_files $uri $uri/ /index.html;
-        
-        # Don't cache index.html to ensure updates are reflected
-        location = /index.html {
-            add_header Cache-Control "no-store, no-cache, must-revalidate";
-        }
+        try_files $uri $uri/ $uri.html /index.html;
+    }
+
+    # Don't cache index.html to ensure updates are reflected
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
     # Cache other static assets (images, fonts, etc.)


### PR DESCRIPTION
## Summary
- ensure nginx keeps redirect targets on the public origin instead of forwarding clients to :3000

## Testing
- not run (config-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c90a7d26148324b90efd987db0f7f2