### PR TITLE
fix(eds-core-react): sidebar links not showing tooltip when sidebar is collapsed

### DIFF
--- a/packages/eds-core-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/eds-core-react/src/components/Tooltip/Tooltip.tsx
@@ -190,8 +190,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
 
     const updatedChildren = cloneElement(children, {
       ...getReferenceProps({
-        ref: anchorRef,
         ...children.props,
+        ref: anchorRef,
       }),
     })
 


### PR DESCRIPTION
This PR fixes an issue after upgrading to React 19, where tooltips no longer appear on **Sidebar Links**.

In React 18, `children.props.ref` was **undefined**, but in React 19, it’s now explicitly set to **null**.  
Because of this change, when spreading `children.props` before adding the `anchorRef`, the `null` ref from `children.props` overwrites the intended `anchorRef`.