### PR TITLE
fix: DatePicker Esc Key Closing Entire Dialog

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/fields/FieldWrapper.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/FieldWrapper.tsx
@@ -191,6 +191,7 @@ export const FieldWrapper = forwardRef(
           onClose={() => setIsOpen(false)}
           onKeyDown={(e) => {
             if (e.key !== 'Escape') return
+            e.stopPropagation()
             e.preventDefault()
           }}
           anchorEl={anchorEl}

--- a/packages/eds-core-react/src/components/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/Dialog/Dialog.tsx
@@ -94,7 +94,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
     if (e.key !== 'Escape') return
     e.preventDefault()
     if (isDismissable && onClose && open) {
-      onClose && onClose()
+      onClose()
     }
   }
 


### PR DESCRIPTION

This PR fixes an issue reported by a user:

If a user opens a DatePicker popover inside a dialog and then presses `Esc` to close it, the whole dialog would close instead of just the DatePicker popover.

This PR fixes the issue by:  
- Switching from using a global hotkey for closing the dialog to a local key event.  
- Ensuring that the popover's `Esc` key event does not bubble up to the dialog.  
