### PR TITLE
fix: expand release-please exclude-paths to prevent false releases

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,7 +7,26 @@
       "release-type": "node",
       "package-name": "@equinor/eds-core-react",
       "component": "eds-core-react",
-      "exclude-paths": ["src/components/next"]
+      "exclude-paths": [
+        "src/components/next",
+        ".storybook",
+        "stories",
+        "tests",
+        ".gitignore",
+        ".cachebust",
+        "rollup.config.js",
+        "jest.config.cjs",
+        "jest.setup.ts",
+        "tsconfig.json",
+        "tsconfig.build.json",
+        "tsconfig.test.json",
+        "playwright.config.ts",
+        "Dockerfile.storybook",
+        "nginx.conf",
+        "README.md",
+        "FIGMA_CODE_CONNECT.md",
+        "figma.config.json"
+      ]
     },
     "packages/eds-core-react/src/components/next": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary

Expands `exclude-paths` for `eds-core-react` to prevent tooling/config changes from triggering releases.

**Problem:** PR #4332 (Field + HelperMessage) triggered a release for both `eds-core-react` and `eds-core-react-next`, even though Field is only exported from the beta package. This happened because the commit touched files outside `src/components/next/` (like `.storybook/`, `rollup.config.js`).

**Solution:** Exclude all infrastructure/tooling files that don't affect the published runtime code:
- `.storybook/`, `stories/`, `tests/` - documentation/testing
- Config files (`rollup`, `jest`, `tsconfig`, `playwright`, etc.)
- Docs (`README.md`, `FIGMA_CODE_CONNECT.md`)
- Other tooling (`.gitignore`, `.cachebust`, `nginx.conf`, `Dockerfile.storybook`)

Only changes to `src/` (excluding `next/`) and `package.json` should trigger a release.