### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # Allow manual triggering from Actions tab
 
 # Permissions required for release-please to function
 permissions:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to the Release Please workflow, allowing manual triggering from the Actions tab.

**Why:** Sometimes release-please needs to be re-run after config changes (like updating `exclude-paths`), but the workflow only triggers on push to main. This makes it possible to manually trigger a new run without needing a dummy commit.