### PR TITLE
feat: Radio 2.0  component

### DIFF
--- a/packages/eds-core-react/src/components/next/Radio/Radio.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.figma.tsx
@@ -1,0 +1,16 @@
+import figma from '@figma/code-connect'
+import { Radio } from './Radio'
+
+figma.connect(
+  Radio,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=112-6322',
+  {
+    props: {
+      label: figma.string('Label'),
+      disabled: figma.boolean('Disabled'),
+    },
+    example: ({ label, disabled }) => (
+      <Radio label={label} disabled={disabled} name="radio-group" />
+    ),
+  },
+)

--- a/packages/eds-core-react/src/components/next/Radio/Radio.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.stories.tsx
@@ -1,0 +1,279 @@
+import { useState } from 'react'
+import type { ChangeEvent, ReactNode } from 'react'
+import { StoryFn, Meta } from '@storybook/react-vite'
+import { Stack } from './../../../../.storybook/components'
+import { Radio } from './Radio'
+import type { RadioProps } from './Radio.types'
+
+const meta: Meta<typeof Radio> = {
+  title: 'EDS 2.0 (beta)/Inputs/Selection Controls/Radio',
+  component: Radio,
+  args: {
+    label: 'Option',
+    disabled: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+
+\`\`\`bash
+npm install @equinor/eds-core-react@beta
+\`\`\`
+
+\`\`\`tsx
+import { Radio } from '@equinor/eds-core-react/next'
+
+// Radio group
+<fieldset>
+  <legend>Select option</legend>
+  <Radio label="Option 1" name="group" value="1" />
+  <Radio label="Option 2" name="group" value="2" />
+</fieldset>
+
+// Without visible label (use aria-label)
+<Radio aria-label="Select row" name="table-row" />
+\`\`\`
+
+Radio buttons allow users to select one option from a set. Always use within a group with the same \`name\` attribute.
+`,
+      },
+      source: {
+        excludeDecorators: true,
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Label text displayed next to the radio button',
+      table: {
+        category: 'Core',
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables radio button interaction',
+      table: {
+        category: 'States',
+        defaultValue: { summary: 'false' },
+      },
+    },
+    checked: {
+      control: 'boolean',
+      description: 'Controlled checked state',
+      table: {
+        category: 'States',
+      },
+    },
+    defaultChecked: {
+      control: 'boolean',
+      description: 'Initial checked state for uncontrolled usage',
+      table: {
+        category: 'States',
+      },
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS class names for the input element',
+      table: {
+        category: 'Styling',
+      },
+    },
+    id: {
+      control: 'text',
+      description: 'HTML id attribute',
+      table: {
+        category: 'HTML Attributes',
+      },
+    },
+    name: {
+      control: 'text',
+      description: 'HTML name attribute for form submission',
+      table: {
+        category: 'HTML Attributes',
+      },
+    },
+    value: {
+      control: 'text',
+      description: 'HTML value attribute for form submission',
+      table: {
+        category: 'HTML Attributes',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Stack>
+        <Story />
+      </Stack>
+    ),
+  ],
+}
+
+export default meta
+
+const Wrapper = ({
+  children,
+  gap = 16,
+  ...rest
+}: {
+  children: ReactNode
+  gap?: number
+} & React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: `${gap}px`,
+      alignItems: 'flex-start',
+    }}
+    {...rest}
+  >
+    {children}
+  </div>
+)
+
+const AllVariants = ({ prefix = 'default' }: { prefix?: string }) => (
+  <>
+    <Radio label="Unchecked" name={`${prefix}-unchecked`} value="unchecked" />
+    <Radio
+      label="Checked"
+      name={`${prefix}-checked`}
+      value="checked"
+      defaultChecked
+    />
+    <Radio label="Disabled" name={`${prefix}-disabled`} disabled />
+    <Radio
+      label="Disabled checked"
+      name={`${prefix}-disabled-checked`}
+      disabled
+      defaultChecked
+    />
+  </>
+)
+
+export const Introduction: StoryFn<RadioProps> = (args) => {
+  return <Radio {...args} />
+}
+
+export const Spacious: StoryFn<RadioProps> = () => (
+  <Wrapper data-density="spacious">
+    <AllVariants prefix="spacious" />
+  </Wrapper>
+)
+
+export const Comfortable: StoryFn<RadioProps> = () => (
+  <Wrapper data-density="comfortable">
+    <AllVariants prefix="comfortable" />
+  </Wrapper>
+)
+
+export const ColorSchemes: StoryFn<RadioProps> = () => (
+  <div style={{ display: 'flex', gap: '32px' }}>
+    <div
+      data-color-scheme="light"
+      style={{ padding: '24px', background: 'var(--eds-color-bg-canvas)' }}
+    >
+      <Wrapper>
+        <h3 style={{ margin: 0 }}>Light Mode</h3>
+        <Radio label="Unchecked" name="light" value="unchecked" />
+        <Radio label="Checked" name="light" value="checked" defaultChecked />
+        <Radio label="Disabled" name="light-disabled" disabled />
+        <Radio
+          label="Disabled checked"
+          name="light-disabled-checked"
+          disabled
+          defaultChecked
+        />
+      </Wrapper>
+    </div>
+    <div
+      data-color-scheme="dark"
+      style={{ padding: '24px', background: 'var(--eds-color-bg-canvas)' }}
+    >
+      <Wrapper>
+        <h3 style={{ margin: 0, color: 'var(--eds-color-text-strong)' }}>
+          Dark Mode
+        </h3>
+        <Radio label="Unchecked" name="dark" value="unchecked" />
+        <Radio label="Checked" name="dark" value="checked" defaultChecked />
+        <Radio label="Disabled" name="dark-disabled" disabled />
+        <Radio
+          label="Disabled checked"
+          name="dark-disabled-checked"
+          disabled
+          defaultChecked
+        />
+      </Wrapper>
+    </div>
+  </div>
+)
+ColorSchemes.storyName = 'Light & Dark Mode'
+
+export const GroupedRadio: StoryFn<RadioProps> = () => (
+  <fieldset>
+    <legend>Select your option</legend>
+    <Wrapper gap={8}>
+      <Radio label="Option 1" name="group" value="1" />
+      <Radio label="Option 2" name="group" value="2" />
+      <Radio label="Option 3" name="group" value="3" />
+    </Wrapper>
+  </fieldset>
+)
+GroupedRadio.parameters = {
+  docs: {
+    description: {
+      story:
+        'Radio buttons with the same `name` form a group. Use arrow keys (↑↓ or ←→) to navigate and select within the group.',
+    },
+  },
+}
+
+export const WithoutVisibleLabel: StoryFn<RadioProps> = () => (
+  <div style={{ display: 'flex', gap: '32px', alignItems: 'flex-start' }}>
+    <div data-density="spacious">
+      <p style={{ margin: '0 0 8px' }}>Spacious</p>
+      <Radio aria-label="Spacious radio" name="standalone-spacious" />
+    </div>
+    <div data-density="comfortable">
+      <p style={{ margin: '0 0 8px' }}>Comfortable</p>
+      <Radio aria-label="Comfortable radio" name="standalone-comfortable" />
+    </div>
+  </div>
+)
+WithoutVisibleLabel.parameters = {
+  docs: {
+    description: {
+      story:
+        'When no visible label is needed, use `aria-label` to provide an accessible name for screen readers.',
+    },
+  },
+}
+
+export const Controlled: StoryFn<RadioProps> = () => {
+  const [selected, setSelected] = useState('option1')
+  return (
+    <Wrapper>
+      <Radio
+        label="Option 1"
+        name="controlled"
+        value="option1"
+        checked={selected === 'option1'}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setSelected(e.target.value)
+        }
+      />
+      <Radio
+        label="Option 2"
+        name="controlled"
+        value="option2"
+        checked={selected === 'option2'}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setSelected(e.target.value)
+        }
+      />
+      <p>Selected: {selected}</p>
+    </Wrapper>
+  )
+}

--- a/packages/eds-core-react/src/components/next/Radio/Radio.test.tsx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.test.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { Radio } from './Radio'
+
+type ControlledProps = {
+  onChange: () => void
+}
+
+const ControlledRadio = ({ onChange }: ControlledProps) => {
+  const [selected, setSelected] = useState('option1')
+  return (
+    <>
+      <Radio
+        label="Option 1"
+        id="controlled-1"
+        name="controlled"
+        value="option1"
+        checked={selected === 'option1'}
+        onChange={(e) => {
+          setSelected(e.target.value)
+          onChange()
+        }}
+      />
+      <Radio
+        label="Option 2"
+        id="controlled-2"
+        name="controlled"
+        value="option2"
+        checked={selected === 'option2'}
+        onChange={(e) => {
+          setSelected(e.target.value)
+          onChange()
+        }}
+      />
+    </>
+  )
+}
+
+describe('Radio (next)', () => {
+  it('matches snapshot', () => {
+    const { asFragment } = render(<Radio label="radio" name="test" />)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  describe('Rendering', () => {
+    it('renders with provided label', () => {
+      const label = 'Radio label'
+      render(<Radio label={label} name="test" />)
+      const inputNode = screen.getByLabelText(label)
+      expect(inputNode).toBeInTheDocument()
+    })
+
+    it('renders without visible label using aria-label', () => {
+      render(<Radio aria-label="No visible label" name="test" />)
+      const radio = screen.getByLabelText('No visible label')
+      expect(radio).toBeInTheDocument()
+    })
+
+    it('extends css with custom className and style', () => {
+      render(
+        <Radio
+          label="radio-test"
+          name="test"
+          className="custom-radio"
+          style={{ clipPath: 'unset' }}
+        />,
+      )
+      const radio = screen.getByLabelText('radio-test')
+      expect(radio).toBeInTheDocument()
+      expect(radio).toHaveClass('custom-radio')
+    })
+
+    it('applies data-* attributes to input element', () => {
+      render(
+        <Radio
+          label="Test Label"
+          name="test"
+          data-testid="test-radio"
+          data-analytics="track-radio"
+        />,
+      )
+
+      const input = screen.getByRole('radio')
+      expect(input).toHaveAttribute('data-testid', 'test-radio')
+      expect(input).toHaveAttribute('data-analytics', 'track-radio')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('passes axe accessibility test', async () => {
+      const { container } = render(<Radio label="radio-test" name="test" />)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('passes axe accessibility test with external label', async () => {
+      const { container } = render(
+        <>
+          <label htmlFor="radio">Label text</label>
+          <Radio id="radio" name="test" />
+        </>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+
+  describe('Interaction', () => {
+    it('can be selected', () => {
+      const labelText = 'Radio label'
+      render(<Radio label={labelText} name="test" />)
+      const radio = screen.getByLabelText(labelText)
+      expect(radio).not.toBeChecked()
+      fireEvent.click(radio)
+      expect(radio).toBeChecked()
+    })
+
+    it('works as a controlled component', () => {
+      const handleChange = jest.fn()
+      render(<ControlledRadio onChange={handleChange} />)
+      const radio1 = screen.getByLabelText('Option 1')
+      const radio2 = screen.getByLabelText('Option 2')
+
+      expect(radio1).toBeChecked()
+      expect(radio2).not.toBeChecked()
+      expect(handleChange).toHaveBeenCalledTimes(0)
+
+      fireEvent.click(radio2)
+      expect(radio1).not.toBeChecked()
+      expect(radio2).toBeChecked()
+      expect(handleChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('cannot be clicked when disabled', async () => {
+      render(
+        <div>
+          <Radio label="Radio one" name="test" disabled />
+        </div>,
+      )
+      const one = screen.getByLabelText('Radio one')
+      expect(one).not.toBeChecked()
+      await userEvent.click(one)
+      expect(one).not.toBeChecked()
+    })
+  })
+
+  describe('States', () => {
+    it('applies disabled attribute to wrapper', () => {
+      render(<Radio label="Disabled radio" name="test" disabled />)
+      const radio = screen.getByLabelText('Disabled radio')
+      // eslint-disable-next-line testing-library/no-node-access
+      const label = radio.closest('.eds-radio')
+      expect(label).toHaveAttribute('data-disabled', 'true')
+    })
+  })
+
+  describe('Radio group behavior', () => {
+    it('only one radio in a group can be selected', () => {
+      render(
+        <>
+          <Radio label="Option 1" id="group-1" name="group" value="1" />
+          <Radio label="Option 2" id="group-2" name="group" value="2" />
+          <Radio label="Option 3" id="group-3" name="group" value="3" />
+        </>,
+      )
+
+      const option1 = screen.getByLabelText('Option 1')
+      const option2 = screen.getByLabelText('Option 2')
+      const option3 = screen.getByLabelText('Option 3')
+
+      fireEvent.click(option1)
+      expect(option1).toBeChecked()
+      expect(option2).not.toBeChecked()
+      expect(option3).not.toBeChecked()
+
+      fireEvent.click(option2)
+      expect(option1).not.toBeChecked()
+      expect(option2).toBeChecked()
+      expect(option3).not.toBeChecked()
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Radio/Radio.tsx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.tsx
@@ -1,0 +1,74 @@
+/* eslint camelcase: "off" */
+import { forwardRef, useId } from 'react'
+import {
+  radio_button_selected,
+  radio_button_unselected,
+} from '@equinor/eds-icons'
+import { Field } from '../Field'
+import { Icon } from '../Icon'
+import type { RadioProps } from './Radio.types'
+
+const classNames = (...classes: (string | boolean | undefined)[]) =>
+  classes.filter(Boolean).join(' ')
+
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
+  { label, disabled = false, id: providedId, ...rest },
+  ref,
+) {
+  const generatedId = useId()
+  const inputId = providedId ?? generatedId
+
+  const radioInput = (
+    <>
+      <input
+        type="radio"
+        id={inputId}
+        className="eds-radio__input"
+        disabled={disabled}
+        ref={ref}
+        {...rest}
+      />
+      <span className="eds-radio__icon-wrapper">
+        <Icon
+          data={radio_button_selected}
+          size="lg"
+          className="eds-radio__icon eds-radio__icon--checked"
+        />
+        <Icon
+          data={radio_button_unselected}
+          size="lg"
+          className="eds-radio__icon eds-radio__icon--unchecked"
+        />
+      </span>
+    </>
+  )
+
+  // Use Field for layout when label is provided
+  if (label) {
+    return (
+      <Field
+        position="start"
+        disabled={disabled}
+        className="eds-radio"
+        data-color-appearance={disabled ? 'neutral' : 'accent'}
+        data-selectable-space="md"
+        data-space-proportions="squished"
+      >
+        {radioInput}
+        <Field.Label htmlFor={inputId}>{label}</Field.Label>
+      </Field>
+    )
+  }
+
+  return (
+    <span
+      className={classNames('eds-radio', 'eds-radio--standalone')}
+      data-color-appearance={disabled ? 'neutral' : 'accent'}
+      data-disabled={disabled || undefined}
+    >
+      {radioInput}
+    </span>
+  )
+})
+
+Radio.displayName = 'Radio'

--- a/packages/eds-core-react/src/components/next/Radio/Radio.types.ts
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.types.ts
@@ -1,0 +1,6 @@
+import type { InputHTMLAttributes, ReactNode } from 'react'
+
+export type RadioProps = {
+  /** Label for the radio button */
+  label?: ReactNode
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>

--- a/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Radio (next) matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="eds-field eds-radio"
+    data-color-appearance="accent"
+    data-position="start"
+    data-selectable-space="md"
+    data-space-proportions="squished"
+  >
+    <input
+      class="eds-radio__input"
+      id="test-id"
+      name="test"
+      type="radio"
+    />
+    <span
+      class="eds-radio__icon-wrapper"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon eds-radio__icon eds-radio__icon--checked"
+        data-icon-size="lg"
+        data-testid="eds-icon"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m-5-8a5 5 0 1 1 10 0 5 5 0 0 1-10 0"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="icon eds-radio__icon eds-radio__icon--unchecked"
+        data-icon-size="lg"
+        data-testid="eds-icon"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M2 12C2 6.48 6.48 2 12 2s10 4.48 10 10-4.48 10-10 10S2 17.52 2 12m2 0c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8-8 3.58-8 8"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </span>
+    <label
+      class="eds-field__label"
+      data-baseline="center"
+      data-font-family="ui"
+      data-font-size="lg"
+      data-font-weight="normal"
+      data-line-height="default"
+      data-tracking="normal"
+      for="test-id"
+    >
+      radio
+    </label>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/eds-core-react/src/components/next/Radio/index.ts
+++ b/packages/eds-core-react/src/components/next/Radio/index.ts
@@ -1,0 +1,2 @@
+export { Radio } from './Radio'
+export type { RadioProps } from './Radio.types'

--- a/packages/eds-core-react/src/components/next/Radio/radio.css
+++ b/packages/eds-core-react/src/components/next/Radio/radio.css
@@ -1,0 +1,152 @@
+@layer eds-components {
+  .eds-radio {
+    --_radio-icon-color: var(--eds-color-bg-fill-emphasis-default);
+    --_radio-hover-color: var(--eds-color-bg-fill-muted-default);
+    --_radio-icon-size: var(--eds-sizing-icon-lg);
+    /* Touch target: 36px spacious, 28px comfortable */
+    --_radio-touch-target: 2.25rem;
+    cursor: pointer;
+    position: relative;
+    box-sizing: border-box;
+  }
+
+  [data-density='comfortable'] .eds-radio {
+    --_radio-touch-target: 1.75rem;
+  }
+
+  .eds-radio--standalone {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    /* Padding calculated from touch target and icon size */
+    padding: calc((var(--_radio-touch-target) - var(--_radio-icon-size)) / 2);
+  }
+
+  .eds-field.eds-radio {
+    /*
+     * Gap must compensate for icon-wrapper negative margin (-4.8px inline).
+     * This negative margin matches Figma's icon container padding for optical alignment.
+     * Compensation: 4.8px (margin) + 2px (visual balance) ≈ 6.8px (0.425rem)
+     */
+    --_radio-gap-compensation: 0.425rem;
+    gap: calc(
+      var(--eds-generic-gap-horizontal) + var(--_radio-gap-compensation)
+    );
+    padding-inline: var(--eds-selectable-space-horizontal);
+    padding-block: var(--eds-selectable-space-vertical);
+    width: auto;
+    border-radius: var(--eds-spacing-border-radius-rounded);
+    transition: background-color 150ms;
+  }
+
+  .eds-radio[data-disabled='true'] {
+    cursor: not-allowed;
+  }
+
+  .eds-radio__icon-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    flex-shrink: 0;
+    overflow: visible;
+    line-height: 0;
+  }
+
+  /* Negative margin matches Figma icon container padding */
+  .eds-field.eds-radio .eds-radio__icon-wrapper {
+    margin-block: -6px;
+    margin-inline: -4.8px;
+  }
+
+  .eds-radio--standalone::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: var(--eds-spacing-border-radius-pill);
+    background-color: transparent;
+    transition: background-color 150ms;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .eds-radio--standalone:hover::before {
+      background-color: var(--_radio-hover-color);
+    }
+
+    .eds-radio--standalone[data-disabled='true']:hover::before {
+      background-color: transparent;
+    }
+
+    .eds-field.eds-radio:hover {
+      background-color: var(--_radio-hover-color);
+    }
+
+    .eds-field.eds-radio[data-disabled='true']:hover {
+      background-color: transparent;
+    }
+  }
+
+  .eds-radio__input {
+    appearance: none;
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  .eds-radio__input:disabled {
+    cursor: not-allowed;
+  }
+
+  .eds-radio__input:focus {
+    outline: none;
+  }
+
+  .eds-radio:has(.eds-radio__input:focus-visible) {
+    outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
+    outline-offset: var(--eds-sizing-stroke-thick);
+    border-radius: var(--eds-spacing-border-radius-rounded);
+  }
+
+  .eds-radio--standalone:has(.eds-radio__input:focus-visible) {
+    border-radius: var(--eds-spacing-border-radius-pill);
+  }
+
+  .eds-radio__icon {
+    pointer-events: none;
+    fill: var(--_radio-icon-color);
+    flex-shrink: 0;
+  }
+
+  .eds-radio[data-disabled='true'] .eds-radio__icon {
+    fill: var(--eds-color-border-medium);
+  }
+
+  /* Icon visibility */
+  .eds-radio__icon--checked {
+    display: none;
+  }
+
+  .eds-radio__icon--unchecked {
+    display: block;
+  }
+
+  .eds-radio:has(.eds-radio__input:checked) .eds-radio__icon--checked {
+    display: block;
+  }
+
+  .eds-radio:has(.eds-radio__input:checked) .eds-radio__icon--unchecked {
+    display: none;
+  }
+
+  .eds-field.eds-radio .eds-field__label {
+    cursor: pointer;
+  }
+
+  .eds-field.eds-radio[data-disabled='true'] .eds-field__label {
+    color: var(--eds-color-border-medium);
+    cursor: not-allowed;
+  }
+}

--- a/packages/eds-core-react/src/components/next/index.css
+++ b/packages/eds-core-react/src/components/next/index.css
@@ -1,7 +1,8 @@
 /* EDS 2.0 Next Components - CSS */
+/* Define layer order - eds-components has lowest priority for easy user overrides */
+@layer eds-components;
+
 @import '@equinor/eds-tokens/css/variables';
 @import './Field/field.css';
 @import './Checkbox/checkbox.css';
-
-/* Define layer order - eds-components has lowest priority for easy user overrides */
-@layer eds-components;
+@import './Radio/radio.css';

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -1,9 +1,12 @@
 export { Icon } from './Icon'
 export { Field, useFieldIds } from './Field'
 export { Checkbox } from './Checkbox'
+export { Radio } from './Radio'
 
 export type { IconProps, IconSize, IconData, IconName } from './Icon'
 export type { CheckboxProps } from './Checkbox'
+export type { RadioProps } from './Radio'
+
 export type {
   FieldProps,
   FieldLabelProps,


### PR DESCRIPTION
Closes #4358

## Summary
- Add Radio component to EDS 2.0 (`/next`)
- Vanilla CSS with BEM naming and EDS foundation tokens
- Full accessibility support, dark mode, and density modes
- Figma Code Connect mapping