### PR TITLE
feat: Button 2.0 component

### DIFF
--- a/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
@@ -1,0 +1,110 @@
+import { Primary, Canvas, Controls, Meta } from '@storybook/addon-docs/blocks'
+import * as ComponentStories from './Button.stories'
+
+<Meta of={ComponentStories} />
+
+# Button
+
+Button component for triggering actions.
+
+**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+
+```bash
+npm install @equinor/eds-core-react@beta
+```
+
+<Primary />
+<Controls />
+
+## Usage
+
+```tsx
+import { Button } from '@equinor/eds-core-react/next'
+import { Icon } from '@equinor/eds-core-react/next'
+import { add, chevron_right } from '@equinor/eds-icons'
+
+// Text only
+<Button variant="primary" tone="accent">
+  Submit
+</Button>
+
+// Icon before label
+<Button variant="secondary">
+  <Icon data={add} aria-hidden />
+  Add item
+</Button>
+
+// Icon after label
+<Button>
+  Next
+  <Icon data={chevron_right} aria-hidden />
+</Button>
+
+// Icon-only button (requires aria-label)
+<Button icon aria-label="Add item">
+  <Icon data={add} aria-hidden />
+</Button>
+
+// Circular icon-only button
+<Button icon round aria-label="Add item">
+  <Icon data={add} aria-hidden />
+</Button>
+```
+
+## Examples
+
+### Sizes
+
+Three sizes are available: `small` (24px spacious / 20px comfortable), `default` (36px spacious / 24px comfortable), and `large` (44px spacious / 36px comfortable).
+
+<Canvas of={ComponentStories.Sizes} />
+
+### Tones
+
+The `tone` prop controls the color scheme using `data-color-appearance`.
+
+<Canvas of={ComponentStories.Tones} />
+
+### With Icons
+
+Place an Icon before or after the text as a child.
+
+<Canvas of={ComponentStories.WithIconBefore} />
+<Canvas of={ComponentStories.WithIconAfter} />
+
+### Disabled States
+
+All variants support the disabled state.
+
+<Canvas of={ComponentStories.DisabledVariants} />
+
+### Danger Actions
+
+Use `tone="danger"` for destructive actions.
+
+<Canvas of={ComponentStories.DangerAction} />
+
+### Icon-Only Buttons
+
+Use the `icon` prop for icon-only buttons. They are square with uniform padding. Always provide `aria-label` for accessibility.
+
+<Canvas of={ComponentStories.IconOnly} />
+<Canvas of={ComponentStories.IconOnlyVariants} />
+
+### Circular Icon-Only Buttons
+
+Use `round` on icon-only buttons to create circular buttons.
+
+<Canvas of={ComponentStories.CircularIconOnly} />
+
+### Density Modes
+
+Comparison of all button sizes across density modes. Use `data-density` on a parent container to control density.
+
+<Canvas of={ComponentStories.DensityComparison} />
+
+### All Variants
+
+Complete overview of all variants, sizes, and color appearances.
+
+<Canvas of={ComponentStories.AllVariants} />

--- a/packages/eds-core-react/src/components/next/Button/Button.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.figma.tsx
@@ -1,0 +1,125 @@
+import figma from '@figma/code-connect'
+import { Button } from './Button'
+
+/**
+ * Code Connect mapping for Button component.
+ *
+ * Maps Figma design variants to React component props.
+ * Run `npx figma connect publish` from packages/eds-core-react/ to publish.
+ *
+ * Figma component structure:
+ * - Button [EDS] (18:1193) → .Geometry Options → ⌘ Button
+ * - Icon Button [EDS] (18:1373) → .Geometry Options → ⌘ Icon Button
+ */
+
+// ============================================
+// Connection 1: Button [EDS] (18:1193)
+// Top-level wrapper with Tone + nested geometry + nested button
+// ============================================
+
+figma.connect(
+  Button,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=18-1193',
+  {
+    props: {
+      tone: figma.enum('Tone', {
+        Accent: 'accent',
+        Neutral: 'neutral',
+        Danger: 'danger',
+      }),
+      geometry: figma.nestedProps('.Geometry Options', {
+        size: figma.enum('Size', {
+          Large: 'large',
+          Default: 'default',
+          Small: 'small',
+        }),
+      }),
+      inner: figma.nestedProps('⌘ Button', {
+        variant: figma.enum('Variant', {
+          Primary: 'primary',
+          Outline: 'secondary',
+          Ghost: 'ghost',
+        }),
+        disabled: figma.enum('State', {
+          Disabled: true,
+        }),
+        leadingIcon: figma.boolean('Show Leading Icon', {
+          true: figma.instance('Leading Icon Item'),
+          false: undefined,
+        }),
+        trailingIcon: figma.boolean('Show Trailing Icon', {
+          true: figma.instance('Trailing Icon Item'),
+          false: undefined,
+        }),
+        label: figma.string('Label'),
+      }),
+    },
+    example: ({ tone, geometry, inner }) => (
+      <Button
+        variant={inner.variant}
+        size={geometry.size}
+        tone={tone}
+        disabled={inner.disabled}
+      >
+        {/* TODO: Replace with actual icon components, when Icon component is
+        available in Code Connect */}
+        {inner.leadingIcon}
+        {inner.label}
+        {inner.trailingIcon}
+      </Button>
+    ),
+  },
+)
+
+// ============================================
+// Connection 2: Icon Button [EDS] (18:1373)
+// Top-level wrapper with Tone + nested geometry (includes Round) + nested icon button
+// ============================================
+
+figma.connect(
+  Button,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=18-1373',
+  {
+    props: {
+      tone: figma.enum('Tone', {
+        Accent: 'accent',
+        Neutral: 'neutral',
+        Danger: 'danger',
+      }),
+      geometry: figma.nestedProps('.Geometry Options', {
+        size: figma.enum('Size', {
+          Large: 'large',
+          Default: 'default',
+          Small: 'small',
+        }),
+        round: figma.boolean('Round'),
+      }),
+      // @ts-expect-error - Code Connect's ConnectedComponent type doesn't match ReactElement
+      inner: figma.nestedProps('⌘ Icon Button', {
+        variant: figma.enum('Variant', {
+          Primary: 'primary',
+          Outline: 'secondary',
+          Ghost: 'ghost',
+        }),
+        disabled: figma.enum('State', {
+          Disabled: true,
+        }),
+        iconContent: figma.instance('icon'),
+      }),
+    },
+    example: ({ tone, geometry, inner }) => (
+      <Button
+        icon
+        variant={inner.variant}
+        size={geometry.size}
+        tone={tone}
+        round={geometry.round}
+        disabled={inner.disabled}
+        /* Remember to describe the action of the icon button for accessibility */
+        aria-label="[Describe action]"
+      >
+        {inner.iconContent}
+      </Button>
+    ),
+  },
+)

--- a/packages/eds-core-react/src/components/next/Button/Button.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.stories.tsx
@@ -1,0 +1,440 @@
+import type { ReactNode } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { add, chevron_right, delete_forever } from '@equinor/eds-icons'
+import { Button } from './Button'
+import { Icon } from '../Icon'
+import page from './Button.docs.mdx'
+
+type StoryArgs = React.ComponentProps<typeof Button>
+
+const meta: Meta<StoryArgs> = {
+  title: 'EDS 2.0 (beta)/Button',
+  component: Button,
+  parameters: {
+    docs: {
+      page,
+      source: {
+        excludeDecorators: true,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'ghost'],
+      description: 'Visual style variant',
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'default', 'large'],
+      description: 'Button size',
+    },
+    tone: {
+      control: 'select',
+      options: ['accent', 'neutral', 'danger'],
+      description: 'Color theme',
+    },
+    round: {
+      control: 'boolean',
+      description:
+        'Makes icon-only buttons circular (only applies to icon-only buttons)',
+    },
+    icon: {
+      control: 'boolean',
+      description: 'Icon-only button mode (requires aria-label)',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disabled state',
+    },
+  },
+  args: {
+    variant: 'primary',
+    size: 'default',
+    tone: 'accent',
+    icon: false,
+    disabled: false,
+  },
+}
+
+export default meta
+
+const Wrapper = ({
+  children,
+  gap = 16,
+  direction = 'column',
+  align = 'flex-start',
+  wrap = false,
+  ...rest
+}: {
+  children: ReactNode
+  gap?: number
+  direction?: 'row' | 'column'
+  align?: 'flex-start' | 'center' | 'flex-end' | 'stretch'
+  wrap?: boolean
+} & React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: direction,
+      gap: `${gap}px`,
+      alignItems: align,
+      flexWrap: wrap ? 'wrap' : undefined,
+    }}
+    {...rest}
+  >
+    {children}
+  </div>
+)
+
+type Story = StoryObj<StoryArgs>
+
+// ===== Basic Examples =====
+
+export const Default: Story = {
+  render: ({ icon, ...args }) => (
+    <Button icon={icon} aria-label={icon ? 'Button' : undefined} {...args}>
+      {icon ? <Icon data={add} aria-hidden /> : 'Button'}
+    </Button>
+  ),
+}
+
+// ===== Sizes =====
+
+export const Sizes: Story = {
+  render: () => (
+    <Wrapper direction="row" align="center">
+      <Button size="small">Small</Button>
+      <Button size="default">Default</Button>
+      <Button size="large">Large</Button>
+    </Wrapper>
+  ),
+}
+
+// ===== Color Appearances =====
+
+export const Tones: Story = {
+  render: () => (
+    <Wrapper>
+      <Wrapper direction="row">
+        <Button tone="accent">Accent</Button>
+        <Button tone="neutral">Neutral</Button>
+        <Button tone="danger">Danger</Button>
+      </Wrapper>
+      <Wrapper direction="row">
+        <Button variant="secondary" tone="accent">
+          Accent
+        </Button>
+        <Button variant="secondary" tone="neutral">
+          Neutral
+        </Button>
+        <Button variant="secondary" tone="danger">
+          Danger
+        </Button>
+      </Wrapper>
+      <Wrapper direction="row">
+        <Button variant="ghost" tone="accent">
+          Accent
+        </Button>
+        <Button variant="ghost" tone="neutral">
+          Neutral
+        </Button>
+        <Button variant="ghost" tone="danger">
+          Danger
+        </Button>
+      </Wrapper>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `tone` prop controls the color scheme using `data-color-appearance`.',
+      },
+    },
+  },
+}
+
+// ===== With Icons =====
+
+export const WithIconBefore: Story = {
+  render: () => (
+    <Button>
+      <Icon data={add} aria-hidden />
+      Add Item
+    </Button>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Place an Icon before the text as a child to show it before the label.',
+      },
+    },
+  },
+}
+
+export const WithIconAfter: Story = {
+  render: () => (
+    <Button>
+      Next
+      <Icon data={chevron_right} aria-hidden />
+    </Button>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Place an Icon after the text as a child to show it after the label.',
+      },
+    },
+  },
+}
+
+// ===== States =====
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: 'Disabled',
+  },
+}
+
+export const DisabledVariants: Story = {
+  render: () => (
+    <Wrapper direction="row">
+      <Button variant="primary" disabled>
+        Primary
+      </Button>
+      <Button variant="secondary" disabled>
+        Secondary
+      </Button>
+      <Button variant="ghost" disabled>
+        Ghost
+      </Button>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'All variants support the disabled state.',
+      },
+    },
+  },
+}
+
+// ===== All Variants Matrix =====
+
+export const AllVariants: Story = {
+  render: () => (
+    <Wrapper gap={24}>
+      {(['primary', 'secondary', 'ghost'] as const).map((variant) => (
+        <div key={variant}>
+          <h3 style={{ marginBottom: '12px', textTransform: 'capitalize' }}>
+            {variant}
+          </h3>
+          <Wrapper direction="row" wrap align="center">
+            {(['accent', 'neutral', 'danger'] as const).map((color) => (
+              <Wrapper key={color} direction="row" gap={8} align="center">
+                <Button variant={variant} tone={color} size="small">
+                  <Icon data={add} aria-hidden />
+                  Small
+                </Button>
+                <Button variant={variant} tone={color} size="default">
+                  <Icon data={add} aria-hidden />
+                  Default
+                </Button>
+                <Button variant={variant} tone={color} size="large">
+                  <Icon data={add} aria-hidden />
+                  Large
+                </Button>
+              </Wrapper>
+            ))}
+          </Wrapper>
+        </div>
+      ))}
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Complete overview of all variants, sizes, and color appearances.',
+      },
+    },
+  },
+}
+
+// ===== Danger Action Example =====
+
+export const DangerAction: Story = {
+  render: () => (
+    <Wrapper direction="row">
+      <Button variant="primary" tone="danger">
+        <Icon data={delete_forever} aria-hidden />
+        Delete
+        <Icon data={delete_forever} aria-hidden />
+      </Button>
+      <Button variant="secondary" tone="danger">
+        Cancel
+      </Button>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Use `tone="danger"` for destructive actions.',
+      },
+    },
+  },
+}
+// ===== Icon-Only Buttons =====
+
+export const IconOnly: Story = {
+  render: () => (
+    <Wrapper direction="row" align="center">
+      <Button icon aria-label="Add" size="small">
+        <Icon data={add} aria-hidden />
+      </Button>
+      <Button icon aria-label="Add" size="default">
+        <Icon data={add} aria-hidden />
+      </Button>
+      <Button icon aria-label="Add" size="large">
+        <Icon data={add} aria-hidden />
+      </Button>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the `icon` prop for icon-only buttons. They are square with uniform padding. Always provide `aria-label` for accessibility.',
+      },
+    },
+  },
+}
+
+export const IconOnlyVariants: Story = {
+  render: () => (
+    <Wrapper>
+      <Wrapper direction="row" align="center">
+        <Button variant="primary" icon aria-label="Add">
+          <Icon data={add} aria-hidden />
+        </Button>
+        <Button variant="secondary" icon aria-label="Add">
+          <Icon data={add} aria-hidden />
+        </Button>
+        <Button variant="ghost" icon aria-label="Add">
+          <Icon data={add} aria-hidden />
+        </Button>
+      </Wrapper>
+      <Wrapper direction="row" align="center">
+        <Button variant="primary" tone="danger" icon aria-label="Delete">
+          <Icon data={delete_forever} aria-hidden />
+        </Button>
+        <Button variant="secondary" tone="danger" icon aria-label="Delete">
+          <Icon data={delete_forever} aria-hidden />
+        </Button>
+        <Button variant="ghost" tone="danger" icon aria-label="Delete">
+          <Icon data={delete_forever} aria-hidden />
+        </Button>
+      </Wrapper>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Icon-only buttons support all variants and color appearances.',
+      },
+    },
+  },
+}
+
+// ===== Circular Icon-Only Buttons =====
+
+export const CircularIconOnly: Story = {
+  render: () => (
+    <Wrapper>
+      <Wrapper direction="row" align="center">
+        <Button icon round aria-label="Add" size="small">
+          <Icon data={add} aria-hidden />
+        </Button>
+        <Button icon round aria-label="Add" size="default">
+          <Icon data={add} aria-hidden />
+        </Button>
+        <Button icon round aria-label="Add" size="large">
+          <Icon data={add} aria-hidden />
+        </Button>
+      </Wrapper>
+      <Wrapper direction="row" align="center">
+        <Button variant="primary" icon round aria-label="Add">
+          <Icon data={add} aria-hidden />
+        </Button>
+        <Button variant="secondary" icon round aria-label="Add">
+          <Icon data={add} aria-hidden />
+        </Button>
+        <Button variant="ghost" icon round aria-label="Add">
+          <Icon data={add} aria-hidden />
+        </Button>
+      </Wrapper>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Use `round` on icon-only buttons to create circular buttons.',
+      },
+    },
+  },
+}
+
+// ===== Density Comparison =====
+
+export const DensityComparison: Story = {
+  render: () => (
+    <Wrapper gap={32}>
+      <div data-density="spacious">
+        <h3 style={{ marginBottom: '12px' }}>Spacious (default)</h3>
+        <Wrapper direction="row" align="center" gap={12}>
+          <Button size="small">Small</Button>
+          <Button size="default">Default</Button>
+          <Button size="large">Large</Button>
+          <Button size="small" icon aria-label="Add">
+            <Icon data={add} aria-hidden />
+          </Button>
+          <Button size="default" icon aria-label="Add">
+            <Icon data={add} aria-hidden />
+          </Button>
+          <Button size="large" icon aria-label="Add">
+            <Icon data={add} aria-hidden />
+          </Button>
+        </Wrapper>
+      </div>
+      <div data-density="comfortable">
+        <h3 style={{ marginBottom: '12px' }}>Comfortable</h3>
+        <Wrapper direction="row" align="center" gap={12}>
+          <Button size="small">Small</Button>
+          <Button size="default">Default</Button>
+          <Button size="large">Large</Button>
+          <Button size="small" icon aria-label="Add">
+            <Icon data={add} aria-hidden />
+          </Button>
+          <Button size="default" icon aria-label="Add">
+            <Icon data={add} aria-hidden />
+          </Button>
+          <Button size="large" icon aria-label="Add">
+            <Icon data={add} aria-hidden />
+          </Button>
+        </Wrapper>
+      </div>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Comparison of all button sizes across density modes. Use `data-density` on a parent container to control density.',
+      },
+    },
+  },
+}

--- a/packages/eds-core-react/src/components/next/Button/Button.test.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.test.tsx
@@ -1,0 +1,515 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+import { Button } from '.'
+
+// Mock icon for testing - forwards props to SVG
+const MockIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg data-testid="mock-icon" aria-hidden {...props} />
+)
+
+describe('Button (next)', () => {
+  describe('Rendering', () => {
+    it('matches snapshot', () => {
+      const { container } = render(<Button>Click me</Button>)
+      expect(container).toMatchSnapshot()
+    })
+
+    it('renders with children', () => {
+      render(<Button>Click me</Button>)
+      expect(
+        screen.getByRole('button', { name: /click me/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('renders with default props', () => {
+      render(<Button>Default</Button>)
+      const button = screen.getByRole('button')
+
+      expect(button).toHaveAttribute('data-variant', 'primary')
+      expect(button).toHaveAttribute('data-color-appearance', 'accent')
+      expect(button).toHaveAttribute('data-selectable-space', 'md')
+      expect(button).toHaveAttribute('type', 'button')
+    })
+
+    it('renders with custom variant', () => {
+      render(<Button variant="secondary">Secondary</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-variant',
+        'secondary',
+      )
+    })
+
+    it('renders with ghost variant', () => {
+      render(<Button variant="ghost">Ghost</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-variant',
+        'ghost',
+      )
+    })
+
+    it('renders with small size', () => {
+      render(<Button size="small">Small</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-selectable-space',
+        'sm',
+      )
+    })
+
+    it('renders with large size', () => {
+      render(<Button size="large">Large</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-selectable-space',
+        'lg',
+      )
+    })
+
+    it('renders with accent tone', () => {
+      render(<Button tone="accent">Accent</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-color-appearance',
+        'accent',
+      )
+    })
+
+    it('renders with danger tone', () => {
+      render(<Button tone="danger">Danger</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-color-appearance',
+        'danger',
+      )
+    })
+
+    it('applies custom className', () => {
+      render(<Button className="custom-class">Custom</Button>)
+      const button = screen.getByRole('button')
+      expect(button).toHaveClass('eds-button', 'custom-class')
+    })
+
+    it('forwards ref to button element', () => {
+      const ref = { current: null as HTMLButtonElement | null }
+      render(<Button ref={ref}>Ref</Button>)
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+    })
+
+    it('spreads additional props to button element', () => {
+      render(<Button data-testid="custom-button">Props</Button>)
+      expect(screen.getByTestId('custom-button')).toBeInTheDocument()
+    })
+  })
+
+  describe('Children (Icons and Text)', () => {
+    it('renders icon as child', () => {
+      render(
+        <Button>
+          <MockIcon />
+          Label
+        </Button>,
+      )
+      expect(screen.getByTestId('mock-icon')).toBeInTheDocument()
+    })
+
+    it('renders icon after label', () => {
+      render(
+        <Button>
+          Label
+          <MockIcon />
+        </Button>,
+      )
+      expect(screen.getByTestId('mock-icon')).toBeInTheDocument()
+      expect(screen.getByRole('button')).toHaveTextContent('Label')
+    })
+
+    it('renders multiple icons', () => {
+      render(
+        <Button>
+          <MockIcon />
+          Navigate
+          <MockIcon />
+        </Button>,
+      )
+      expect(screen.getAllByTestId('mock-icon')).toHaveLength(2)
+    })
+
+    it('wraps text children in typography', () => {
+      render(<Button>Text Content</Button>)
+      const button = screen.getByRole('button')
+      // Text should be wrapped in a span (TypographyNext)
+      // eslint-disable-next-line testing-library/no-node-access
+      const span = button.querySelector('span')
+      expect(span).toBeInTheDocument()
+      expect(span).toHaveTextContent('Text Content')
+    })
+
+    it('preserves child order', () => {
+      render(
+        <Button>
+          <MockIcon />
+          Middle
+          <MockIcon />
+        </Button>,
+      )
+      const button = screen.getByRole('button')
+      // Children are wrapped in TypographyNext span
+      // eslint-disable-next-line testing-library/no-node-access
+      const span = button.children[0]
+      expect(span).toHaveTextContent('Middle')
+
+      // Get all icons using data-testid
+      const icons = screen.getAllByTestId('mock-icon')
+      expect(icons).toHaveLength(2)
+    })
+  })
+
+  describe('States', () => {
+    it('is disabled when disabled prop is true', () => {
+      render(<Button disabled>Disabled</Button>)
+      expect(screen.getByRole('button')).toBeDisabled()
+    })
+
+    it('does not trigger onClick when disabled', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(
+        <Button onClick={handleClick} disabled>
+          Disabled
+        </Button>,
+      )
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).not.toHaveBeenCalled()
+    })
+
+    it('sets tone to neutral when disabled regardless of tone prop', () => {
+      render(
+        <Button tone="danger" disabled>
+          Disabled
+        </Button>,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-color-appearance',
+        'neutral',
+      )
+    })
+
+    it('sets tone to neutral when disabled with accent', () => {
+      render(
+        <Button tone="accent" disabled>
+          Disabled
+        </Button>,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-color-appearance',
+        'neutral',
+      )
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('handles null children gracefully', () => {
+      render(<Button>{null}</Button>)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('handles undefined children gracefully', () => {
+      render(<Button>{undefined}</Button>)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('handles mixed children with null values', () => {
+      render(
+        <Button>
+          {null}
+          Label
+          {undefined}
+        </Button>,
+      )
+      expect(screen.getByRole('button')).toHaveTextContent('Label')
+    })
+
+    it('handles empty fragment children', () => {
+      render(
+        <Button>
+          <></>
+        </Button>,
+      )
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+  })
+
+  describe('Behavior', () => {
+    it('handles click events', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Button onClick={handleClick}>Click</Button>)
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('supports keyboard navigation with Enter', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Button onClick={handleClick}>Keyboard</Button>)
+      const button = screen.getByRole('button')
+      button.focus()
+      expect(button).toHaveFocus()
+      await user.keyboard('{Enter}')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('supports keyboard activation with Space', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Button onClick={handleClick}>Space</Button>)
+      const button = screen.getByRole('button')
+      button.focus()
+      await user.keyboard(' ')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('defaults to type="button"', () => {
+      render(<Button>Default Type</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+    })
+
+    it('supports type="submit"', () => {
+      render(<Button type="submit">Submit</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'submit')
+    })
+
+    it('supports type="reset"', () => {
+      render(<Button type="reset">Reset</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'reset')
+    })
+  })
+
+  describe('Variants', () => {
+    it.each(['primary', 'secondary', 'ghost'] as const)(
+      'renders %s variant',
+      (variant) => {
+        render(<Button variant={variant}>{variant}</Button>)
+        expect(screen.getByRole('button')).toHaveAttribute(
+          'data-variant',
+          variant,
+        )
+      },
+    )
+  })
+
+  describe('Sizes', () => {
+    it.each([
+      ['small', 'sm'],
+      ['default', 'md'],
+      ['large', 'lg'],
+    ] as const)(
+      'renders %s size with data-selectable-space=%s',
+      (size, expected) => {
+        render(<Button size={size}>{size}</Button>)
+        expect(screen.getByRole('button')).toHaveAttribute(
+          'data-selectable-space',
+          expected,
+        )
+      },
+    )
+  })
+
+  describe('Color Appearances', () => {
+    it.each(['accent', 'neutral', 'danger'] as const)(
+      'renders %s tone',
+      (tone) => {
+        render(<Button tone={tone}>{tone}</Button>)
+        expect(screen.getByRole('button')).toHaveAttribute(
+          'data-color-appearance',
+          tone,
+        )
+      },
+    )
+  })
+
+  describe('Accessibility', () => {
+    it('has no accessibility violations (default)', async () => {
+      const { container } = render(<Button>Accessible</Button>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (disabled)', async () => {
+      const { container } = render(<Button disabled>Disabled</Button>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (with icon)', async () => {
+      const { container } = render(
+        <Button>
+          <MockIcon />
+          With Icon
+        </Button>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (all variants)', async () => {
+      const { container } = render(
+        <>
+          <Button variant="primary">Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="ghost">Ghost</Button>
+        </>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('is focusable', () => {
+      render(<Button>Focusable</Button>)
+      const button = screen.getByRole('button')
+      button.focus()
+      expect(button).toHaveFocus()
+    })
+
+    it('has no accessibility violations (icon-only with aria-label)', async () => {
+      const { container } = render(
+        <Button icon aria-label="Add item">
+          <MockIcon />
+        </Button>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+
+  describe('Icon-Only (icon prop)', () => {
+    it('sets data-icon-only when icon prop is true', () => {
+      render(
+        <Button icon aria-label="Add">
+          <MockIcon />
+        </Button>,
+      )
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-icon-only', 'true')
+    })
+
+    it('uses selectable space tokens for icon-only (default size)', () => {
+      render(
+        <Button icon aria-label="Add">
+          <MockIcon />
+        </Button>,
+      )
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-selectable-space', 'md')
+    })
+
+    it('uses selectable space tokens for icon-only (small size)', () => {
+      render(
+        <Button icon aria-label="Add" size="small">
+          <MockIcon />
+        </Button>,
+      )
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-selectable-space', 'sm')
+    })
+
+    it('uses selectable space tokens for icon-only (large size)', () => {
+      render(
+        <Button icon aria-label="Add" size="large">
+          <MockIcon />
+        </Button>,
+      )
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-selectable-space', 'lg')
+    })
+
+    it('uses selectable space tokens for regular button', () => {
+      render(
+        <Button>
+          <MockIcon />
+          Label
+        </Button>,
+      )
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-selectable-space', 'md')
+    })
+
+    it('renders icon child in icon-only mode', () => {
+      render(
+        <Button icon aria-label="Add">
+          <MockIcon />
+        </Button>,
+      )
+      expect(screen.getByTestId('mock-icon')).toBeInTheDocument()
+    })
+
+    it.each(['small', 'default', 'large'] as const)(
+      'renders icon-only with %s size',
+      (size) => {
+        render(
+          <Button icon aria-label="Add" size={size}>
+            <MockIcon />
+          </Button>,
+        )
+        expect(screen.getByRole('button')).toHaveAttribute('data-icon-only')
+      },
+    )
+
+    it('does not set data-icon-only when icon prop is false', () => {
+      render(<Button>Regular Button</Button>)
+      const button = screen.getByRole('button')
+      expect(button).not.toHaveAttribute('data-icon-only')
+    })
+  })
+
+  describe('Round (icon-only buttons)', () => {
+    it('does not set data-round on non-icon buttons', () => {
+      render(<Button>Label Button</Button>)
+      expect(screen.getByRole('button')).not.toHaveAttribute('data-round')
+    })
+
+    it('does not set data-round on buttons with label and icon', () => {
+      render(
+        <Button>
+          <MockIcon />
+          Label
+        </Button>,
+      )
+      expect(screen.getByRole('button')).not.toHaveAttribute('data-round')
+    })
+
+    it('does not set data-round on icon-only button by default', () => {
+      render(
+        <Button icon aria-label="Add">
+          <MockIcon />
+        </Button>,
+      )
+      expect(screen.getByRole('button')).not.toHaveAttribute('data-round')
+    })
+
+    it('sets data-round on icon-only button when round is true', () => {
+      render(
+        <Button icon aria-label="Add" round>
+          <MockIcon />
+        </Button>,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute('data-round', 'true')
+    })
+
+    it('ignores round prop on non-icon buttons', () => {
+      render(<Button round>Label Button</Button>)
+      expect(screen.getByRole('button')).not.toHaveAttribute('data-round')
+    })
+
+    it('has no accessibility violations (circular icon-only)', async () => {
+      const { container } = render(
+        <Button icon aria-label="Add" round>
+          <MockIcon />
+        </Button>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (square icon-only)', async () => {
+      const { container } = render(
+        <Button icon aria-label="Add">
+          <MockIcon />
+        </Button>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.tsx
@@ -1,0 +1,64 @@
+import { forwardRef } from 'react'
+import { TypographyNext } from '../../Typography'
+import type { ButtonProps } from './Button.types'
+
+const SIZE_MAPPING = {
+  small: 'sm',
+  default: 'md',
+  large: 'lg',
+} as const
+
+const sizeToTypography = SIZE_MAPPING
+const sizeToSelectableSpace = SIZE_MAPPING
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      variant = 'primary',
+      size = 'default',
+      tone = 'accent',
+      icon = false,
+      round = false,
+      children,
+      className,
+      disabled,
+      type = 'button',
+      ...rest
+    },
+    ref,
+  ) {
+    const classes = ['eds-button', className].filter(Boolean).join(' ')
+    const typographySize = sizeToTypography[size]
+    const selectableSpace = sizeToSelectableSpace[size]
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={classes}
+        disabled={disabled}
+        data-variant={variant}
+        data-selectable-space={selectableSpace}
+        data-space-proportions="squished"
+        data-font-family="ui"
+        data-font-size={typographySize}
+        data-line-height="squished"
+        data-color-appearance={disabled ? 'neutral' : tone}
+        data-icon-only={icon || undefined}
+        data-round={icon && round ? true : undefined}
+        {...rest}
+      >
+        <TypographyNext
+          family="ui"
+          size={typographySize}
+          baseline="center"
+          lineHeight="squished"
+        >
+          {children}
+        </TypographyNext>
+      </button>
+    )
+  },
+)
+
+Button.displayName = 'Button'

--- a/packages/eds-core-react/src/components/next/Button/Button.types.ts
+++ b/packages/eds-core-react/src/components/next/Button/Button.types.ts
@@ -1,0 +1,84 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+/**
+ * Button visual style variants
+ * - `primary`: Solid filled button for primary actions
+ * - `secondary`: Bordered button for secondary actions
+ * - `ghost`: Minimal button for tertiary actions
+ */
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost'
+
+/**
+ * Button size options
+ * - `small`: Compact size (24px height)
+ * - `default`: Standard size (36px height)
+ * - `large`: Generous size (44px height)
+ */
+export type ButtonSize = 'small' | 'default' | 'large'
+
+/**
+ * Color tone for theming
+ * - `accent`: Brand/action color (default)
+ * - `neutral`: Neutral gray tones
+ * - `danger`: Destructive/warning actions
+ */
+export type ButtonTone = 'accent' | 'neutral' | 'danger'
+
+export type ButtonProps = {
+  /**
+   * Button variant - controls visual style
+   * @default 'primary'
+   */
+  variant?: ButtonVariant
+  /**
+   * Button size
+   * @default 'default'
+   */
+  size?: ButtonSize
+  /**
+   * Color tone for theming
+   * @default 'accent'
+   */
+  tone?: ButtonTone
+  /**
+   * Icon-only mode. Creates a square button optimized for a single icon.
+   * Always provide `aria-label` for accessibility when using icon-only buttons.
+   *
+   * @default false
+   *
+   * @example
+   * ```tsx
+   * import { save } from '@equinor/eds-icons'
+   * <Button icon aria-label="Save">
+   *   <Icon data={save} />
+   * </Button>
+   * ```
+   */
+  icon?: boolean
+  /**
+   * Makes icon-only buttons circular instead of square.
+   * Only applies when `icon` prop is true.
+   * @default false
+   */
+  round?: boolean
+  /**
+   * Button content. Can include text, icons, or both.
+   * Layout is handled automatically with CSS flexbox.
+   *
+   * @example
+   * ```tsx
+   * // Text only
+   * <Button>Save</Button>
+   *
+   * // Icon before text
+   * <Button><Icon data={save} /> Save</Button>
+   *
+   * // Icon after text
+   * <Button>Next <Icon data={chevron_right} /></Button>
+   *
+   * // Icon only (requires aria-label)
+   * <Button icon aria-label="Save"><Icon data={save} /></Button>
+   * ```
+   */
+  children?: ReactNode
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'>

--- a/packages/eds-core-react/src/components/next/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Button/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Button (next) Rendering matches snapshot 1`] = `
+<div>
+  <button
+    class="eds-button"
+    data-color-appearance="accent"
+    data-font-family="ui"
+    data-font-size="md"
+    data-line-height="squished"
+    data-selectable-space="md"
+    data-space-proportions="squished"
+    data-variant="primary"
+    type="button"
+  >
+    <span
+      data-baseline="center"
+      data-font-family="ui"
+      data-font-size="md"
+      data-line-height="squished"
+    >
+      Click me
+    </span>
+  </button>
+</div>
+`;

--- a/packages/eds-core-react/src/components/next/Button/button.css
+++ b/packages/eds-core-react/src/components/next/Button/button.css
@@ -1,0 +1,347 @@
+@layer eds-components {
+  .eds-button {
+    /* Layout */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+
+    /* Appearance */
+    border: none;
+    border-radius: var(--eds-spacing-border-radius-rounded, 4px);
+    cursor: pointer;
+    outline: none;
+    text-decoration: none;
+
+    /* Transitions */
+    transition:
+      background-color 150ms ease-in-out,
+      border-color 150ms ease-in-out,
+      color 150ms ease-in-out;
+
+    /* Comfortable density asymmetric padding for visual text centering */
+    /* These values compensate for font metrics (ascenders/descenders) */
+    /* Empirically determined from Figma design */
+    --_comfortable-padding-top: 0.313rem; /* 5px */
+    --_comfortable-padding-bottom: 0.188rem; /* 3px */
+
+    /* Comfortable density icon-only padding to match label button heights */
+    /* Formula: (target-height - icon-size) / 2 where target-height = label button height */
+    /* Empirically determined from Figma design */
+    --_comfortable-icon-padding-sm: 0.125rem; /* 2px: (20px - 16px) / 2 */
+    --_comfortable-icon-padding-md: 0.188rem; /* 3px: (24px - 18px) / 2 */
+    --_comfortable-icon-padding-lg: 0.5rem; /* 8px: (36px - 20px) / 2 */
+  }
+
+  /* ===== SIZE VARIANTS (Button with label) ===== */
+  /*
+   * Spacing adjusted from design tokens to compensate for icon negative margins
+   * Icons have margin-block: -0.25em and margin-inline: -0.1em for optical alignment
+   *
+   * Token reference (from --eds-selectable-space-*):
+   * - lg: horizontal=20px, vertical=16px (spacious) / 12px (comfortable)
+   * - md: horizontal=16px, vertical=12px (spacious) / 8px (comfortable)
+   * - sm: horizontal=12px, vertical=8px (spacious) / 6px (comfortable)
+   *
+   * Adjustments made:
+   * - Vertical padding reduced by ~4px to account for icon negative margins
+   * - Gap values slightly adjusted for visual balance with icons
+   */
+
+  .eds-button[data-selectable-space='lg'] {
+    /* Base from token (16px spacious / 12px comfortable) → Adjusted: -4px vertical for icon margins */
+    padding-block: calc(var(--eds-selectable-space-vertical) - 0.25rem); /* 16px → 12px / 12px → 8px */
+    padding-inline: var(--eds-selectable-space-horizontal); /* 20px spacious / 16px comfortable */
+    gap: var(--eds-typography-gap-horizontal);
+  }
+
+  .eds-button[data-selectable-space='md'] {
+    /* Base from token (12px spacious / 8px comfortable) → Adjusted: -2px vertical for icon margins */
+    padding-block: calc(var(--eds-selectable-space-vertical) - 0.125rem); /* 12px → 10px / 8px → 6px */
+    padding-inline: var(--eds-selectable-space-horizontal); /* 16px spacious / 12px comfortable */
+    gap: var(--eds-typography-gap-horizontal);
+  }
+
+  .eds-button[data-selectable-space='sm'] {
+    /* Base from token (8px spacious / 6px comfortable) → Adjusted: -2px vertical for icon margins */
+    padding-block: calc(var(--eds-selectable-space-vertical) - 0.125rem); /* 8px → 6px / 6px → 4px */
+    padding-inline: var(--eds-selectable-space-horizontal); /* 12px spacious / 8px comfortable */
+    gap: var(--eds-typography-gap-horizontal);
+  }
+
+  /* ===== DENSITY OVERRIDES ===== */
+  /*
+   * Note: Density-specific overrides are defined OUTSIDE @layer (after this block closes)
+   * to ensure they can override the typography tokens from @equinor/eds-tokens
+   */
+
+  /* ===== ICON-ONLY BUTTON ===== */
+  /*
+   * Icon-only buttons maintain same height as label buttons but adapt to density.
+   * Formula: padding = base-padding + (line-height - icon-size) / 2
+   *
+   * This ensures icon buttons:
+   * - Match label button height in both spacious and comfortable density
+   * - Center the icon vertically regardless of density mode
+   * - Adapt automatically via --eds-typography-line-height-squished token
+   *
+   * Density behavior:
+   * - Spacious: Uses larger line-height → more padding → taller buttons
+   * - Comfortable: Uses smaller line-height → less padding → shorter buttons
+   */
+
+  .eds-button[data-icon-only] {
+    aspect-ratio: 1;
+  }
+
+  .eds-button[data-icon-only][data-selectable-space='lg'] {
+    /* Base padding from token minus icon compensation: (16px - 4px) = 12px spacious / (12px - 4px) = 8px comfortable */
+    /* Adapts with line-height (20px spacious / 16px comfortable) */
+    /* Target height: 44px spacious / 40px comfortable */
+    --_base-padding: calc(var(--eds-selectable-space-vertical) - 0.25rem);
+    padding: calc(
+      var(--_base-padding) +
+        (
+          var(--eds-typography-line-height-squished) -
+            var(--eds-typography-icon-size)
+        ) /
+        2
+    );
+  }
+
+  .eds-button[data-icon-only][data-selectable-space='md'] {
+    /* Base padding from token minus icon compensation: (12px - 2px) = 10px spacious / (8px - 2px) = 6px comfortable */
+    /* Adapts with line-height (16px spacious / 12px comfortable) */
+    /* Target height: 36px spacious / 32px comfortable */
+    --_base-padding: calc(var(--eds-selectable-space-vertical) - 0.125rem);
+    padding: calc(
+      var(--_base-padding) +
+        (
+          var(--eds-typography-line-height-squished) -
+            var(--eds-typography-icon-size)
+        ) /
+        2
+    );
+  }
+
+  .eds-button[data-icon-only][data-selectable-space='sm'] {
+    /* Base padding from token minus icon compensation: (8px - 2px) = 6px spacious / (6px - 2px) = 4px comfortable */
+    /* Line-height (12px) same for both densities */
+    /* Target height: 24px (consistent across densities) */
+    --_base-padding: calc(var(--eds-selectable-space-vertical) - 0.125rem);
+    padding: calc(
+      var(--_base-padding) +
+        (
+          var(--eds-typography-line-height-squished) -
+            var(--eds-typography-icon-size)
+        ) /
+        2
+    );
+  }
+
+  /* ===== ROUND ICON-ONLY BUTTON ===== */
+
+  .eds-button[data-round] {
+    border-radius: 50%;
+  }
+
+  /* ===== PRIMARY VARIANT ===== */
+
+  .eds-button[data-variant='primary'] {
+    background-color: var(--eds-color-bg-fill-emphasis-default);
+    color: var(--eds-color-text-strong-on-emphasis);
+  }
+
+  .eds-button[data-variant='primary']:hover:not(:disabled) {
+    background-color: var(--eds-color-bg-fill-emphasis-hover);
+  }
+
+  .eds-button[data-variant='primary']:active:not(:disabled) {
+    background-color: var(--eds-color-bg-fill-emphasis-active);
+  }
+
+  .eds-button[data-variant='primary']:disabled {
+    background-color: var(--eds-color-bg-fill-muted-default);
+    color: var(--eds-color-border-medium);
+    cursor: not-allowed;
+  }
+
+  /* ===== SECONDARY VARIANT ===== */
+
+  .eds-button[data-variant='secondary'] {
+    background-color: transparent;
+    color: var(--eds-color-text-subtle);
+    outline: var(--eds-border-width-default, 1px) solid
+      var(--eds-color-border-strong);
+    outline-offset: calc(-1 * var(--eds-border-width-default, 1px));
+  }
+
+  .eds-button[data-variant='secondary']:hover:not(:disabled) {
+    background-color: var(--eds-color-bg-fill-muted-default);
+  }
+
+  .eds-button[data-variant='secondary']:active:not(:disabled) {
+    background-color: var(--eds-color-bg-fill-muted-hover);
+  }
+
+  .eds-button[data-variant='secondary']:disabled {
+    outline: var(--eds-border-width-default, 1px) solid
+      var(--eds-color-border-medium);
+    outline-offset: calc(-1 * var(--eds-border-width-default, 1px));
+    color: var(--eds-color-border-medium);
+    cursor: not-allowed;
+  }
+
+  /* ===== GHOST VARIANT ===== */
+
+  .eds-button[data-variant='ghost'] {
+    background-color: transparent;
+    color: var(--eds-color-text-subtle);
+  }
+
+  .eds-button[data-variant='ghost']:hover:not(:disabled) {
+    background-color: var(--eds-color-bg-fill-muted-default);
+  }
+
+  .eds-button[data-variant='ghost']:active:not(:disabled) {
+    background-color: var(--eds-color-bg-fill-muted-hover);
+  }
+
+  .eds-button[data-variant='ghost']:disabled {
+    color: var(--eds-color-border-medium);
+    cursor: not-allowed;
+  }
+
+  /* ===== FOCUS STATE ===== */
+
+  .eds-button:focus-visible {
+    outline: var(--eds-sizing-stroke-thick) solid
+      var(--eds-color-border-focus);
+    outline-offset: var(--eds-sizing-stroke-thin);
+  }
+
+  .eds-button[data-variant='secondary']:focus-visible {
+    outline-offset: var(--eds-sizing-stroke-thin);
+  }
+
+  /* ===== ICON STYLING ===== */
+  /* Icons inherit size from Typography via --eds-typography-icon-size */
+  /* Icons use em-based negative margins from icon.css for optical alignment */
+
+  .eds-button .icon {
+    flex-shrink: 0;
+  }
+
+  /* Icon-only buttons: remove negative margins, use padding for sizing */
+  .eds-button[data-icon-only] .icon {
+    margin: 0;
+  }
+}
+
+/* ===== LABEL WRAPPER (TypographyNext) ===== */
+/* Outside @layer to override typography.css which sets display: block on [data-font-family] */
+
+.eds-button {
+  display: inline-flex;
+}
+
+.eds-button > span {
+  display: inline-flex;
+  align-items: center;
+  gap: inherit;
+}
+
+/* Reset baseline padding and text-box-trim for proper centering */
+.eds-button > span[data-baseline] {
+  padding: 0;
+  /* Disable text-box-trim so text sits centered within its line-height box */
+  /* Flexbox will then center the entire line-height box vertically in the button */
+  text-box-trim: none;
+  text-box-edge: auto;
+}
+
+/* Icon-only: span should not affect layout */
+.eds-button[data-icon-only] > span {
+  display: contents;
+}
+
+/* ===== DENSITY OVERRIDES ===== */
+/*
+ * Comfortable density uses smaller font-sizes (one size down) and tighter spacing.
+ *
+ * Font-size mapping (from Figma):
+ * - small: XS (10.5px) instead of SM (12px)
+ * - default: SM (12px) instead of MD (14px)
+ * - large: MD (14px) instead of LG (16px)
+ *
+ * Target heights in comfortable mode:
+ * - small: 20px (4px × 2 + 12px line-height)
+ * - default: 24px (4px × 2 + 16px line-height)
+ * - large: 36px (8px × 2 + 20px line-height)
+ *
+ * These overrides are OUTSIDE @layer to ensure they can override the typography
+ * tokens from @equinor/eds-tokens/css/variables.
+ */
+
+[data-density='comfortable'] .eds-button[data-selectable-space='sm'][data-font-size='sm'],
+[data-density='comfortable'] .eds-button[data-selectable-space='sm'] [data-font-size='sm'] {
+  /* Override line-height to maintain SM height (12px instead of XS's 12px) */
+  --eds-typography-line-height: 0.75rem; /* 12px (SM line-height) */
+  --eds-typography-line-height-squished: 0.75rem; /* 12px */
+}
+
+[data-density='comfortable'] .eds-button[data-selectable-space='sm'][data-font-size='sm'] {
+  /* Target: 20px = (5px + 3px) + 12px line-height */
+  /* Asymmetric padding to visually center text (more top, less bottom) */
+  padding-top: var(--_comfortable-padding-top);
+  padding-bottom: var(--_comfortable-padding-bottom);
+}
+
+[data-density='comfortable'] .eds-button[data-selectable-space='md'][data-font-size='md'],
+[data-density='comfortable'] .eds-button[data-selectable-space='md'] [data-font-size='md'] {
+  /* Override line-height to maintain MD height (16px instead of SM's 12px) */
+  --eds-typography-line-height: 1rem; /* 16px (MD line-height, NOT SM) */
+  --eds-typography-line-height-squished: 1rem; /* 16px */
+}
+
+[data-density='comfortable'] .eds-button[data-selectable-space='md'][data-font-size='md'] {
+  /* Target: 24px = (5px + 3px) + 16px line-height */
+  /* Asymmetric padding to visually center text (more top, less bottom) */
+  padding-top: var(--_comfortable-padding-top);
+  padding-bottom: var(--_comfortable-padding-bottom);
+}
+
+[data-density='comfortable'] .eds-button[data-selectable-space='lg'][data-font-size='lg'],
+[data-density='comfortable'] .eds-button[data-selectable-space='lg'] [data-font-size='lg'] {
+  /* Override line-height to maintain LG height (20px instead of MD's 16px) */
+  --eds-typography-line-height: 1.25rem; /* 20px (LG line-height, NOT MD) */
+  --eds-typography-line-height-squished: 1.25rem; /* 20px */
+}
+
+[data-density='comfortable'] .eds-button[data-selectable-space='lg'][data-font-size='lg'] {
+  /* Target: 36px = (8px × 2) + 20px */
+  /* Token gives 12px in comfortable mode, minus icon compensation = 8px */
+  padding-block: calc(var(--eds-selectable-space-vertical) - 0.25rem); /* 12px → 8px */
+}
+
+/* Icon-only button overrides for comfortable density */
+/* Set fixed padding to ensure square buttons that match labeled button heights */
+/* Formula: padding = (target-height - icon-size) / 2 */
+
+[data-density='comfortable'] .eds-button[data-icon-only][data-selectable-space='sm'] {
+  /* Target: 20×20px to match labeled small button (20px height) */
+  /* Icon size: 16px, padding needed: (20 - 16) / 2 = 2px */
+  padding: var(--_comfortable-icon-padding-sm);
+}
+
+[data-density='comfortable'] .eds-button[data-icon-only][data-selectable-space='md'] {
+  /* Target: 24×24px to match labeled default button (24px height) */
+  /* Icon size: 18px, padding needed: (24 - 18) / 2 = 3px */
+  padding: var(--_comfortable-icon-padding-md);
+}
+
+[data-density='comfortable'] .eds-button[data-icon-only][data-selectable-space='lg'] {
+  /* Target: 36×36px to match labeled large button (36px height) */
+  /* Icon size: 20px, padding needed: (36 - 20) / 2 = 8px */
+  padding: var(--_comfortable-icon-padding-lg);
+}

--- a/packages/eds-core-react/src/components/next/Button/index.ts
+++ b/packages/eds-core-react/src/components/next/Button/index.ts
@@ -1,0 +1,7 @@
+export { Button } from './Button'
+export type {
+  ButtonProps,
+  ButtonVariant,
+  ButtonSize,
+  ButtonTone,
+} from './Button.types'

--- a/packages/eds-core-react/src/components/next/Icon/icon.css
+++ b/packages/eds-core-react/src/components/next/Icon/icon.css
@@ -1,58 +1,60 @@
-/* Inline with text: uses token from parent's data-font-size, or 1.5em fallback */
-.icon {
-  /*
-   * Set font-size first to establish the icon's size context.
-   * Then use 1em for width/height (relative to computed font-size).
-   * This avoids compound scaling (1.5em × 1.5em = 2.25em would be wrong).
-   */
-  font-size: var(--eds-typography-icon-size, 1.5em);
-  width: 1em;
-  height: 1em;
+@layer eds-components {
+  /* Inline with text: uses token from parent's data-font-size, or 1.5em fallback */
+  .icon {
+    /*
+     * Set font-size first to establish the icon's size context.
+     * Then use 1em for width/height (relative to computed font-size).
+     * This avoids compound scaling (1.5em × 1.5em = 2.25em would be wrong).
+     */
+    font-size: var(--eds-typography-icon-size, 1.5em);
+    width: 1em;
+    height: 1em;
 
-  /* Negative margins for optical alignment with text baseline */
-  margin-block: -0.25em;
-  margin-inline: -0.1em;
+    /* Negative margins for optical alignment with text baseline */
+    margin-block: -0.25em;
+    margin-inline: -0.1em;
 
-  flex-shrink: 0;
-}
+    flex-shrink: 0;
+  }
 
-/* Explicit size: fixed size from design tokens, no margins */
-.icon[data-icon-size] {
-  --_explicit-size: var(--eds-sizing-icon-md); /* fallback */
+  /* Explicit size: fixed size from design tokens, no margins */
+  .icon[data-icon-size] {
+    --_explicit-size: var(--eds-sizing-icon-md); /* fallback */
 
-  width: var(--_explicit-size);
-  height: var(--_explicit-size);
-  margin: 0;
-  font-size: inherit;
-}
+    width: var(--_explicit-size);
+    height: var(--_explicit-size);
+    margin: 0;
+    font-size: inherit;
+  }
 
-.icon[data-icon-size='xs'] {
-  --_explicit-size: var(--eds-sizing-icon-xs);
-}
-.icon[data-icon-size='sm'] {
-  --_explicit-size: var(--eds-sizing-icon-sm);
-}
-.icon[data-icon-size='md'] {
-  --_explicit-size: var(--eds-sizing-icon-md);
-}
-.icon[data-icon-size='lg'] {
-  --_explicit-size: var(--eds-sizing-icon-lg);
-}
-.icon[data-icon-size='xl'] {
-  --_explicit-size: var(--eds-sizing-icon-xl);
-}
-.icon[data-icon-size='2xl'] {
-  --_explicit-size: var(--eds-sizing-icon-2xl);
-}
-.icon[data-icon-size='3xl'] {
-  --_explicit-size: var(--eds-sizing-icon-3xl);
-}
-.icon[data-icon-size='4xl'] {
-  --_explicit-size: var(--eds-sizing-icon-4xl);
-}
-.icon[data-icon-size='5xl'] {
-  --_explicit-size: var(--eds-sizing-icon-5xl);
-}
-.icon[data-icon-size='6xl'] {
-  --_explicit-size: var(--eds-sizing-icon-6xl);
+  .icon[data-icon-size='xs'] {
+    --_explicit-size: var(--eds-sizing-icon-xs);
+  }
+  .icon[data-icon-size='sm'] {
+    --_explicit-size: var(--eds-sizing-icon-sm);
+  }
+  .icon[data-icon-size='md'] {
+    --_explicit-size: var(--eds-sizing-icon-md);
+  }
+  .icon[data-icon-size='lg'] {
+    --_explicit-size: var(--eds-sizing-icon-lg);
+  }
+  .icon[data-icon-size='xl'] {
+    --_explicit-size: var(--eds-sizing-icon-xl);
+  }
+  .icon[data-icon-size='2xl'] {
+    --_explicit-size: var(--eds-sizing-icon-2xl);
+  }
+  .icon[data-icon-size='3xl'] {
+    --_explicit-size: var(--eds-sizing-icon-3xl);
+  }
+  .icon[data-icon-size='4xl'] {
+    --_explicit-size: var(--eds-sizing-icon-4xl);
+  }
+  .icon[data-icon-size='5xl'] {
+    --_explicit-size: var(--eds-sizing-icon-5xl);
+  }
+  .icon[data-icon-size='6xl'] {
+    --_explicit-size: var(--eds-sizing-icon-6xl);
+  }
 }

--- a/packages/eds-core-react/src/components/next/index.css
+++ b/packages/eds-core-react/src/components/next/index.css
@@ -3,6 +3,8 @@
 @layer eds-components;
 
 @import '@equinor/eds-tokens/css/variables';
+@import './Icon/icon.css';
+@import './Button/button.css';
 @import './Field/field.css';
 @import './Checkbox/checkbox.css';
 @import './Radio/radio.css';

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -1,9 +1,16 @@
+export { Button } from './Button'
 export { Icon } from './Icon'
 export { Field, useFieldIds } from './Field'
 export { Checkbox } from './Checkbox'
 export { Radio } from './Radio'
 export { Switch } from './Switch'
 
+export type {
+  ButtonProps,
+  ButtonVariant,
+  ButtonSize,
+  ButtonTone,
+} from './Button'
 export type { IconProps, IconSize, IconData, IconName } from './Icon'
 export type { CheckboxProps } from './Checkbox'
 export type { RadioProps } from './Radio'


### PR DESCRIPTION
## Summary

Adds a new Button component to EDS 2.0 (`/next`) with full Figma design spec compliance.

### Features

- **Variants:** `primary`, `secondary`, `ghost`
- **Sizes:** `small`, `default`, `large`
- **Tones:** `accent`, `neutral`, `danger`
- **Icon support:** 
  - Icons as children with automatic spacing
  - Icon-only mode via `icon` prop (square buttons)
  - Round icon buttons via `round` prop
- **Density modes:** Supports both spacious and comfortable density
- **Accessibility:** Full keyboard navigation and ARIA support

### Technical

- CSS-variable based styling with data attributes
- Figma Code Connect integration for both Button and Icon Button
- Comprehensive test coverage (63 tests)

## Notes: 
  Comfortable density mode caused a brain twist for me + Claude. We had to add CSS overrides because of an inconsistency in Figma's design specs:                                                  
                                                                                                                                                                                                   
  - Comfortable density uses font-size one step down (e.g., large uses MD font)                                                                                                                    
  - BUT line-height stays at the original size (large keeps LG line-height)                                                                                                                        
                                                                                                                                                                                                   
  Our typography tokens couple font-size and line-height together, so we needed manual overrides to decouple them for comfortable mode. Is this an ok approach in code or should tokens handle this?