### PR TITLE
fix: Autocomplete - restore onBlur and onKeyDown event handler support

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/SingleInput.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/SingleInput.tsx
@@ -20,8 +20,8 @@ export const SingleInput = () => {
       rightAdornmentsWidth={hideClearButton ? 24 + 8 : 24 * 2 + 8}
       rightAdornments={<RightAdornments />}
       {...restHtmlProps}
-      {...consolidatedEvents}
       {...inputProps}
+      {...consolidatedEvents}
     ></Input>
   )
 }


### PR DESCRIPTION
## Summary

Fixes a regression in v2.3.0 where `onBlur` and `onKeyDown` event handlers passed to the Autocomplete component were not being triggered.

### Root cause

The refactoring in v2.3.0 introduced `SingleInput.tsx` with incorrect props spread order:

```tsx
// v2.3.0 (broken)
{...restHtmlProps}
{...consolidatedEvents}
{...inputProps}  // ← overwrites merged events
```

This caused `inputProps` (downshift's internal handlers) to overwrite `consolidatedEvents` (which contains the merged user + internal handlers).

### Fix

Restored the correct order (matching v2.2.0 behavior):

```tsx
// Fixed
{...restHtmlProps}
{...inputProps}
{...consolidatedEvents}  // ← merged events applied last
```

Note: `MultipleInput.tsx` already had the correct order.

## Test plan

- [x] All existing Autocomplete tests pass (30 tests)
- [x] Manual verification that onBlur/onKeyDown handlers work