### PR TITLE
fix: update Field stories to use Input component

### DIFF
--- a/packages/eds-core-react/src/components/next/Field/Field.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.stories.tsx
@@ -204,7 +204,6 @@ export const Disabled: StoryFn<FieldProps> = () => {
         id={inputId}
         value="john.doe"
         disabled
-        readOnly
         aria-describedby={getDescribedBy()}
       />
     </Field>


### PR DESCRIPTION
- Replace native inputs with Input component from next
- Remove Checkbox-related stories (not applicable for Field)
- Add beta tag and warning for consistency with other next components
- Add tip recommending TextField for most use cases
- Add Storybook controls for disabled prop