### PR TITLE
fix: output next bundle to separate directory to prevent export overwrite

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -149,7 +149,7 @@ jobs:
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
             pkg.exports['./next'] = {
               types: './dist/types/index.next.d.ts',
-              import: './dist/esm/index.next.js',
+              import: './dist/esm-next/index.next.js',
               require: './dist/index.next.cjs'
             };
             pkg.exports['./next/index.css'] = './build/index.css';

--- a/packages/eds-core-react/rollup.config.js
+++ b/packages/eds-core-react/rollup.config.js
@@ -74,8 +74,8 @@ const createPlugins = (includeDelete = false) => [
   }),
 ]
 
-const createEsmOutput = () => ({
-  dir: 'dist/esm',
+const createEsmOutput = (dir = 'dist/esm') => ({
+  dir,
   preserveModules: true,
   preserveModulesRoot: 'src',
   format: 'es',
@@ -95,13 +95,14 @@ export default [
     ],
   },
   // Beta components (EDS 2.0)
+  // Output to separate directory to prevent overwriting shared files from main bundle
   {
     input: ['./src/index.next.ts'],
     external: externalDeps,
     watch: watchConfig,
     plugins: createPlugins(false),
     output: [
-      createEsmOutput(),
+      createEsmOutput('dist/esm-next'),
       { file: './dist/index.next.cjs', format: 'cjs', interop: 'auto' },
     ],
   },


### PR DESCRIPTION
## Summary
- Fix EdsProvider missing from package exports in v2.3.1
- Output next/beta bundle to `dist/esm-next` instead of `dist/esm`

## What happened
When building the package, the beta/next components bundle was overwriting files from the main bundle. This caused `EdsProvider` to be removed from the package exports.

## Impact
Users upgrading to v2.3.1 got a build error: `No matching export for import "EdsProvider"`.

## Fix
The next bundle now outputs to a separate directory so it doesn't overwrite the main bundle files.