### PR TITLE
fix: Fix compact density mode for multiple selection in Autocomplete

### DIFF
--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -504,12 +504,37 @@ export const Compact: StoryFn<AutocompleteProps<MyOptionType>> = (args) => {
         }}
         checked={compact}
       />
-      <Autocomplete
-        label="Select a stock"
-        initialSelectedOptions={[options[0]]}
-        options={options}
-        optionLabel={optionLabel}
-      />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          marginTop: '16px',
+          width: '300px',
+        }}
+      >
+        <Autocomplete
+          label="Single select"
+          initialSelectedOptions={[options[0]]}
+          options={options}
+          optionLabel={optionLabel}
+        />
+        <Autocomplete
+          label="Multiple (summary)"
+          multiple
+          initialSelectedOptions={[options[0], options[1]]}
+          options={options}
+          optionLabel={optionLabel}
+        />
+        <Autocomplete
+          label="Multiple (chips)"
+          multiple
+          selectionDisplay="chips"
+          initialSelectedOptions={[options[0], options[1]]}
+          options={options}
+          optionLabel={optionLabel}
+        />
+      </div>
     </EdsProvider>
   )
 }

--- a/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/Autocomplete.test.tsx
@@ -10,6 +10,7 @@ import {
 import '@testing-library/jest-dom'
 import styled from 'styled-components'
 import { Autocomplete } from '.'
+import { EdsProvider } from '../EdsProvider'
 
 const itemObjects = [{ label: 'One' }, { label: 'Two' }, { label: 'Three' }]
 const items = ['One', 'Two', 'Three']
@@ -980,5 +981,47 @@ describe('Autocomplete: Scroll position and navigation memory', () => {
 
     const chip2Button = screen.getByRole('button', { name: /Two/i })
     expect(chip2Button).toHaveFocus()
+  })
+})
+
+describe('Autocomplete: Density mode', () => {
+  it('Has 36px minHeight in comfortable density with multiple chips', () => {
+    const { container } = render(
+      <EdsProvider density="comfortable">
+        <Autocomplete
+          label={labelText}
+          options={items}
+          multiple
+          selectionDisplay="chips"
+        />
+      </EdsProvider>,
+    )
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const inputContainer = container.querySelector(
+      '[style*="min-height: 36px"]',
+    )
+
+    expect(inputContainer).toBeInTheDocument()
+  })
+
+  it('Has 24px minHeight in compact density with multiple chips', () => {
+    const { container } = render(
+      <EdsProvider density="compact">
+        <Autocomplete
+          label={labelText}
+          options={items}
+          multiple
+          selectionDisplay="chips"
+        />
+      </EdsProvider>,
+    )
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const inputContainer = container.querySelector(
+      '[style*="min-height: 24px"]',
+    )
+
+    expect(inputContainer).toBeInTheDocument()
   })
 })

--- a/packages/eds-core-react/src/components/Autocomplete/MultipleInput.tsx
+++ b/packages/eds-core-react/src/components/Autocomplete/MultipleInput.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 import styled from 'styled-components'
 import { Chip } from '../Chip'
+import { useEds } from '../EdsProvider'
 import { Input } from '../Input'
 import { useAutocompleteContext } from './AutocompleteContext'
 import { RightAdornments } from './RightAdornments'
@@ -17,14 +18,18 @@ const UnstyledInput = styled.input`
   }
 `
 
-const ChipContainer = styled.div`
+const ChipContainer = styled.div<{ $density: string }>`
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  height: 100%;
+  align-items: center;
+  align-content: center;
+  min-height: 100%;
+  gap: ${({ $density }) => ($density === 'compact' ? '2px' : '0.5rem')};
+  margin: ${({ $density }) => ($density === 'compact' ? '-2px 0' : '0')};
 `
 
 export const MultipleInput = () => {
+  const { density } = useEds()
   const {
     selectedItems,
     selectionDisplay,
@@ -71,6 +76,8 @@ export const MultipleInput = () => {
       handleChipRemove(item, index, false)
     }
 
+  const minHeight = density === 'compact' ? '24px' : '36px'
+
   return (
     <Input
       as={'div'}
@@ -78,12 +85,12 @@ export const MultipleInput = () => {
       rightAdornmentsWidth={hideClearButton ? 24 + 8 : 24 * 2 + 8}
       rightAdornments={<RightAdornments />}
       readOnly={readOnly}
-      style={{
-        height: 'auto',
-        minHeight: '36px',
-      }}
+      style={
+        selectionDisplay === 'chips' ? { height: 'auto', minHeight } : undefined
+      }
+      data-density={density}
     >
-      <ChipContainer>
+      <ChipContainer $density={density}>
         {selectionDisplay === 'chips' &&
           selectedItems.map((item, index) => (
             <Chip
@@ -94,6 +101,11 @@ export const MultipleInput = () => {
               }}
               style={{
                 outline: '1px solid var(--eds-color-accent-12)',
+                ...(density === 'compact' && {
+                  height: '16px',
+                  fontSize: '12px',
+                  gridGap: '0px',
+                }),
               }}
               onDelete={handleChipDelete(item, index)}
               onClick={handleChipClick(item, index)}


### PR DESCRIPTION
## Summary

Fixes #4466 - Autocomplete + compact does not work with multiple selection.

### Background

After a recent refactoring where we introduced chips display for multiple selection in Autocomplete, the compact density mode stopped working correctly. The `MultipleInput` component was not properly respecting the EdsProvider density context, causing the input to always render at the comfortable height (36px) instead of the compact height (24px).

### Changes

- **MultipleInput.tsx**: Added density-aware styling for chips mode with proper `minHeight` (24px compact, 36px comfortable)
- **ChipContainer**: Added `min-height: 100%` and `align-content: center` for proper vertical text centering
- **Chip styling**: Reduced chip size in compact mode (height: 16px, fontSize: 12px) to fit within compact input
- **Tests**: Added density mode tests verifying correct minHeight values
- **Story**: Updated Compact story to show all three variants (single, multiple summary, multiple chips) in column layout

## Test plan
- [x] Verified compact mode shows 24px height for all Autocomplete variants
- [x] Verified comfortable mode shows 36px height for all Autocomplete variants
- [x] Verified text is vertically centered in both modes
- [x] All 32 Autocomplete tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)