### PR TITLE
fix(github): add missing contents: read permission to publish workflows

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -20,6 +20,7 @@ on:
           - production
         default: 'development'
 permissions:
+  contents: read
   id-token: write
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -18,6 +18,7 @@ on:
       - 'packages/eds-tokens/**'
       - 'packages/eds-icons/**'
 permissions:
+  contents: read
   id-token: write
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- Adds missing `contents: read` permission to `publish_core_react.yaml` and `publish_storybook.yaml`
- These workflows call `_setup.yml` which requires `contents: read`, but only `id-token: write` was declared — implicitly setting all other permissions to `none`
- This was introduced in #4472

## Test plan
- [ ] Re-run the "Publish core-react" workflow and verify it no longer fails with the permissions error

🤖 Generated with [Claude Code](https://claude.com/claude-code)