### PR TITLE
fix(github): add id-token: write permission to purge CDN workflow

### DIFF
--- a/.github/workflows/_purge_cdn.yaml
+++ b/.github/workflows/_purge_cdn.yaml
@@ -11,7 +11,8 @@ on:
 jobs:
   purge:
     name: Purge the cdn to refresh cache
-    permissions: {}
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the `_purge_cdn.yaml` reusable workflow
- The workflow had `permissions: {}` which removed all permissions, preventing Azure federated credential login from obtaining the OIDC token
- This caused the "Purge cdn" job to fail in Publish core-react #189

## Test plan
- [ ] Merge and re-run the "Purge cdn" step or trigger a new publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)