### PR TITLE
chore(deps): add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: weekly
       day: thursday
-      time: '13:30'
+      time: '13:10'
       timezone: Europe/Oslo
     groups:
       all-dependencies:
@@ -24,7 +24,7 @@ updates:
     schedule:
       interval: weekly
       day: thursday
-      time: '13:30'
+      time: '13:10'
       timezone: Europe/Oslo
     groups:
       all-actions:


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to automate dependency updates (#4479)
- Groups all minor/patch npm updates into a single weekly PR, major updates get individual PRs
- Groups GitHub Actions minor/patch updates into a single weekly PR
- Uses `chore(deps)` commit message prefix for conventional commits
- Schedule set to Thursday 13:30 Oslo time for initial testing — will be changed to Monday 05:00 after verification

## Configuration
- **`directory: /`** — Dependabot discovers all pnpm workspace packages from root lockfile
- **`versioning-strategy: increase`** — updates `package.json` versions, not just lockfile
- **`open-pull-requests-limit: 5`**

## Test plan
- [ ] Merge to main and verify Dependabot picks up the config (Settings → Code security → Dependabot)
- [ ] Trigger manual check or wait for scheduled run
- [ ] Verify PR has correct title format and `pnpm-lock.yaml` is updated across workspaces
- [ ] Verify CI passes on the generated PR
- [ ] Change schedule back to Monday 05:00 after successful test

🤖 Generated with [Claude Code](https://claude.com/claude-code)