### PR TITLE
fix(github): allow bot actors in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'dependabot[bot],github-actions[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Adds `dependabot[bot]` and `github-actions[bot]` to `allowed_bots` in the Claude Code Review workflow
- Fixes Dependabot PRs failing with: `Workflow initiated by non-human actor: dependabot (type: Bot)`
- Also allows release-please PRs (`github-actions[bot]`) to be reviewed

## Test plan
- [ ] Verify Claude Code Review runs successfully on Dependabot PRs
- [ ] Verify Claude Code Review runs successfully on release-please PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)