### PR TITLE
chore(config): prevent chore/ci/build/test from triggering releases

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -83,19 +83,23 @@
     },
     {
       "type": "chore",
-      "section": "🔧 Chores"
+      "section": "🔧 Chores",
+      "hidden": true
     },
     {
       "type": "ci",
-      "section": "👷 CI/CD"
+      "section": "👷 CI/CD",
+      "hidden": true
     },
     {
       "type": "build",
-      "section": "📦 Build System"
+      "section": "📦 Build System",
+      "hidden": true
     },
     {
       "type": "test",
-      "section": "✅ Tests"
+      "section": "✅ Tests",
+      "hidden": true
     }
   ],
 


### PR DESCRIPTION
## Summary
- Add `hidden: true` to `chore`, `ci`, `build`, and `test` commit types in release-please config
- Only `feat` and `fix` commits should trigger npm releases and version bumps
- These commit types will still appear in changelogs when accompanying actual releasable changes

## Why
Dependabot `chore(deps)` commits (like devDependency bumps) were triggering unnecessary patch releases and npm publishes, even though they don't change anything for consumers.