### PR TITLE
fix: Potential fix for code scanning alert no. 46: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-tokens-to-figma.yml
+++ b/.github/workflows/sync-tokens-to-figma.yml
@@ -1,4 +1,6 @@
 name: Sync tokens to Figma
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/design-system/security/code-scanning/46](https://github.com/equinor/design-system/security/code-scanning/46)

In general, fix this by adding an explicit `permissions:` block that grants only the minimal scopes required by the workflow, either at the root (applies to all jobs) or per job. Since the visible jobs don’t clearly need any write operations via `GITHUB_TOKEN`, we can safely restrict permissions to read‑only repository contents.

The best minimal change is to add a top‑level `permissions:` block after `name:` (before `on:`) in `.github/workflows/sync-tokens-to-figma.yml`, setting `contents: read`. This documents that the workflow only needs read access to repository contents and ensures that, even if org/repo defaults change or the workflow is copied elsewhere, the token remains restricted. No other functionality is altered because none of the shown steps require higher privileges.

Concretely:
- Edit `.github/workflows/sync-tokens-to-figma.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Sync tokens to Figma`) and line 2 (`on:`). No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
