### PR TITLE
docs(eds-tokens): add CLAUDE.md to token packages

### DIFF
--- a/packages/eds-tokens-build/CLAUDE.md
+++ b/packages/eds-tokens-build/CLAUDE.md
@@ -1,0 +1,57 @@
+# @equinor/eds-tokens-build
+
+Build tools and generate scripts for EDS design tokens. Provides CLI binaries consumed by `eds-tokens`.
+
+## Scripts run from compiled dist
+
+All CLI binaries point to `dist/scripts/*.js`. After editing any source file, you **must rebuild** before the changes take effect:
+
+```bash
+pnpm run build   # tsc && vite build
+```
+
+If you skip this, `eds-tokens` will still run the old compiled version and your changes won't apply.
+
+## Generate Scripts
+
+These generate token JSON files in `eds-tokens/tokens/` from `eds-tokens/token-config.json`:
+
+| Script | Writes | Config key |
+|---|---|---|
+| `generate-color-scheme-tokens` | `🌗 Color Scheme.{Light,Dark}.json` | `colorSchemeConfig` + `conceptColorGroups` |
+| `generate-semantic-tokens` | `Semantic.Mode 1.json` | `colorSchemeConfig` |
+| `generate-dynamic-appearance-tokens` | `🎨 Appearance.*.json` | `colorSchemeConfig` |
+| `generate-concept-tokens` | `Concept.Mode 1.json` (static + dynamic) | `conceptColorGroups` |
+
+### Adding new tokens
+
+When adding new token categories (like disabled states):
+
+1. Add entries to `token-config.json` (in `eds-tokens`) if they're concept-level (`conceptColorGroups`) or scheme-level (`colorSchemeConfig`)
+2. Update the relevant generate script(s) in `src/scripts/`
+3. Rebuild this package: `pnpm run build`
+4. Run the generate script from `eds-tokens` to verify output matches Figma sync
+5. If output differs from Figma only in `codeSyntax.WEB` values, the generated version is likely correct (Figma sometimes assigns wrong WEB variable names)
+
+## Build Scripts
+
+These compile token JSON into CSS/JS/JSON output:
+
+| Script | Input | Output |
+|---|---|---|
+| `build-color-scheme-variables` | Color scheme JSON | `build/css/color/color-scheme/`, JS, JSON |
+| `build-semantic-static-variables` | Semantic + color scheme JSON | `build/css/color/static/`, JS, JSON |
+| `build-semantic-dynamic-variables` | Appearance JSON | `build/css/color/dynamic/`, JS, JSON |
+
+## Key Source Files
+
+- `src/scripts/generate-*.ts` — Token generation scripts
+- `src/scripts/build-*.ts` — CSS/JS compilation scripts
+- `src/scripts/utils.ts` — Shared utilities (`buildToken`, `varName`, `loadTokenConfig`, etc.)
+
+## Testing
+
+```bash
+pnpm run test      # vitest watch
+pnpm run test:run  # vitest single run
+```

--- a/packages/eds-tokens-sync/CLAUDE.md
+++ b/packages/eds-tokens-sync/CLAUDE.md
@@ -1,0 +1,59 @@
+# @equinor/eds-tokens-sync
+
+Two-way sync between Figma variables and local JSON token files.
+
+## Setup
+
+Requires a Figma personal access token. Create `bin/.env`:
+
+```
+PERSONAL_ACCESS_TOKEN=your-figma-token
+```
+
+The `.env.example` file shows the format. Never commit the actual `.env` file.
+
+## CLI Commands
+
+Run from `eds-tokens` (not from this package):
+
+```bash
+# Figma → JSON (pull)
+pnpm run update-tokens              # All tokens
+pnpm run update-tokens:foundations   # Foundation palette + color scheme
+pnpm run update-tokens:color-static # Static semantic + concept
+pnpm run update-tokens:color-dynamic # Dynamic appearance + concept
+
+# JSON → Figma (push)
+pnpm run update-figma               # All tokens
+```
+
+## How It Works
+
+### Figma → JSON (`sync-figma-to-tokens`)
+- Calls Figma REST API to read local variables from a file
+- Transforms variable collections/modes into JSON files
+- Writes to `eds-tokens/tokens/{fileKey}/`
+- File naming: `{collectionName}.{modeName}.json`
+
+### JSON → Figma (`sync-tokens-to-figma`)
+- Reads JSON files from `eds-tokens/tokens/{fileKey}/`
+- Flattens token paths to `{group/subgroup/token}` format
+- Resolves `{Reference}` aliases to Figma variable IDs
+- Creates/updates variables via Figma POST API
+
+## Figma File Keys
+
+Defined in `eds-tokens/token-config.json`:
+
+| File | Key | Contents |
+|---|---|---|
+| EDS Foundations | `GnovDpL3UV6X51Ot7Kv6Im` | Palette colors, color scheme |
+| EDS Static | `OWxw2XogDLUt1aCvcDFXPw` | Semantic tokens, concept tokens |
+| EDS Dynamic | `nyPaQ3QnI1UAcxKW4a0d2c` | Appearance tokens, concept tokens |
+| Spacing primitives | `cpNchKjiIM19dPqTxE0fqg` | Spacing scale |
+| Spacing modes | `FQQqyumcpPQoiFRCjdS9GM` | Spacing density variants |
+
+## Important
+
+- Synced files and generated files write to the **same paths**. After syncing new tokens from Figma, update the generate scripts in `eds-tokens-build` so they produce matching output.
+- The `codeSyntax.WEB` field in synced JSON is Figma metadata for the code panel — it does not affect CSS build output. Figma sometimes assigns incorrect WEB values; the generate scripts produce correct ones.

--- a/packages/eds-tokens/CLAUDE.md
+++ b/packages/eds-tokens/CLAUDE.md
@@ -1,0 +1,83 @@
+# @equinor/eds-tokens
+
+Design tokens package — CSS variables, JSON, and JS/TS outputs consumed by EDS components and product teams.
+
+## Build Pipeline (3 steps)
+
+```
+1. Figma → JSON       (pnpm run update-tokens)
+        OR
+   Config → JSON      (pnpm run generate:tokens:all-color)
+
+2. JSON → CSS/JS      (pnpm run build:variables:color)
+
+3. CSS → Bundle       (pnpm run _build:css)
+```
+
+**Or all at once:** `pnpm run build:variables` (clean + typography + spacing + color + bundle)
+
+### Step 1: Get token JSON files
+
+**Option A — Sync from Figma** (requires `.env` with `PERSONAL_ACCESS_TOKEN` in `eds-tokens-sync/bin/`):
+```bash
+pnpm run update-tokens              # All tokens
+pnpm run update-tokens:foundations   # Foundation palette + color scheme
+pnpm run update-tokens:color-static # Static semantic + concept
+pnpm run update-tokens:color-dynamic # Dynamic appearance + concept
+```
+
+**Option B — Generate from config** (no Figma access needed):
+```bash
+pnpm run generate:tokens:all-color  # All color tokens
+pnpm run generate:tokens:static     # Color scheme + semantic + concept
+pnpm run generate:tokens:dynamic    # Color scheme + appearance + concept
+```
+
+Both write to the same `tokens/` directory. They must stay in sync.
+
+### Step 2: Compile to CSS/JS/JSON
+
+```bash
+pnpm run build:variables:color  # Compiles all color tokens
+```
+
+Outputs go to `build/css/color/`, `build/js/color/`, `build/json/color/`.
+
+### Step 3: Bundle into final output
+
+```bash
+pnpm run _build:css
+```
+
+Bundles all `@import`s from `src/css/index-variables.css` into `build/css/variables.min.css` using lightningcss. **This is the file consumers import.**
+
+## Pitfalls
+
+### Missing step 3
+Running only `build:variables:color` compiles individual CSS files but does NOT update `variables.min.css`. Tokens will exist in `build/css/color/*/` but not reach the browser. Always run `_build:css` after.
+
+### Generate scripts overwrite Figma sync
+The generate scripts write to the **same files** as the Figma sync. If you add tokens via Figma sync, you must also update the generate scripts and `token-config.json`, otherwise running `generate:tokens:all-color` will silently remove the new tokens.
+
+### Build output is git-tracked
+The `build/` directory is in `.gitignore` but files are tracked. Use `git add -f` when staging build output changes.
+
+### Generate scripts run from compiled dist
+The generate scripts in `eds-tokens-build` run from `dist/`, not `src/`. After editing a generate script, you must rebuild `eds-tokens-build` first:
+```bash
+cd ../eds-tokens-build && pnpm run build
+```
+
+## Key Files
+
+- `token-config.json` — Drives generate scripts: color scheme mappings, concept color groups, Figma file IDs
+- `src/css/index-variables.css` — Entry point for the CSS bundle (step 3)
+- `tokens/{figmaFileKey}/` — Synced/generated JSON token files
+- `build/css/variables.min.css` — Final bundled output consumers import
+
+## Token Structure
+
+- **Color scheme** (`🌗 Color Scheme.*.json`) — Foundation palette → semantic mapping (Accent→Moss Green, Neutral→Gray) + concept tokens (bg-disabled, bg-floating, etc.)
+- **Semantic** (`Semantic.Mode 1.json`) — Per-intent tokens: Bg/Border/Text × Canvas/Surface/Fill/Subtle/Medium/Strong
+- **Appearance** (`🎨 Appearance.*.json`) — Generic slot tokens per semantic intent, used with `[data-color-appearance]`
+- **Concept** (`Concept.Mode 1.json`) — Cross-cutting tokens that reference color scheme (bg-floating, border-focus, bg-disabled, etc.)


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to `eds-tokens`, `eds-tokens-build`, and `eds-tokens-sync`
- Documents the 3-step build pipeline, setup, and common pitfalls discovered during #4239

Closes #4526

## Test plan
- [x] Verify CLAUDE.md files are picked up by Claude Code when working in each package