### PR TITLE
refactor: use semantic disabled tokens in next components

### DIFF
--- a/packages/eds-core-react/src/components/next/Button/button.css
+++ b/packages/eds-core-react/src/components/next/Button/button.css
@@ -161,8 +161,8 @@
   }
 
   .eds-button[data-variant='primary']:disabled {
-    background-color: var(--eds-color-bg-fill-muted-default);
-    color: var(--eds-color-border-medium);
+    background-color: var(--eds-color-bg-fill-emphasis-disabled);
+    color: var(--eds-color-text-disabled);
     cursor: not-allowed;
   }
 
@@ -186,9 +186,9 @@
 
   .eds-button[data-variant='secondary']:disabled {
     outline: var(--eds-border-width-default, 1px) solid
-      var(--eds-color-border-medium);
+      var(--eds-color-border-disabled);
     outline-offset: calc(-1 * var(--eds-border-width-default, 1px));
-    color: var(--eds-color-border-medium);
+    color: var(--eds-color-text-disabled);
     cursor: not-allowed;
   }
 
@@ -208,7 +208,7 @@
   }
 
   .eds-button[data-variant='ghost']:disabled {
-    color: var(--eds-color-border-medium);
+    color: var(--eds-color-text-disabled);
     cursor: not-allowed;
   }
 

--- a/packages/eds-core-react/src/components/next/Checkbox/checkbox.css
+++ b/packages/eds-core-react/src/components/next/Checkbox/checkbox.css
@@ -146,7 +146,7 @@
   }
 
   .eds-checkbox[data-disabled='true'] .eds-checkbox__icon {
-    fill: var(--eds-color-border-medium);
+    fill: var(--eds-color-text-disabled);
   }
 
   /* Icon visibility */
@@ -185,7 +185,7 @@
   }
 
   .eds-field.eds-checkbox[data-disabled='true'] .eds-field__label {
-    color: var(--eds-color-border-medium);
+    color: var(--eds-color-text-disabled);
     cursor: not-allowed;
   }
 

--- a/packages/eds-core-react/src/components/next/Field/field.css
+++ b/packages/eds-core-react/src/components/next/Field/field.css
@@ -58,6 +58,6 @@
 
   /* Only helper message changes color when disabled */
   .eds-field[data-disabled='true'] {
-    --_eds-field-helper-color: var(--eds-color-border-neutral-medium);
+    --_eds-field-helper-color: var(--eds-color-text-disabled);
   }
 }

--- a/packages/eds-core-react/src/components/next/Input/input.css
+++ b/packages/eds-core-react/src/components/next/Input/input.css
@@ -80,23 +80,23 @@
       outline-color: transparent;
 
       & .eds-input {
-        color: var(--eds-color-border-medium);
+        color: var(--eds-color-text-disabled);
         cursor: not-allowed;
         opacity: 1;
         -webkit-text-fill-color: var(
-          --eds-color-border-medium
+          --eds-color-text-disabled
         ); /* Safari autofill override */
 
         &::placeholder {
-          color: var(--eds-color-border-medium);
-          -webkit-text-fill-color: var(--eds-color-border-medium);
+          color: var(--eds-color-text-disabled);
+          -webkit-text-fill-color: var(--eds-color-text-disabled);
         }
       }
 
       & .eds-adornment__text,
       & .eds-adornment__adornment,
       & .eds-error-icon {
-        color: var(--eds-color-border-medium);
+        color: var(--eds-color-text-disabled);
       }
     }
 

--- a/packages/eds-core-react/src/components/next/Radio/radio.css
+++ b/packages/eds-core-react/src/components/next/Radio/radio.css
@@ -143,7 +143,7 @@
   }
 
   .eds-radio[data-disabled='true'] .eds-radio__icon {
-    fill: var(--eds-color-border-medium);
+    fill: var(--eds-color-text-disabled);
   }
 
   /* Icon visibility */
@@ -168,7 +168,7 @@
   }
 
   .eds-field.eds-radio[data-disabled='true'] .eds-field__label {
-    color: var(--eds-color-border-medium);
+    color: var(--eds-color-text-disabled);
     cursor: not-allowed;
   }
 }

--- a/packages/eds-core-react/src/components/next/Switch/switch.css
+++ b/packages/eds-core-react/src/components/next/Switch/switch.css
@@ -50,7 +50,7 @@
     }
 
     &[data-disabled='true'] .eds-field__label {
-      color: var(--eds-color-border-medium);
+      color: var(--eds-color-text-disabled);
       cursor: not-allowed;
     }
   }
@@ -124,7 +124,7 @@
     }
 
     .eds-switch:has(.eds-switch__input:disabled) & {
-      background-color: var(--eds-color-border-medium);
+      background-color: var(--eds-color-bg-disabled);
       box-shadow: none;
     }
   }


### PR DESCRIPTION
## Summary
- Replace incorrect use of `--eds-color-border-medium` and `--eds-color-border-neutral-medium` with dedicated disabled state tokens in all `/next` components
- Uses `--eds-color-text-disabled`, `--eds-color-border-disabled`, `--eds-color-bg-fill-emphasis-disabled`, and `--eds-color-bg-disabled` introduced in #4525
- No visual change — tokens currently resolve to the same values, but this ensures components update correctly if disabled colors are changed in the future

## Test plan
- [x] Verified visually in Storybook (localhost vs prod) — no visual diff
- [x] Confirmed no remaining `--eds-color-border-medium` usage in disabled contexts
- [x] Review disabled states in Storybook for Button, Switch, Radio, Checkbox, Input, TextField

Ref #4239