### PR TITLE
feat(eds-core-react): add dark mode toggle to Storybook

### DIFF
--- a/packages/eds-core-react/.storybook/manager.mjs
+++ b/packages/eds-core-react/.storybook/manager.mjs
@@ -1,45 +1,6 @@
-import {
-  addons,
-  types,
-  useGlobals,
-  useStorybookState,
-} from 'storybook/manager-api'
-import { createElement } from 'react'
-import { IconButton } from 'storybook/internal/components'
+import { addons } from 'storybook/manager-api'
 
 import { theme } from './theme.mjs'
-
-const ADDON_ID = 'eds-color-scheme-toggle'
-
-addons.register(ADDON_ID, () => {
-  addons.add(ADDON_ID, {
-    type: types.TOOL,
-    title: 'Color Scheme',
-    render: () => {
-      const [globals, updateGlobals] = useGlobals()
-      const state = useStorybookState()
-      const story = state.index?.[state.storyId]
-      const isNext = story?.title?.startsWith('EDS 2.0')
-
-      if (!isNext) return null
-
-      const isDark = globals.colorScheme === 'dark'
-
-      return createElement(
-        IconButton,
-        {
-          key: ADDON_ID,
-          title: isDark ? 'Switch to light mode' : 'Switch to dark mode',
-          onClick: () =>
-            updateGlobals({
-              colorScheme: isDark ? 'light' : 'dark',
-            }),
-        },
-        isDark ? '☾ Dark mode' : '☼ Light mode',
-      )
-    },
-  })
-})
 
 addons.setConfig({
   theme,

--- a/packages/eds-core-react/.storybook/preview.mjs
+++ b/packages/eds-core-react/.storybook/preview.mjs
@@ -5,6 +5,21 @@ import '../src/components/next/index.css'
 const preview = {
   viewMode: 'docs',
 
+  globalTypes: {
+    colorScheme: {
+      description: 'Color scheme for components',
+      toolbar: {
+        title: 'Color Scheme',
+        icon: 'mirror',
+        items: [
+          { value: 'light', title: 'Light', icon: 'sun' },
+          { value: 'dark', title: 'Dark', icon: 'moon' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+
   initialGlobals: {
     colorScheme: 'light',
   },


### PR DESCRIPTION
## Summary
- Adds a single-click Light/Dark toggle button to the Storybook toolbar (custom addon in `manager.mjs`)
- Wraps stories with `data-color-scheme` attribute and `--eds-color-bg-neutral-surface` background so EDS tokens respond to the selected color scheme
- Scoped to **EDS 2.0 (beta)** stories only — the toggle button and wrapper are hidden for legacy component stories

Closes #4534

## Test plan
- [x] Start Storybook and navigate to an EDS 2.0 story — verify the toggle appears in the toolbar
- [x] Navigate to a legacy component story — verify the toggle is hidden
- [x] Click the toggle and confirm background and component colors switch to dark mode
- [x] Click again and confirm everything reverts to light mode