### PR TITLE
chore(github): group major dependency bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,5 +86,6 @@ updates:
         patterns:
           - '*'
         update-types:
+          - major
           - minor
           - patch


### PR DESCRIPTION
## Summary
- Add dependency groups for major version bumps: **storybook**, **react**, **react-aria**, **rollup**, and **testing**
- Major bumps for related packages will now be raised as a single PR instead of separate PRs per package
- Minor and patch updates continue to be bundled in the existing `all-dependencies` group

## Context
Dependabot splits major version bumps into separate PRs per package. This caused issues with e.g. Storybook v10 where `storybook`, `@storybook/addon-docs`, `@storybook/addon-a11y` etc. each got their own PR, making it impossible to merge them individually without version mismatches.

## Test plan
- [ ] Verify next dependabot run groups major bumps correctly
- [ ] Verify minor/patch updates still bundle in `all-dependencies`