### PR TITLE
feat(eds-icons): add manage_accounts icon

### DIFF
--- a/packages/eds-icons/package.json
+++ b/packages/eds-icons/package.json
@@ -37,8 +37,8 @@
   },
   "keywords": [
     "eds",
-    "design system",
     "equinor",
+    "design system",
     "icons"
   ],
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Empty commit to trigger a minor release of `@equinor/eds-icons` for the `manage_accounts` icon added in #4488
- The icon was already added to the codebase but the original PR used `chore(figma-broker)` scope, so release-please did not pick it up for an eds-icons release

## Test plan
- [ ] Verify release-please creates a minor version bump for eds-icons after merge