### PR TITLE
fix: icon color in TextField not adapting to dark mode

### DIFF
--- a/packages/eds-core-react/src/components/next/TextField/text-field.css
+++ b/packages/eds-core-react/src/components/next/TextField/text-field.css
@@ -14,13 +14,13 @@
     padding: 0;
     border: none;
     background: transparent;
-    color: var(--eds-color-icon-subtle);
+    color: var(--eds-color-text-strong);
     cursor: pointer;
     margin-block: calc(var(--eds-sizing-icon-xs) / -2);
 
     &:hover,
     &:focus-visible {
-      color: var(--eds-color-icon-info);
+      color: var(--eds-color-text-strong);
 
       & svg {
         background: var(--eds-color-bg-fill-muted-hover);


### PR DESCRIPTION
## Summary
- Replaces undefined `--eds-color-icon-subtle` and `--eds-color-icon-info` tokens with `--eds-color-text-strong` in `text-field.css`
- These tokens did not exist in the token system, causing the info icon to not adapt its color in dark mode
- `--eds-color-text-strong` uses `light-dark()` and correctly updates in both light and dark mode

Fixes #4561

## Test plan
- [ ] Verify info icon color updates correctly when switching to dark mode in Storybook