### PR TITLE
chore(config): add exclude-paths and make docs type hidden in release-please

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -185,6 +185,8 @@ type(scope): description
 
 **Breaking**: `feat(eds-core-react)!: remove deprecated prop`
 
+**Scope and release-please interaction**: Release-please detects packages from file paths — you don't always need a package scope. Using a package scope with a visible type forces a bump regardless of which files changed. For non-publishable changes (config, Storybook, tests, README, docs), use hidden types: `chore`, `build`, `ci`, `docs`, or `test`.
+
 See `documentation/how-to/CONVENTIONAL_COMMITS.md` for full guidelines.
 
 ## Git Workflow

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -36,27 +36,82 @@
     "packages/eds-data-grid-react": {
       "release-type": "node",
       "package-name": "@equinor/eds-data-grid-react",
-      "component": "eds-data-grid-react"
+      "component": "eds-data-grid-react",
+      "exclude-paths": [
+        ".storybook",
+        "src/tests",
+        "src/stories",
+        "src/EdsDataGrid.stories.tsx",
+        "jest.config.ts",
+        "jest.setup.ts",
+        "rollup.config.js",
+        "tsconfig.json",
+        "tsconfig.build.json",
+        "tsconfig.test.json",
+        "README.md"
+      ]
     },
     "packages/eds-icons": {
       "release-type": "node",
       "package-name": "@equinor/eds-icons",
-      "component": "eds-icons"
+      "component": "eds-icons",
+      "exclude-paths": [
+        "rollup.config.js",
+        "tsconfig.json",
+        "README.md"
+      ]
     },
     "packages/eds-lab-react": {
       "release-type": "node",
       "package-name": "@equinor/eds-lab-react",
-      "component": "eds-lab-react"
+      "component": "eds-lab-react",
+      "exclude-paths": [
+        ".storybook",
+        "stories",
+        "src/stories",
+        "babel.config.cjs",
+        "jest.config.cjs",
+        "jest.setup.ts",
+        "rollup.config.js",
+        "tsconfig.json",
+        "tsconfig.build.json",
+        "tsconfig.test.json",
+        "Dockerfile.storybook",
+        "nginx.conf",
+        "README.md"
+      ]
     },
     "packages/eds-tokens": {
       "release-type": "node",
       "package-name": "@equinor/eds-tokens",
-      "component": "eds-tokens"
+      "component": "eds-tokens",
+      "exclude-paths": [
+        "tokens",
+        "build-generate-variables",
+        ".vscode",
+        ".gitignore",
+        "rollup.config.js",
+        "tsconfig.json",
+        "vite.generate-variables.config.ts",
+        "palette-config.json",
+        "token-config.json",
+        "tokens.json",
+        "README.md",
+        "CLAUDE.md"
+      ]
     },
     "packages/eds-utils": {
       "release-type": "node",
       "package-name": "@equinor/eds-utils",
-      "component": "eds-utils"
+      "component": "eds-utils",
+      "exclude-paths": [
+        "rollup.config.js",
+        "tsconfig.json",
+        "tsconfig.build.json",
+        "vitest.config.ts",
+        "vitest.setup.ts",
+        "README.md"
+      ]
     }
   },
   "separate-pull-requests": false,
@@ -71,7 +126,8 @@
     },
     {
       "type": "docs",
-      "section": "📝 Changed"
+      "section": "📝 Changed",
+      "hidden": true
     },
     {
       "type": "perf",

--- a/.github/release-please-config.md
+++ b/.github/release-please-config.md
@@ -97,6 +97,12 @@ The `eds-core-react` package uses a **dual release strategy** to support both st
 - `prerelease-type: "beta"`: Adds `-beta.X` suffix to versions
 - `changelog-path`: Uses separate changelog for beta releases
 
+### Exclude Paths
+
+All packages use `exclude-paths` to prevent non-publishable files from triggering version bumps. This includes config files, test files, Storybook, documentation, and build tooling.
+
+**Important limitation:** `exclude-paths` only filters file-path-based detection. If a commit has a **scope that matches a package's `component` name** (e.g. `feat(eds-core-react): ...`), it will trigger a release for that package regardless of `exclude-paths`. To avoid this, use non-release-triggering types (`chore`, `build`, `ci`, `test`) for commits that only touch excluded files. See `documentation/how-to/CONVENTIONAL_COMMITS.md` for guidance.
+
 ## Pull Request Configuration
 
 ### Combined Releases

--- a/documentation/how-to/CONVENTIONAL_COMMITS.md
+++ b/documentation/how-to/CONVENTIONAL_COMMITS.md
@@ -115,6 +115,33 @@ refactor(eds-tokens, eds-icons): standardize naming conventions
 ❌ `FEAT(eds-core-react): add button` (uppercase type)
 ❌ `feat(eds-core-react) add button` (missing colon)
 
+## Scope and Release-Please Interaction
+
+**Important:** The commit scope directly affects which packages get version bumps via release-please. If a commit scope matches a package's `component` name (e.g. `eds-core-react`), it will trigger a release for that package **regardless of which files were changed** — even if the files are in `exclude-paths`.
+
+### When to avoid package scopes
+
+Release-please detects which packages are affected based on **file paths** — you don't always need a package scope. For example, a commit touching `packages/eds-tokens/src/color.ts` will automatically be associated with `eds-tokens`. Omitting the scope avoids accidentally forcing a bump via scope-matching.
+
+### When to use a scope
+
+- **Package scope** (`eds-core-react`, `eds-tokens`, etc.): Only when the commit message alone doesn't make the package clear, or for changelog readability. Be aware this forces a bump regardless of `exclude-paths`.
+- **Infrastructure scope** (`config`, `github`, `build`, `deps`): For changes that don't belong to a specific package.
+- **No scope**: Perfectly fine for most commits — release-please will figure it out from the file paths.
+
+### Avoiding unnecessary version bumps
+
+For commits that only touch **non-publishable files** (config, docs, Storybook, tests), use a hidden type:
+
+| Scenario | Recommended | Avoid |
+| --- | --- | --- |
+| Storybook-only changes | `chore: ...` or `build(config): ...` | `feat(eds-core-react): ...` |
+| Config file updates | `chore(config): ...` or `build: ...` | `feat(eds-core-react): ...` |
+| Test-only changes | `test: ...` | `feat(eds-core-react): ...` |
+| README/docs in packages | `docs: ...` or `chore: ...` | `feat(eds-core-react): ...` |
+
+The types `chore`, `ci`, `build`, `docs`, and `test` are hidden in release-please and will not trigger version bumps.
+
 ## Emojis (Optional)
 
 Emojis are supported and can be placed after the colon:


### PR DESCRIPTION
## Summary
- Add `exclude-paths` to release-please config for all packages missing it (eds-data-grid-react, eds-icons, eds-lab-react, eds-tokens, eds-utils) to prevent non-publishable files from triggering unnecessary version bumps
- Make `docs` changelog section hidden — documentation changes (Docusaurus) are deployed separately and should not trigger npm releases
- Document scope and release-please interaction in CLAUDE.md and CONVENTIONAL_COMMITS.md to prevent future misuse (e.g. `feat(eds-core-react)` for Storybook-only changes)

## Context
Commits like `feat(eds-core-react): add dark mode toggle to Storybook` (#4535) and `docs(eds-tokens): add CLAUDE.md` (#4527) triggered unnecessary version bumps. This was caused by:
1. Missing `exclude-paths` for most packages
2. `docs` type not being hidden in release-please
3. Package scopes forcing bumps regardless of `exclude-paths` (expected release-please behavior, now documented)

Closes #4546

## Test plan
- [ ] Verify `release-please-config.json` is valid JSON (validated locally)
- [ ] Review exclude-paths for each package match non-publishable files
- [ ] Review documentation changes in CONVENTIONAL_COMMITS.md and CLAUDE.md