### PR TITLE
fix(github): add gh api to claude-review allowed-tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,4 +68,4 @@ jobs:
             test coverage with jest-axe, and conventional commits.
             Refer to CLAUDE.md and .github/copilot-instructions.md for detailed conventions."
             --allowed-tools
-            "Bash(git:*),Bash(gh pr:*),Bash(gh issue:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*)"
+            "Bash(git:*),Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*)"


### PR DESCRIPTION
## Summary
- The `code-review` plugin in the Claude Code Review workflow needs `gh api` access to fetch file contents and post PR reviews
- Without it, these calls were silently denied (10+ permission denials in [the last run](https://github.com/equinor/design-system/actions/runs/22348943113/job/64670742921?pr=4572)), preventing the review from being posted
- Adds `Bash(gh api:*)` to `allowed_tools` in the workflow

## Test plan
- [ ] Re-run the Claude Code Review workflow on an open PR and verify a review is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)