### PR TITLE
fix(eds-color-palette-generator): handle nullable OKLCH color coordinates

### DIFF
--- a/apps/eds-color-palette-generator/src/components/ChromaDistributionDemo.tsx
+++ b/apps/eds-color-palette-generator/src/components/ChromaDistributionDemo.tsx
@@ -35,7 +35,7 @@ export const ChromaDistributionDemo = ({
     try {
       const base = new Color(baseColor)
       const oklchBase = base.to('oklch')
-      const baseChroma = oklchBase.c
+      const baseChroma = oklchBase.c ?? 0
 
       return lightnessValues.map((lightness) => {
         const multiplier = gaussian(lightness, mean, stdDev)

--- a/apps/eds-color-palette-generator/src/components/ColorScale.tsx
+++ b/apps/eds-color-palette-generator/src/components/ColorScale.tsx
@@ -60,9 +60,9 @@ function getOklchInfo(colorValue: string, index: number): OklchInfo {
     const oklch = color.to('oklch')
 
     return {
-      l: parseFloat(oklch.l.toFixed(3)),
-      c: parseFloat(oklch.c.toFixed(3)),
-      h: parseFloat((isNaN(oklch.h) ? 0 : oklch.h).toFixed(1)),
+      l: parseFloat((oklch.l ?? 0).toFixed(3)),
+      c: parseFloat((oklch.c ?? 0).toFixed(3)),
+      h: parseFloat((oklch.h == null || isNaN(oklch.h) ? 0 : oklch.h).toFixed(1)),
       value: colorValue,
       index: index,
     }

--- a/apps/eds-color-palette-generator/src/utils/color.ts
+++ b/apps/eds-color-palette-generator/src/utils/color.ts
@@ -68,8 +68,10 @@ export function gaussian(
 export function formatColorAsString(color: Color, format: ColorFormat): string {
   if (format === 'OKLCH') {
     const oklch = color.to('oklch')
-    const hue = isNaN(oklch.h) ? 0 : oklch.h
-    return `oklch(${oklch.l.toFixed(3)} ${oklch.c.toFixed(3)} ${hue.toFixed(1)})`
+    const l = oklch.l ?? 0
+    const c = oklch.c ?? 0
+    const hue = oklch.h == null || isNaN(oklch.h) ? 0 : oklch.h
+    return `oklch(${l.toFixed(3)} ${c.toFixed(3)} ${hue.toFixed(1)})`
   } else {
     // Default to HEX format
     const srgbColor = color.to('srgb')
@@ -210,8 +212,8 @@ export function generateColorScaleWithInterpolation(
       const oklchColor = interpolatedColor.to('oklch')
 
       // Get the interpolated hue and base chroma
-      const interpolatedHue = isNaN(oklchColor.h) ? 0 : oklchColor.h
-      const baseChroma = oklchColor.c
+      const interpolatedHue = oklchColor.h == null || isNaN(oklchColor.h) ? 0 : oklchColor.h
+      const baseChroma = oklchColor.c ?? 0
 
       // Create the final color with Gaussian-adjusted chroma
       const finalColor = createColorWithGaussianChroma(
@@ -268,8 +270,8 @@ export function generateColorScale(
         const color = new Color(base.toString({ format: 'hex' }))
         // Convert to OKLCH to get the chroma and hue values
         const oklchColor = color.to('oklch')
-        const baseChroma = oklchColor.c
-        const hue = isNaN(oklchColor.h) ? 0 : oklchColor.h
+        const baseChroma = oklchColor.c ?? 0
+        const hue = oklchColor.h == null || isNaN(oklchColor.h) ? 0 : oklchColor.h
 
         // Create the final color with Gaussian-adjusted chroma
         const finalColor = createColorWithGaussianChroma(


### PR DESCRIPTION
## Summary
- colorjs.io updated its types so OKLCH coordinates (`.l`, `.c`, `.h`) are now `number | null` instead of `number`
- This broke the `next build` for color-palette-generator in the Radix pipeline (introduced by the deps bump in #4560, but not caught until now)
- Adds null coalescing (`?? 0`) to all OKLCH coordinate usages across 3 files

## Test plan
- [x] `pnpm --filter @equinor/eds-color-palette-generator run build` passes locally