### PR TITLE
fix(eds-core-react): stabilise DatePicker popover size when navigating months

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarGrid.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarGrid.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import { CalendarState, RangeCalendarState } from '@react-stately/calendar'
-import { AriaCalendarGridProps, useCalendarGrid, useLocale } from 'react-aria'
-import { getWeeksInMonth } from '@internationalized/date'
+import { AriaCalendarGridProps, useCalendarGrid } from 'react-aria'
 import { CalendarCell } from './CalendarCell'
 import { YearGrid } from './YearGrid'
 import { Dispatch, SetStateAction } from 'react'
@@ -23,15 +22,14 @@ export function CalendarGrid({
   yearPickerPage: number
   setYearPickerPage: Dispatch<SetStateAction<number>>
 } & AriaCalendarGridProps) {
-  const { locale } = useLocale()
   const { gridProps, headerProps, weekDays } = useCalendarGrid(
     { ...props, weekdayStyle: 'long' },
     state,
   )
 
-  // Get the number of weeks in the month so that we can render the proper number of rows.
-  const howManyWeeksInMonth = getWeeksInMonth(state.visibleRange.start, locale)
-  const weeksInMonthArray = [...new Array(howManyWeeksInMonth).keys()]
+  // Always render 6 rows (the maximum weeks in any month) so the calendar
+  // height stays consistent when navigating between months.
+  const weeksInMonthArray = [...new Array(6).keys()]
 
   return showYearPicker ? (
     <YearGrid

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -42,7 +42,7 @@ function TodayPicker({
         )
       }
       variant={'ghost'}
-      style={{ marginLeft: 16 }}
+      style={{ marginLeft: 4 }}
     >
       Today
     </Button>
@@ -53,6 +53,19 @@ const HeaderActions = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
+`
+
+const TitleButton = styled(Button)`
+  min-width: 13.1rem;
+  white-space: nowrap;
+  font-size: ${tokens.typography.heading.h5.fontSize};
+  text-transform: capitalize;
+  & > span {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
 `
 
 /**
@@ -104,19 +117,15 @@ export function CalendarHeader({
           <Icon data={chevron_left} />
         </Button>
         <span style={{ flex: '1 1 auto' }}></span>
-        <Button
+        <TitleButton
           onClick={() => setShowYearPicker(!showYearPicker)}
           data-testid={'heading'}
           aria-live={'polite'}
           variant={'ghost'}
-          style={{
-            fontSize: tokens.typography.heading.h5.fontSize,
-            textTransform: 'capitalize',
-          }}
         >
           {title}
           <Icon data={showYearPicker ? chevron_up : chevron_down} />
-        </Button>
+        </TitleButton>
         <TodayPicker
           disabled={showYearPicker}
           onClick={(v: CalendarDate) => state.setFocusedDate(v)}


### PR DESCRIPTION
## Summary

Fixes #4376

The DatePicker popover was shifting/resizing when navigating between months because:
- The calendar height changed depending on how many weeks were in a month (4, 5, or 6)
- The calendar width changed based on the length of the month name (e.g. July vs September)
- The chevron icon in the title button shifted horizontally with the text

## Changes

- **`CalendarGrid`**: Always render 6 rows (the maximum any month can have). Extra rows show `visibility: hidden` dates from the adjacent month, keeping height consistent.
- **`CalendarHeader`**: Replaced the plain `Button` with a `TitleButton` styled component that has a `min-width: 13.1rem`, ensuring all month names (including the longest, September) fit without the calendar resizing. Longer month names in other locales can still grow beyond the minimum without breaking the layout.
- **`CalendarHeader`**: Override the button's inner `span` layout with `display: flex; justify-content: space-between` so the chevron is always pinned to the right edge regardless of text length.
- Reduced the gap between the title button and the Today button.

## Test plan

- [ ] Open DatePicker and navigate through months — verify height stays consistent (especially between 4-week months like February and 5/6-week months)
- [ ] Verify the calendar width stays consistent when navigating between short (May, July) and long (September, December) month names
- [ ] Verify the chevron icon always appears at the same rightmost position
- [ ] Test with `nb-NO` locale — month names should fit without issues
- [ ] Test in both comfortable and compact density
- [ ] Test DateRangePicker as well (uses the same components)