### PR TITLE
ci(github): allow write permission to trigger Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,46 +25,48 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Check admin permission
+      - name: Check permission
         id: check-permission
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
-          echo "permission=$PERMISSION" >> "$GITHUB_OUTPUT"
-          if [ "$PERMISSION" != "admin" ]; then
-            echo "::notice::User ${{ github.actor }} has '$PERMISSION' permission, 'admin' required. Skipping."
-            exit 0
+          if [ "$PERMISSION" = "admin" ] || [ "$PERMISSION" = "maintain" ] || [ "$PERMISSION" = "write" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            echo "User ${{ github.actor }} authorized with '$PERMISSION' permission."
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::User ${{ github.actor }} has '$PERMISSION' permission, 'write' or higher required. Skipping."
           fi
 
       - name: Checkout repository
-        if: steps.check-permission.outputs.permission == 'admin'
+        if: steps.check-permission.outputs.authorized == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install Node.js
-        if: steps.check-permission.outputs.permission == 'admin'
+        if: steps.check-permission.outputs.authorized == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
 
       - name: Setup pnpm
-        if: steps.check-permission.outputs.permission == 'admin'
+        if: steps.check-permission.outputs.authorized == 'true'
         uses: pnpm/action-setup@v4
         with:
           run_install: false
 
       - name: Install dependencies
-        if: steps.check-permission.outputs.permission == 'admin'
+        if: steps.check-permission.outputs.authorized == 'true'
         run: pnpm install --force
 
       - name: Build packages
-        if: steps.check-permission.outputs.permission == 'admin'
+        if: steps.check-permission.outputs.authorized == 'true'
         run: pnpm run build
 
       - name: Run Claude Code
-        if: steps.check-permission.outputs.permission == 'admin'
+        if: steps.check-permission.outputs.authorized == 'true'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary

- Lowers the permission check in the Claude Code workflow from `admin`-only to `write` or higher
- This allows all repo collaborators (including eds-core team members) to trigger Claude via `@claude` mentions in PRs and issues
- External users without repo write access are still blocked

**Context**: `@millus` tagged `@claude` on #4620 but the workflow silently skipped because it required admin permission. See [workflow run log](https://github.com/equinor/design-system/actions/runs/22710474714).

## Test plan

- [ ] Have a user with `write` permission comment `@claude` on a PR and verify the workflow runs