### PR TITLE
chore(github): re-add eds-tokens to release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -81,6 +81,25 @@
         "README.md"
       ]
     },
+    "packages/eds-tokens": {
+      "release-type": "node",
+      "package-name": "@equinor/eds-tokens",
+      "component": "eds-tokens",
+      "exclude-paths": [
+        "tokens",
+        "build-generate-variables",
+        ".vscode",
+        ".gitignore",
+        "rollup.config.js",
+        "tsconfig.json",
+        "vite.generate-variables.config.ts",
+        "palette-config.json",
+        "token-config.json",
+        "tokens.json",
+        "README.md",
+        "CLAUDE.md"
+      ]
+    },
     "packages/eds-utils": {
       "release-type": "node",
       "package-name": "@equinor/eds-utils",

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -4,5 +4,6 @@
   "packages/eds-data-grid-react": "1.2.4",
   "packages/eds-icons": "1.3.0",
   "packages/eds-lab-react": "0.10.2",
+  "packages/eds-tokens": "2.2.0",
   "packages/eds-utils": "2.0.0"
 }


### PR DESCRIPTION
## Summary

- Re-adds `eds-tokens` package entry to `release-please-config.json` and `release-please-manifest.json`
- Was temporarily removed in f3244fcf to unblock stable releases while beta testing `@equinor/eds-tokens@2.3.0-beta.0`

## After merge

1. Release-please will pick up unreleased commits and create a release entry for eds-tokens
2. Merge the release PR to publish `@equinor/eds-tokens@latest`
3. Deprecate beta: `npm deprecate @equinor/eds-tokens@2.3.0-beta.0 "Use @latest instead"`

Closes #4591