### PR TITLE
chore(github): ignore eslint major version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,19 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint-*'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@typescript-eslint/*'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@eslint/*'
+        update-types:
+          - 'version-update:semver-major'
     cooldown:
       default-days: 5
     versioning-strategy: increase


### PR DESCRIPTION
## Summary
- Adds `ignore` rules in `dependabot.yml` to skip major version bumps for all eslint-related packages (`eslint`, `eslint-*`, `@typescript-eslint/*`, `@eslint/*`)
- Minor/patch updates continue as normal via the `all-dependencies` group
- Context: [#4677](https://github.com/equinor/design-system/pull/4677) — `eslint-plugin-react-hooks` 5→7 major bump requires coordinated migration effort

## Background
ESLint major upgrades are blocked until we complete the migration tracked in these issues:
- #4161 — Migrate to ESLint 9+ flat config
- #4606 — Upgrade to ESLint 10 when ecosystem support is ready
