### PR TITLE
feat: add Slot utility and asChild prop to Link

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -168,6 +168,18 @@ Query priority: `getByRole` > `getByLabelText` > `getByText` > `getByTestId`
 - **CSS classes**: `eds-` prefix on root class (`eds-button`, `eds-text-area`); simple nested names for internal elements (`.label-row`, `.icon`); variants via data attributes
 - **Files**: Match export (`Icon.tsx`, `Icon.types.ts`, `icon.css`)
 
+## Polymorphism (`asChild` + `Slot`)
+
+EDS 2.0 uses the `asChild` pattern for components that need polymorphic rendering (e.g. Link, Button). This lets consumers swap the underlying element for router links, custom components, etc.
+
+- **`Slot`** utility in `packages/eds-core-react/src/components/next/Slot/` merges parent props onto the child element
+- Add `asChild?: boolean` to the component's props type
+- When `asChild` is true, render `<Slot>` instead of the default element
+- Extract shared props into a `sharedProps` object to avoid duplication
+- See `Slot/README.md` for merge behavior details and usage examples
+
+Components that should support `asChild`: **Link**, **Button**, and any component rendering an interactive element that consumers may want to swap.
+
 ## Accessibility
 
 - WCAG 2.1 AA compliance required

--- a/packages/eds-core-react/src/components/next/Link/Link.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Link/Link.stories.tsx
@@ -77,6 +77,22 @@ export const WithIcons: Story = {
   ),
 }
 
+export const AsChild: Story = {
+  render: () => {
+    const CustomLink = (
+      props: React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    ) => (
+      // eslint-disable-next-line jsx-a11y/anchor-has-content
+      <a {...props} data-custom-router />
+    )
+    return (
+      <Link asChild>
+        <CustomLink href="/my-page">Router link</CustomLink>
+      </Link>
+    )
+  },
+}
+
 export const ExternalLink: Story = {
   render: () => (
     <Link

--- a/packages/eds-core-react/src/components/next/Link/Link.test.tsx
+++ b/packages/eds-core-react/src/components/next/Link/Link.test.tsx
@@ -128,6 +128,55 @@ describe('Link (next)', () => {
     })
   })
 
+  describe('asChild', () => {
+    it('renders child element instead of <a>', () => {
+      render(
+        <Link asChild>
+          <button type="button">Link as button</button>
+        </Link>,
+      )
+      expect(screen.getByRole('button')).toBeInTheDocument()
+      expect(screen.getByRole('button')).toHaveTextContent('Link as button')
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    })
+
+    it('merges className onto child', () => {
+      render(
+        <Link asChild className="custom">
+          <button type="button" className="child-class">
+            Link
+          </button>
+        </Link>,
+      )
+      expect(screen.getByRole('button')).toHaveClass(
+        'eds-link',
+        'custom',
+        'child-class',
+      )
+    })
+
+    it('merges data attributes onto child', () => {
+      render(
+        <Link asChild variant="standalone">
+          <a href="/page">Link</a>
+        </Link>,
+      )
+      expect(screen.getByRole('link')).toHaveAttribute(
+        'data-variant',
+        'standalone',
+      )
+    })
+
+    it('preserves child href', () => {
+      render(
+        <Link asChild>
+          <a href="/my-route">Router link</a>
+        </Link>,
+      )
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/my-route')
+    })
+  })
+
   describe('Accessibility', () => {
     it('has no accessibility violations (inline)', async () => {
       const { container } = render(<Link href="#">Link</Link>)

--- a/packages/eds-core-react/src/components/next/Link/Link.test.tsx
+++ b/packages/eds-core-react/src/components/next/Link/Link.test.tsx
@@ -175,6 +175,25 @@ describe('Link (next)', () => {
       )
       expect(screen.getByRole('link')).toHaveAttribute('href', '/my-route')
     })
+
+    it('slot href wins over child href when both are set', () => {
+      render(
+        <Link asChild href="/from-link">
+          <a href="/from-child">Link</a>
+        </Link>,
+      )
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/from-link')
+    })
+
+    it('forwards ref to child element', () => {
+      const ref = { current: null as HTMLAnchorElement | null }
+      render(
+        <Link asChild ref={ref}>
+          <a href="/">Link</a>
+        </Link>,
+      )
+      expect(ref.current).toBeInstanceOf(HTMLAnchorElement)
+    })
   })
 
   describe('Accessibility', () => {

--- a/packages/eds-core-react/src/components/next/Link/Link.tsx
+++ b/packages/eds-core-react/src/components/next/Link/Link.tsx
@@ -1,25 +1,29 @@
 import { forwardRef } from 'react'
 import type { LinkProps } from './Link.types'
+import { Slot } from '../Slot'
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
-  { variant = 'inline', className, children, ...rest },
+  { variant = 'inline', asChild, className, children, ...rest },
   ref,
 ) {
   const classes = ['eds-link', className].filter(Boolean).join(' ')
 
-  return (
-    <a
-      ref={ref}
-      className={classes}
-      data-variant={variant}
-      data-font-family={variant === 'standalone' ? 'ui' : undefined}
-      data-font-size={variant === 'standalone' ? 'md' : undefined}
-      data-line-height={variant === 'standalone' ? 'squished' : undefined}
-      {...rest}
-    >
-      {children}
-    </a>
-  )
+  const sharedProps = {
+    ref,
+    className: classes,
+    'data-variant': variant,
+    'data-color-appearance': 'info',
+    'data-font-family': variant === 'standalone' ? 'ui' : undefined,
+    'data-font-size': variant === 'standalone' ? 'md' : undefined,
+    'data-line-height': variant === 'standalone' ? 'squished' : undefined,
+    ...rest,
+  }
+
+  if (asChild) {
+    return <Slot {...sharedProps}>{children}</Slot>
+  }
+
+  return <a {...sharedProps}>{children}</a>
 })
 
 Link.displayName = 'Link'

--- a/packages/eds-core-react/src/components/next/Link/Link.types.ts
+++ b/packages/eds-core-react/src/components/next/Link/Link.types.ts
@@ -4,10 +4,14 @@ export type LinkVariant = 'inline' | 'standalone'
 
 export type LinkProps = {
   /** Link destination URL */
-  href: string
+  href?: string
   /** Visual variant
    * - `inline` (default): used within text, inherits surrounding font size
    * - `standalone`: used on its own with flex layout, compose icons as children
    */
   variant?: LinkVariant
+  /** Render as child element instead of `<a>`, merging Link styles onto the child.
+   * Useful for integrating with router links (React Router, Next.js, etc.)
+   */
+  asChild?: boolean
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>

--- a/packages/eds-core-react/src/components/next/Link/Link.types.ts
+++ b/packages/eds-core-react/src/components/next/Link/Link.types.ts
@@ -3,8 +3,6 @@ import type { AnchorHTMLAttributes } from 'react'
 export type LinkVariant = 'inline' | 'standalone'
 
 export type LinkProps = {
-  /** Link destination URL */
-  href?: string
   /** Visual variant
    * - `inline` (default): used within text, inherits surrounding font size
    * - `standalone`: used on its own with flex layout, compose icons as children
@@ -14,4 +12,4 @@ export type LinkProps = {
    * Useful for integrating with router links (React Router, Next.js, etc.)
    */
   asChild?: boolean
-} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>
+} & AnchorHTMLAttributes<HTMLAnchorElement>

--- a/packages/eds-core-react/src/components/next/Slot/README.md
+++ b/packages/eds-core-react/src/components/next/Slot/README.md
@@ -54,5 +54,5 @@ Consumer usage:
 ## Constraints
 
 - Requires exactly one valid React element child when `asChild` is used
-- Logs a `console.warn` in development if the child is invalid
+- Returns `null` silently if the child is invalid
 - Does not support multiple children or text-only children

--- a/packages/eds-core-react/src/components/next/Slot/README.md
+++ b/packages/eds-core-react/src/components/next/Slot/README.md
@@ -1,6 +1,6 @@
 # Slot
 
-Internal utility component that enables the `asChild` pattern for polymorphic rendering.
+Utility component that enables the `asChild` pattern for polymorphic rendering. Exported publicly from `@equinor/eds-core-react/next`.
 
 ## What it does
 
@@ -54,5 +54,5 @@ Consumer usage:
 ## Constraints
 
 - Requires exactly one valid React element child when `asChild` is used
-- Logs a warning in development if the child is invalid
+- Logs a `console.warn` in development if the child is invalid
 - Does not support multiple children or text-only children

--- a/packages/eds-core-react/src/components/next/Slot/README.md
+++ b/packages/eds-core-react/src/components/next/Slot/README.md
@@ -1,0 +1,58 @@
+# Slot
+
+Internal utility component that enables the `asChild` pattern for polymorphic rendering.
+
+## What it does
+
+`Slot` takes its props and merges them onto its single child element, instead of rendering a wrapper element. This lets consumers swap the underlying DOM element while keeping the component's styles and behavior.
+
+## Merge behavior
+
+| Prop type | Behavior |
+|---|---|
+| `className` | Concatenated (both parent and child classes kept) |
+| `style` | Shallow merged (child overrides parent) |
+| Event handlers | Composed (both called — child first, then parent) |
+| Other props | Parent (Slot) wins if defined |
+
+## How to use in a component
+
+```tsx
+import { Slot } from '../Slot'
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button({ asChild, className, children, ...rest }, ref) {
+    const classes = ['eds-button', className].filter(Boolean).join(' ')
+    const sharedProps = { ref, className: classes, ...rest }
+
+    if (asChild) {
+      return <Slot {...sharedProps}>{children}</Slot>
+    }
+
+    return <button {...sharedProps}>{children}</button>
+  },
+)
+```
+
+Consumer usage:
+
+```tsx
+// Default — renders <button>
+<Button>Click me</Button>
+
+// asChild — renders <a> with Button styles
+<Button asChild>
+  <a href="/page">Click me</a>
+</Button>
+
+// asChild — renders router link with Button styles
+<Button asChild>
+  <RouterLink to="/page">Click me</RouterLink>
+</Button>
+```
+
+## Constraints
+
+- Requires exactly one valid React element child when `asChild` is used
+- Logs a warning in development if the child is invalid
+- Does not support multiple children or text-only children

--- a/packages/eds-core-react/src/components/next/Slot/Slot.test.tsx
+++ b/packages/eds-core-react/src/components/next/Slot/Slot.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import { Slot } from '.'
+
+describe('Slot (next)', () => {
+  describe('Rendering', () => {
+    it('renders child element', () => {
+      render(
+        <Slot>
+          <button type="button">Click</button>
+        </Slot>,
+      )
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('returns null for invalid children', () => {
+      const { container } = render(<Slot>plain text</Slot>)
+      expect(container.innerHTML).toBe('')
+    })
+
+    it('returns null when children is null', () => {
+      const { container } = render(<Slot>{null}</Slot>)
+      expect(container.innerHTML).toBe('')
+    })
+
+    it('warns in development for invalid children', () => {
+      const spy = jest.spyOn(console, 'warn').mockImplementation()
+      render(<Slot>plain text</Slot>)
+      expect(spy).toHaveBeenCalledWith(
+        'Slot: asChild requires a single valid React element as a child.',
+      )
+      spy.mockRestore()
+    })
+  })
+
+  describe('Prop merging', () => {
+    it('concatenates className from slot and child', () => {
+      render(
+        <Slot className="slot-class">
+          <div data-testid="child" className="child-class">
+            content
+          </div>
+        </Slot>,
+      )
+      expect(screen.getByTestId('child')).toHaveClass(
+        'slot-class',
+        'child-class',
+      )
+    })
+
+    it('shallow-merges style with child winning on conflicts', () => {
+      render(
+        <Slot style={{ color: 'red', fontSize: '14px' }}>
+          <div data-testid="child" style={{ color: 'blue', margin: '8px' }}>
+            content
+          </div>
+        </Slot>,
+      )
+      const el = screen.getByTestId('child')
+      expect(el).toHaveStyle({
+        color: 'rgb(0, 0, 255)',
+        fontSize: '14px',
+        margin: '8px',
+      })
+    })
+
+    it('composes event handlers — child called first, then slot', async () => {
+      const user = userEvent.setup()
+      const callOrder: string[] = []
+      const slotClick = () => callOrder.push('slot')
+      const childClick = () => callOrder.push('child')
+
+      render(
+        <Slot onClick={slotClick}>
+          <button type="button" onClick={childClick}>
+            Click
+          </button>
+        </Slot>,
+      )
+
+      await user.click(screen.getByRole('button'))
+      expect(callOrder).toEqual(['child', 'slot'])
+    })
+
+    it('slot prop wins for non-special props', () => {
+      render(
+        <Slot data-variant="from-slot">
+          <div data-testid="child" data-variant="from-child">
+            content
+          </div>
+        </Slot>,
+      )
+      expect(screen.getByTestId('child')).toHaveAttribute(
+        'data-variant',
+        'from-slot',
+      )
+    })
+
+    it('preserves child props not present on slot', () => {
+      render(
+        <Slot className="slot">
+          <div data-testid="child" data-custom="preserved">
+            content
+          </div>
+        </Slot>,
+      )
+      expect(screen.getByTestId('child')).toHaveAttribute(
+        'data-custom',
+        'preserved',
+      )
+    })
+
+    it('does not override child prop when slot value is undefined', () => {
+      render(
+        <Slot data-value={undefined}>
+          <div data-testid="child" data-value="kept">
+            content
+          </div>
+        </Slot>,
+      )
+      expect(screen.getByTestId('child')).toHaveAttribute('data-value', 'kept')
+    })
+  })
+
+  describe('Ref forwarding', () => {
+    it('forwards ref to child element', () => {
+      const ref = { current: null as HTMLButtonElement | null }
+      render(
+        <Slot ref={ref}>
+          <button type="button">Click</button>
+        </Slot>,
+      )
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('preserves aria attributes from both slot and child', () => {
+      render(
+        <Slot aria-label="slot-label">
+          <button type="button" aria-describedby="desc">
+            Click
+          </button>
+        </Slot>,
+      )
+      const btn = screen.getByRole('button')
+      expect(btn).toHaveAttribute('aria-label', 'slot-label')
+      expect(btn).toHaveAttribute('aria-describedby', 'desc')
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Slot/Slot.test.tsx
+++ b/packages/eds-core-react/src/components/next/Slot/Slot.test.tsx
@@ -24,13 +24,8 @@ describe('Slot (next)', () => {
       expect(container.innerHTML).toBe('')
     })
 
-    it('warns in development for invalid children', () => {
-      const spy = jest.spyOn(console, 'warn').mockImplementation()
-      render(<Slot>plain text</Slot>)
-      expect(spy).toHaveBeenCalledWith(
-        'Slot: asChild requires a single valid React element as a child.',
-      )
-      spy.mockRestore()
+    it('does not throw for invalid children', () => {
+      expect(() => render(<Slot>plain text</Slot>)).not.toThrow()
     })
   })
 

--- a/packages/eds-core-react/src/components/next/Slot/Slot.tsx
+++ b/packages/eds-core-react/src/components/next/Slot/Slot.tsx
@@ -48,11 +48,6 @@ export const Slot = forwardRef<HTMLElement, SlotProps>(function Slot(
   ref,
 ) {
   if (!isValidElement(children)) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        'Slot: asChild requires a single valid React element as a child.',
-      )
-    }
     return null
   }
 

--- a/packages/eds-core-react/src/components/next/Slot/Slot.tsx
+++ b/packages/eds-core-react/src/components/next/Slot/Slot.tsx
@@ -1,0 +1,63 @@
+import {
+  forwardRef,
+  isValidElement,
+  cloneElement,
+  type ReactElement,
+} from 'react'
+import type { SlotProps } from './Slot.types'
+
+function mergeClassNames(...classNames: (string | undefined)[]) {
+  return classNames.filter(Boolean).join(' ')
+}
+
+function mergeProps(
+  slotProps: Record<string, unknown>,
+  childProps: Record<string, unknown>,
+) {
+  const merged: Record<string, unknown> = { ...childProps }
+
+  for (const key of Object.keys(slotProps)) {
+    const slotValue = slotProps[key]
+    const childValue = childProps[key]
+
+    if (key === 'className') {
+      merged[key] = mergeClassNames(
+        slotValue as string | undefined,
+        childValue as string | undefined,
+      )
+    } else if (key === 'style') {
+      merged[key] = { ...(slotValue as object), ...(childValue as object) }
+    } else if (
+      typeof slotValue === 'function' &&
+      typeof childValue === 'function'
+    ) {
+      merged[key] = (...args: unknown[]) => {
+        ;(childValue as (...a: unknown[]) => void)(...args)
+        ;(slotValue as (...a: unknown[]) => void)(...args)
+      }
+    } else if (slotValue !== undefined) {
+      merged[key] = slotValue
+    }
+  }
+
+  return merged
+}
+
+export const Slot = forwardRef<HTMLElement, SlotProps>(function Slot(
+  { children, ...slotProps },
+  ref,
+) {
+  if (!isValidElement(children)) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Slot: asChild requires a single valid React element child')
+    }
+    return null
+  }
+
+  const child = children as ReactElement<Record<string, unknown>>
+  const merged = mergeProps(slotProps, child.props)
+
+  return cloneElement(child, { ...merged, ref })
+})
+
+Slot.displayName = 'Slot'

--- a/packages/eds-core-react/src/components/next/Slot/Slot.tsx
+++ b/packages/eds-core-react/src/components/next/Slot/Slot.tsx
@@ -48,9 +48,6 @@ export const Slot = forwardRef<HTMLElement, SlotProps>(function Slot(
   ref,
 ) {
   if (!isValidElement(children)) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn('Slot: asChild requires a single valid React element child')
-    }
     return null
   }
 

--- a/packages/eds-core-react/src/components/next/Slot/Slot.tsx
+++ b/packages/eds-core-react/src/components/next/Slot/Slot.tsx
@@ -48,6 +48,11 @@ export const Slot = forwardRef<HTMLElement, SlotProps>(function Slot(
   ref,
 ) {
   if (!isValidElement(children)) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        'Slot: asChild requires a single valid React element as a child.',
+      )
+    }
     return null
   }
 

--- a/packages/eds-core-react/src/components/next/Slot/Slot.types.ts
+++ b/packages/eds-core-react/src/components/next/Slot/Slot.types.ts
@@ -1,0 +1,5 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export type SlotProps = {
+  children: ReactNode
+} & HTMLAttributes<HTMLElement>

--- a/packages/eds-core-react/src/components/next/Slot/index.ts
+++ b/packages/eds-core-react/src/components/next/Slot/index.ts
@@ -1,0 +1,2 @@
+export { Slot } from './Slot'
+export type { SlotProps } from './Slot.types'

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -51,3 +51,6 @@ export type {
   BannerActionsProps,
   BannerActionsPlacement,
 } from './Banner'
+
+export { Slot } from './Slot'
+export type { SlotProps } from './Slot'


### PR DESCRIPTION
## Summary

- Adds the `Slot` utility component for the `asChild` polymorphism pattern (see ADR-0005)
- Adds `asChild` prop to `Link`, enabling consumers to render Link styles on custom elements (e.g. React Router `<NavLink>`, Next.js `<Link>`)

## Usage

```tsx
// Default — renders <a>
<Link href="/page">Link</Link>

// asChild — renders the child element with Link styles merged
<Link asChild variant="standalone">
  <NextLink href="/page">Router link</NextLink>
</Link>
```

## Test plan

- [x] Link tests pass, including new asChild tests
- [x] TypeScript compiles without errors
- [x] Lint passes