### PR TITLE
feat: add Chip component to EDS 2.0

### DIFF
--- a/packages/eds-core-react/src/components/next/Chip/Chip.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.figma.tsx
@@ -1,0 +1,41 @@
+import figma from '@figma/code-connect'
+import { Chip } from '.'
+
+figma.connect(
+  Chip,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=3853-3622&m=dev',
+  {
+    props: {
+      tone: figma.enum('Tone', {
+        Neutral: 'neutral',
+        Accent: 'accent',
+        Success: 'success',
+        Info: 'info',
+        Warning: 'warning',
+        Error: 'danger',
+      }),
+      type: figma.enum('Type', {
+        Default: 'default',
+        Deletable: 'deletable',
+        Checked: 'checked',
+        Dropdown: 'dropdown',
+      }),
+      style: figma.enum('Style', {
+        Default: 'default',
+        Outlined: 'outlined',
+        'High contrast': 'high-contrast',
+      }),
+    },
+    example: ({ tone, type, style }) => (
+      <Chip
+        tone={tone}
+        variant={style}
+        selected={type === 'checked'}
+        deletable={type === 'deletable'}
+        dropdown={type === 'dropdown'}
+      >
+        Label
+      </Chip>
+    ),
+  },
+)

--- a/packages/eds-core-react/src/components/next/Chip/Chip.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.figma.tsx
@@ -31,7 +31,7 @@ figma.connect(
         tone={tone}
         variant={style}
         selected={type === 'checked'}
-        deletable={type === 'deletable'}
+        onDelete={type === 'deletable' ? () => {} : undefined}
         dropdown={type === 'dropdown'}
       >
         Label

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -8,7 +8,7 @@ import { bookmark_filled, person } from '@equinor/eds-icons'
 type StoryArgs = ComponentProps<typeof Chip>
 
 const meta: Meta<StoryArgs> = {
-  title: 'EDS 2.0 (beta)/Chip',
+  title: 'EDS 2.0 (beta)/Data Display/Chip',
   component: Chip,
   parameters: {
     docs: {

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Chip } from './Chip'
 import { Icon } from '../Icon'
 import { Button } from '../Button'
-import { bookmark_filled, close, person } from '@equinor/eds-icons'
+import { bookmark_filled, person } from '@equinor/eds-icons'
 
 type StoryArgs = ComponentProps<typeof Chip>
 
@@ -342,19 +342,13 @@ export const CustomIcons: Story = {
           <h3 style={{ marginBottom: '12px' }}>Recipients</h3>
           <Wrapper wrap>
             {recipients.map((name) => (
-              <Chip key={name} tone="accent">
+              <Chip
+                key={name}
+                tone="accent"
+                onDelete={() => remove(name)}
+              >
                 <Icon data={person} aria-hidden />
                 {name}
-                <Icon
-                  data={close}
-                  aria-label={`Remove ${name}`}
-                  role="button"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    remove(name)
-                  }}
-                  style={{ cursor: 'pointer' }}
-                />
               </Chip>
             ))}
             {recipients.length === 0 && (
@@ -376,7 +370,7 @@ export const CustomIcons: Story = {
     docs: {
       description: {
         story:
-          'Custom chips give consumers full control over leading and/or trailing icons and click behaviour. Two realistic patterns: a saved filter (leading icon + toggle) and recipient chips with a custom close icon that removes from a list.',
+          'Custom chips give consumers full control over leading and/or trailing icons and click behaviour. Two realistic patterns: a saved filter (leading bookmark icon + toggle) and recipient chips combining a custom leading person icon with built-in `onDelete` behaviour.',
       },
     },
   },

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -2,7 +2,8 @@ import { useState, type ReactNode, type ComponentProps } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Chip } from './Chip'
 import { Icon } from '../Icon'
-import { save, settings } from '@equinor/eds-icons'
+import { Button } from '../Button'
+import { bookmark_filled, close, person } from '@equinor/eds-icons'
 
 type StoryArgs = ComponentProps<typeof Chip>
 
@@ -35,11 +36,8 @@ import { Chip } from '@equinor/eds-core-react/next'
     },
     selected: {
       control: 'boolean',
-      description: 'Selected state — shows leading check icon',
-    },
-    deletable: {
-      control: 'boolean',
-      description: 'Shows trailing close icon',
+      description:
+        'Selected state — leading check icon (default) or flipped dropdown arrow.',
     },
     dropdown: {
       control: 'boolean',
@@ -50,7 +48,6 @@ import { Chip } from '@equinor/eds-core-react/next'
     tone: 'neutral',
     variant: 'default',
     selected: false,
-    deletable: false,
     dropdown: false,
   },
 }
@@ -192,19 +189,29 @@ export const Variants: Story = {
 export const Types: Story = {
   render: () => {
     const [selected, setSelected] = useState(false)
+    const [deletableVisible, setDeletableVisible] = useState(true)
+    const [dropdownOpen, setDropdownOpen] = useState(false)
     return (
       <Wrapper>
         <Chip selected={selected} onClick={() => setSelected(!selected)}>
           Selectable
         </Chip>
-        <Chip deletable onClick={() => console.log('delete')}>
-          Deletable
-        </Chip>
-        <Chip dropdown onClick={() => console.log('dropdown')}>
+        {deletableVisible ? (
+          <Chip onDelete={() => setDeletableVisible(false)}>Deletable</Chip>
+        ) : (
+          <Button variant="ghost" onClick={() => setDeletableVisible(true)}>
+            Reset
+          </Button>
+        )}
+        <Chip
+          dropdown
+          selected={dropdownOpen}
+          onClick={() => setDropdownOpen(!dropdownOpen)}
+        >
           Dropdown
         </Chip>
         <Chip onClick={() => console.log('custom')}>
-          <Icon data={settings} size="sm" aria-hidden />
+          <Icon data={bookmark_filled} aria-hidden />
           Custom
         </Chip>
       </Wrapper>
@@ -221,71 +228,155 @@ export const Types: Story = {
 }
 
 export const Deletable: Story = {
-  render: () => (
-    <Wrapper>
-      <Chip deletable onClick={() => console.log('delete neutral')}>
-        Neutral
-      </Chip>
-      <Chip
-        deletable
-        tone="accent"
-        onClick={() => console.log('delete accent')}
-      >
-        Accent
-      </Chip>
-      <Chip
-        deletable
-        tone="danger"
-        onClick={() => console.log('delete danger')}
-      >
-        Danger
-      </Chip>
-    </Wrapper>
-  ),
-}
-
-export const Dropdown: Story = {
-  render: () => (
-    <Wrapper>
-      <Chip dropdown onClick={() => console.log('options')}>
-        Options
-      </Chip>
-      <Chip dropdown tone="accent" onClick={() => console.log('filter')}>
-        Filter
-      </Chip>
-      <Chip dropdown variant="outlined" onClick={() => console.log('sort')}>
-        Sort
-      </Chip>
-    </Wrapper>
-  ),
+  render: () => {
+    const [filters, setFilters] = useState([
+      'Status: Active',
+      'Type: Well',
+      'Year: 2024',
+      'Region: North Sea',
+    ])
+    const remove = (filter: string) =>
+      setFilters((f) => f.filter((item) => item !== filter))
+    return (
+      <Wrapper wrap>
+        {filters.map((filter) => (
+          <Chip key={filter} onDelete={() => remove(filter)}>
+            {filter}
+          </Chip>
+        ))}
+        {filters.length === 0 && (
+          <Button
+            variant="ghost"
+            onClick={() =>
+              setFilters([
+                'Status: Active',
+                'Type: Well',
+                'Year: 2024',
+                'Region: North Sea',
+              ])
+            }
+          >
+            Reset
+          </Button>
+        )}
+      </Wrapper>
+    )
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'Dropdown chips show a trailing arrow icon. The consumer handles what happens on click.',
+          'Deletable chips are typically used as filter tags. The consumer handles removal — here the chip is filtered out of state on click.',
+      },
+    },
+  },
+}
+
+export const Dropdown: Story = {
+  render: () => {
+    const [openChip, setOpenChip] = useState<string | null>(null)
+    const toggle = (chip: string) =>
+      setOpenChip((current) => (current === chip ? null : chip))
+    return (
+      <Wrapper>
+        <Chip
+          dropdown
+          selected={openChip === 'options'}
+          onClick={() => toggle('options')}
+        >
+          Options
+        </Chip>
+        <Chip
+          dropdown
+          selected={openChip === 'filter'}
+          onClick={() => toggle('filter')}
+          tone="accent"
+        >
+          Filter
+        </Chip>
+        <Chip
+          dropdown
+          selected={openChip === 'sort'}
+          onClick={() => toggle('sort')}
+          variant="outlined"
+        >
+          Sort
+        </Chip>
+      </Wrapper>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dropdown chips trigger a menu. Pass `selected` while the menu is open — the arrow flips from down to up. The consumer owns the actual menu and open/close state.',
       },
     },
   },
 }
 
 export const CustomIcons: Story = {
-  render: () => (
-    <Wrapper>
-      <Chip onClick={() => console.log('save')}>
-        <Icon data={save} size="sm" aria-hidden />
-        Save
-      </Chip>
-      <Chip onClick={() => console.log('settings')}>
-        <Icon data={settings} size="sm" aria-hidden />
-        Settings
-      </Chip>
-    </Wrapper>
-  ),
+  render: () => {
+    const [filterApplied, setFilterApplied] = useState(false)
+    const [recipients, setRecipients] = useState([
+      'John Doe',
+      'Jane Smith',
+      'Alex Berg',
+    ])
+    const remove = (name: string) =>
+      setRecipients((r) => r.filter((n) => n !== name))
+
+    return (
+      <Wrapper direction="column" gap={24} align="flex-start">
+        <div>
+          <h3 style={{ marginBottom: '12px' }}>Saved filter</h3>
+          <Chip
+            selected={filterApplied}
+            onClick={() => setFilterApplied(!filterApplied)}
+          >
+            My filter
+            <Icon data={bookmark_filled} aria-hidden />
+          </Chip>
+        </div>
+        <div>
+          <h3 style={{ marginBottom: '12px' }}>Recipients</h3>
+          <Wrapper wrap>
+            {recipients.map((name) => (
+              <Chip key={name} tone="accent">
+                <Icon data={person} aria-hidden />
+                {name}
+                <Icon
+                  data={close}
+                  aria-label={`Remove ${name}`}
+                  role="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    remove(name)
+                  }}
+                  style={{ cursor: 'pointer' }}
+                />
+              </Chip>
+            ))}
+            {recipients.length === 0 && (
+              <Button
+                variant="ghost"
+                onClick={() =>
+                  setRecipients(['John Doe', 'Jane Smith', 'Alex Berg'])
+                }
+              >
+                Reset
+              </Button>
+            )}
+          </Wrapper>
+        </div>
+      </Wrapper>
+    )
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'Custom chips allow consumers to add their own leading and/or trailing icons as children.',
+          'Custom chips give consumers full control over leading and/or trailing icons and click behaviour. Two realistic patterns: a saved filter (leading icon + toggle) and recipient chips with a custom close icon that removes from a list.',
       },
     },
   },
@@ -295,6 +386,10 @@ export const Density: Story = {
   render: () => {
     const [s1, setS1] = useState(false)
     const [s2, setS2] = useState(false)
+    const [d1, setD1] = useState(true)
+    const [d2, setD2] = useState(true)
+    const [o1, setO1] = useState(false)
+    const [o2, setO2] = useState(false)
     return (
       <Wrapper direction="column" gap={24} align="flex-start">
         <div data-density="spacious">
@@ -303,10 +398,14 @@ export const Density: Story = {
             <Chip selected={s1} onClick={() => setS1(!s1)}>
               Selectable
             </Chip>
-            <Chip deletable onClick={() => {}}>
-              Deletable
-            </Chip>
-            <Chip dropdown onClick={() => {}}>
+            {d1 ? (
+              <Chip onDelete={() => setD1(false)}>Deletable</Chip>
+            ) : (
+              <Button variant="ghost" onClick={() => setD1(true)}>
+                Reset
+              </Button>
+            )}
+            <Chip dropdown selected={o1} onClick={() => setO1(!o1)}>
               Dropdown
             </Chip>
           </Wrapper>
@@ -317,10 +416,14 @@ export const Density: Story = {
             <Chip selected={s2} onClick={() => setS2(!s2)}>
               Selectable
             </Chip>
-            <Chip deletable onClick={() => {}}>
-              Deletable
-            </Chip>
-            <Chip dropdown onClick={() => {}}>
+            {d2 ? (
+              <Chip onDelete={() => setD2(false)}>Deletable</Chip>
+            ) : (
+              <Button variant="ghost" onClick={() => setD2(true)}>
+                Reset
+              </Button>
+            )}
+            <Chip dropdown selected={o2} onClick={() => setO2(!o2)}>
               Dropdown
             </Chip>
           </Wrapper>

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -210,7 +210,7 @@ export const Types: Story = {
         >
           Dropdown
         </Chip>
-        <Chip onClick={() => console.log('custom')}>
+        <Chip onClick={() => {}}>
           <Icon data={bookmark_filled} aria-hidden />
           Custom
         </Chip>

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -1,0 +1,390 @@
+import { useState, type ReactNode, type ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Chip } from './Chip'
+import { Icon } from '../Icon'
+import { save, settings } from '@equinor/eds-icons'
+
+type StoryArgs = ComponentProps<typeof Chip>
+
+const meta: Meta<StoryArgs> = {
+  title: 'EDS 2.0 (beta)/Chip',
+  component: Chip,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+⚠️ **Beta Component** - This component is under active development.
+
+\`\`\`tsx
+import { Chip } from '@equinor/eds-core-react/next'
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    tone: {
+      control: 'select',
+      options: ['neutral', 'accent', 'success', 'info', 'warning', 'danger'],
+      description: 'Color tone',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'outlined', 'high-contrast'],
+      description: 'Visual style',
+    },
+    selected: {
+      control: 'boolean',
+      description: 'Selected state — shows leading check icon',
+    },
+    deletable: {
+      control: 'boolean',
+      description: 'Shows trailing close icon',
+    },
+    dropdown: {
+      control: 'boolean',
+      description: 'Shows trailing dropdown arrow icon',
+    },
+  },
+  args: {
+    tone: 'neutral',
+    variant: 'default',
+    selected: false,
+    deletable: false,
+    dropdown: false,
+  },
+}
+
+export default meta
+
+const Wrapper = ({
+  children,
+  gap = 16,
+  direction = 'row',
+  align = 'center',
+  wrap = false,
+}: {
+  children: ReactNode
+  gap?: number
+  direction?: 'row' | 'column'
+  align?: 'flex-start' | 'center' | 'flex-end' | 'stretch'
+  wrap?: boolean
+}) => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: direction,
+      gap: `${gap}px`,
+      alignItems: align,
+      flexWrap: wrap ? 'wrap' : undefined,
+    }}
+  >
+    {children}
+  </div>
+)
+
+type Story = StoryObj<StoryArgs>
+
+const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
+
+export const Default: Story = {
+  render: (args) => {
+    const [selected, setSelected] = useState(false)
+    return (
+      <Chip
+        {...args}
+        selected={selected}
+        onClick={() => setSelected(!selected)}
+      >
+        Chip
+      </Chip>
+    )
+  },
+}
+
+export const Selectable: Story = {
+  render: () => {
+    const [a, setA] = useState(false)
+    const [b, setB] = useState(false)
+    const [c, setC] = useState(false)
+    const [d, setD] = useState(false)
+    return (
+      <Wrapper>
+        <Chip selected={a} onClick={() => setA(!a)}>
+          Default
+        </Chip>
+        <Chip selected={b} onClick={() => setB(!b)} tone="accent">
+          Accent
+        </Chip>
+        <Chip selected={c} onClick={() => setC(!c)} variant="outlined">
+          Outlined
+        </Chip>
+        <Chip
+          selected={d}
+          onClick={() => setD(!d)}
+          variant="high-contrast"
+          tone="success"
+        >
+          High contrast
+        </Chip>
+      </Wrapper>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Chips are always selectable. Click to toggle the selected state, which shows a leading check icon.',
+      },
+    },
+  },
+}
+
+export const Tones: Story = {
+  render: () => {
+    const tones = [
+      'neutral',
+      'accent',
+      'success',
+      'info',
+      'warning',
+      'danger',
+    ] as const
+    const [selected, setSelected] = useState<Record<string, boolean>>({})
+    return (
+      <Wrapper>
+        {tones.map((tone) => (
+          <Chip
+            key={tone}
+            tone={tone}
+            selected={selected[tone] ?? false}
+            onClick={() => setSelected((s) => ({ ...s, [tone]: !s[tone] }))}
+          >
+            {capitalize(tone)}
+          </Chip>
+        ))}
+      </Wrapper>
+    )
+  },
+}
+
+export const Variants: Story = {
+  render: () => {
+    const [a, setA] = useState(false)
+    const [b, setB] = useState(false)
+    const [c, setC] = useState(false)
+    return (
+      <Wrapper>
+        <Chip selected={a} onClick={() => setA(!a)} variant="default">
+          Default
+        </Chip>
+        <Chip selected={b} onClick={() => setB(!b)} variant="outlined">
+          Outlined
+        </Chip>
+        <Chip selected={c} onClick={() => setC(!c)} variant="high-contrast">
+          High contrast
+        </Chip>
+      </Wrapper>
+    )
+  },
+}
+
+export const Types: Story = {
+  render: () => {
+    const [selected, setSelected] = useState(false)
+    return (
+      <Wrapper>
+        <Chip selected={selected} onClick={() => setSelected(!selected)}>
+          Selectable
+        </Chip>
+        <Chip deletable onClick={() => console.log('delete')}>
+          Deletable
+        </Chip>
+        <Chip dropdown onClick={() => console.log('dropdown')}>
+          Dropdown
+        </Chip>
+        <Chip onClick={() => console.log('custom')}>
+          <Icon data={settings} size="sm" aria-hidden />
+          Custom
+        </Chip>
+      </Wrapper>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Chips support four types: selectable (default, toggles check icon), deletable (trailing close icon), dropdown (trailing arrow), and custom (user-provided icons).',
+      },
+    },
+  },
+}
+
+export const Deletable: Story = {
+  render: () => (
+    <Wrapper>
+      <Chip deletable onClick={() => console.log('delete neutral')}>
+        Neutral
+      </Chip>
+      <Chip
+        deletable
+        tone="accent"
+        onClick={() => console.log('delete accent')}
+      >
+        Accent
+      </Chip>
+      <Chip
+        deletable
+        tone="danger"
+        onClick={() => console.log('delete danger')}
+      >
+        Danger
+      </Chip>
+    </Wrapper>
+  ),
+}
+
+export const Dropdown: Story = {
+  render: () => (
+    <Wrapper>
+      <Chip dropdown onClick={() => console.log('options')}>
+        Options
+      </Chip>
+      <Chip dropdown tone="accent" onClick={() => console.log('filter')}>
+        Filter
+      </Chip>
+      <Chip dropdown variant="outlined" onClick={() => console.log('sort')}>
+        Sort
+      </Chip>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dropdown chips show a trailing arrow icon. The consumer handles what happens on click.',
+      },
+    },
+  },
+}
+
+export const CustomIcons: Story = {
+  render: () => (
+    <Wrapper>
+      <Chip onClick={() => console.log('save')}>
+        <Icon data={save} size="sm" aria-hidden />
+        Save
+      </Chip>
+      <Chip onClick={() => console.log('settings')}>
+        <Icon data={settings} size="sm" aria-hidden />
+        Settings
+      </Chip>
+    </Wrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Custom chips allow consumers to add their own leading and/or trailing icons as children.',
+      },
+    },
+  },
+}
+
+export const Density: Story = {
+  render: () => {
+    const [s1, setS1] = useState(false)
+    const [s2, setS2] = useState(false)
+    return (
+      <Wrapper direction="column" gap={24} align="flex-start">
+        <div data-density="spacious">
+          <h3 style={{ marginBottom: '12px' }}>Spacious (default)</h3>
+          <Wrapper>
+            <Chip selected={s1} onClick={() => setS1(!s1)}>
+              Selectable
+            </Chip>
+            <Chip deletable onClick={() => {}}>
+              Deletable
+            </Chip>
+            <Chip dropdown onClick={() => {}}>
+              Dropdown
+            </Chip>
+          </Wrapper>
+        </div>
+        <div data-density="comfortable">
+          <h3 style={{ marginBottom: '12px' }}>Comfortable</h3>
+          <Wrapper>
+            <Chip selected={s2} onClick={() => setS2(!s2)}>
+              Selectable
+            </Chip>
+            <Chip deletable onClick={() => {}}>
+              Deletable
+            </Chip>
+            <Chip dropdown onClick={() => {}}>
+              Dropdown
+            </Chip>
+          </Wrapper>
+        </div>
+      </Wrapper>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Chips respect the `data-density` attribute on a parent element for density-aware sizing.',
+      },
+    },
+  },
+}
+
+export const ToneVariantMatrix: Story = {
+  render: () => {
+    const tones = [
+      'neutral',
+      'accent',
+      'success',
+      'info',
+      'warning',
+      'danger',
+    ] as const
+    const variants = ['default', 'outlined', 'high-contrast'] as const
+    const [selected, setSelected] = useState<Record<string, boolean>>({})
+    const toggle = (key: string) =>
+      setSelected((s) => ({ ...s, [key]: !s[key] }))
+    return (
+      <Wrapper direction="column" gap={24} align="flex-start">
+        {variants.map((variant) => (
+          <div key={variant}>
+            <h3 style={{ marginBottom: '12px', textTransform: 'capitalize' }}>
+              {variant}
+            </h3>
+            <Wrapper wrap>
+              {tones.map((tone) => {
+                const key = `${variant}-${tone}`
+                return (
+                  <Chip
+                    key={key}
+                    tone={tone}
+                    variant={variant}
+                    selected={selected[key] ?? false}
+                    onClick={() => toggle(key)}
+                  >
+                    {capitalize(tone)}
+                  </Chip>
+                )
+              })}
+            </Wrapper>
+          </div>
+        ))}
+      </Wrapper>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Complete matrix of all tone × variant combinations.',
+      },
+    },
+  },
+}

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -342,11 +342,7 @@ export const CustomIcons: Story = {
           <h3 style={{ marginBottom: '12px' }}>Recipients</h3>
           <Wrapper wrap>
             {recipients.map((name) => (
-              <Chip
-                key={name}
-                tone="accent"
-                onDelete={() => remove(name)}
-              >
+              <Chip key={name} tone="accent" onDelete={() => remove(name)}>
                 <Icon data={person} aria-hidden />
                 {name}
               </Chip>

--- a/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
@@ -217,6 +217,34 @@ describe('Chip (next)', () => {
       expect(onDelete).toHaveBeenCalledTimes(1)
     })
 
+    it('fires onDelete on Backspace when focused', async () => {
+      const user = userEvent.setup()
+      const onDelete = jest.fn()
+      render(<Chip onDelete={onDelete}>Label</Chip>)
+      screen.getByRole('button').focus()
+      await user.keyboard('{Backspace}')
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('fires onDelete on Delete when focused', async () => {
+      const user = userEvent.setup()
+      const onDelete = jest.fn()
+      render(<Chip onDelete={onDelete}>Label</Chip>)
+      screen.getByRole('button').focus()
+      await user.keyboard('{Delete}')
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not fire onClick on Backspace/Delete for non-deletable chips', async () => {
+      const user = userEvent.setup()
+      const onClick = jest.fn()
+      render(<Chip onClick={onClick}>Label</Chip>)
+      screen.getByRole('button').focus()
+      await user.keyboard('{Backspace}')
+      await user.keyboard('{Delete}')
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
     it('accessible name includes the chip text and the remove hint', () => {
       render(<Chip onDelete={jest.fn()}>Status: Active</Chip>)
       const name = screen.getByRole('button').textContent ?? ''

--- a/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
@@ -143,53 +143,50 @@ describe('Chip (next)', () => {
 
   describe('Deletable', () => {
     it('renders close icon when onDelete is provided', () => {
-      const { container } = render(<Chip onDelete={jest.fn()}>Label</Chip>)
-      expect(container.querySelector('.delete')).toBeInTheDocument()
+      render(<Chip onDelete={jest.fn()}>Label</Chip>)
+      expect(screen.getByTestId('eds-icon')).toBeInTheDocument()
     })
 
     it('does not render close icon when onDelete is omitted', () => {
-      const { container } = render(<Chip>Label</Chip>)
-      expect(container.querySelector('.delete')).not.toBeInTheDocument()
+      render(<Chip>Label</Chip>)
+      expect(screen.queryByTestId('eds-icon')).not.toBeInTheDocument()
     })
 
-    it('fires onDelete when close icon is clicked', async () => {
+    it('fires onDelete when the chip is clicked', async () => {
       const user = userEvent.setup()
       const onDelete = jest.fn()
-      const { container } = render(<Chip onDelete={onDelete}>Label</Chip>)
-      await user.click(container.querySelector('.delete')!)
+      render(<Chip onDelete={onDelete}>Label</Chip>)
+      await user.click(screen.getByRole('button'))
       expect(onDelete).toHaveBeenCalledTimes(1)
     })
 
-    it('stops propagation — chip onClick does not fire when close is clicked', async () => {
+    it('onClick is ignored when onDelete is set', async () => {
       const user = userEvent.setup()
       const onClick = jest.fn()
       const onDelete = jest.fn()
-      const { container } = render(
+      render(
         <Chip onClick={onClick} onDelete={onDelete}>
           Label
         </Chip>,
       )
-      await user.click(container.querySelector('.delete')!)
+      await user.click(screen.getByRole('button'))
       expect(onDelete).toHaveBeenCalledTimes(1)
       expect(onClick).not.toHaveBeenCalled()
     })
 
-    it('fires onDelete on Backspace when focused', async () => {
+    it('fires onDelete on Enter when focused', async () => {
       const user = userEvent.setup()
       const onDelete = jest.fn()
       render(<Chip onDelete={onDelete}>Label</Chip>)
       screen.getByRole('button').focus()
-      await user.keyboard('{Backspace}')
+      await user.keyboard('{Enter}')
       expect(onDelete).toHaveBeenCalledTimes(1)
     })
 
-    it('fires onDelete on Delete key when focused', async () => {
-      const user = userEvent.setup()
-      const onDelete = jest.fn()
-      render(<Chip onDelete={onDelete}>Label</Chip>)
-      screen.getByRole('button').focus()
-      await user.keyboard('{Delete}')
-      expect(onDelete).toHaveBeenCalledTimes(1)
+    it('accessible name includes the chip text and the remove hint', () => {
+      render(<Chip onDelete={jest.fn()}>Status: Active</Chip>)
+      const name = screen.getByRole('button').textContent ?? ''
+      expect(name).toContain('Status: Active')
     })
   })
 
@@ -200,14 +197,14 @@ describe('Chip (next)', () => {
     })
 
     it('onDelete takes priority over dropdown', () => {
-      const { container } = render(
+      render(
         <Chip onDelete={jest.fn()} dropdown>
           Label
         </Chip>,
       )
-      expect(container.querySelector('.delete')).toBeInTheDocument()
-      expect(container.querySelector('[data-icon-name="arrow_drop_down"]'))
-        .not.toBeInTheDocument
+      // Close icon shown (deletable), not dropdown arrow
+      const icons = screen.getAllByTestId('eds-icon')
+      expect(icons).toHaveLength(1)
     })
   })
 

--- a/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
@@ -142,7 +142,10 @@ describe('Chip (next)', () => {
 
     it('sets aria-pressed for toggleable chips', () => {
       const { rerender } = render(<Chip>Label</Chip>)
-      expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      )
       rerender(<Chip selected>Label</Chip>)
       expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true')
     })
@@ -165,7 +168,10 @@ describe('Chip (next)', () => {
           Label
         </Chip>,
       )
-      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      )
     })
   })
 

--- a/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
@@ -28,9 +28,9 @@ describe('Chip (next)', () => {
     })
 
     it('forwards ref', () => {
-      const ref = { current: null as HTMLDivElement | null }
+      const ref = { current: null as HTMLButtonElement | null }
       render(<Chip ref={ref}>Label</Chip>)
-      expect(ref.current).toBeInstanceOf(HTMLDivElement)
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement)
     })
 
     it('spreads additional props', () => {
@@ -49,9 +49,11 @@ describe('Chip (next)', () => {
       expect(screen.getByRole('button')).toBeInTheDocument()
     })
 
-    it('is focusable', () => {
-      render(<Chip data-testid="eds-chip">Label</Chip>)
-      expect(screen.getByTestId('eds-chip')).toHaveAttribute('tabindex', '0')
+    it('is focusable', async () => {
+      const user = userEvent.setup()
+      render(<Chip>Label</Chip>)
+      await user.tab()
+      expect(screen.getByRole('button')).toHaveFocus()
     })
   })
 

--- a/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+import { Chip } from '.'
+
+describe('Chip (next)', () => {
+  describe('Rendering', () => {
+    it('renders with children', () => {
+      render(<Chip>Label</Chip>)
+      expect(screen.getByText('Label')).toBeInTheDocument()
+    })
+
+    it('renders with default props', () => {
+      render(<Chip data-testid="eds-chip">Label</Chip>)
+      const chip = screen.getByTestId('eds-chip')
+      expect(chip).toHaveAttribute('data-variant', 'default')
+      expect(chip).toHaveAttribute('data-color-appearance', 'neutral')
+    })
+
+    it('applies custom className', () => {
+      render(
+        <Chip data-testid="eds-chip" className="custom">
+          Label
+        </Chip>,
+      )
+      expect(screen.getByTestId('eds-chip')).toHaveClass('eds-chip', 'custom')
+    })
+
+    it('forwards ref', () => {
+      const ref = { current: null as HTMLDivElement | null }
+      render(<Chip ref={ref}>Label</Chip>)
+      expect(ref.current).toBeInstanceOf(HTMLDivElement)
+    })
+
+    it('spreads additional props', () => {
+      render(
+        <Chip data-testid="test" data-custom="value">
+          Label
+        </Chip>,
+      )
+      expect(screen.getByTestId('test')).toHaveAttribute('data-custom', 'value')
+    })
+  })
+
+  describe('Always interactive', () => {
+    it('has role="button"', () => {
+      render(<Chip>Label</Chip>)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('is focusable', () => {
+      render(<Chip data-testid="eds-chip">Label</Chip>)
+      expect(screen.getByTestId('eds-chip')).toHaveAttribute('tabindex', '0')
+    })
+  })
+
+  describe('Tones', () => {
+    it.each([
+      ['neutral', 'neutral'],
+      ['accent', 'accent'],
+      ['success', 'success'],
+      ['info', 'info'],
+      ['warning', 'warning'],
+      ['danger', 'danger'],
+    ] as const)(
+      'renders tone="%s" with color-appearance="%s"',
+      (tone, expected) => {
+        render(
+          <Chip data-testid="eds-chip" tone={tone}>
+            Label
+          </Chip>,
+        )
+        expect(screen.getByTestId('eds-chip')).toHaveAttribute(
+          'data-color-appearance',
+          expected,
+        )
+      },
+    )
+  })
+
+  describe('Variants', () => {
+    it('renders default variant', () => {
+      render(<Chip data-testid="eds-chip">Label</Chip>)
+      expect(screen.getByTestId('eds-chip')).toHaveAttribute(
+        'data-variant',
+        'default',
+      )
+    })
+
+    it('renders outlined variant', () => {
+      render(
+        <Chip data-testid="eds-chip" variant="outlined">
+          Label
+        </Chip>,
+      )
+      expect(screen.getByTestId('eds-chip')).toHaveAttribute(
+        'data-variant',
+        'outlined',
+      )
+    })
+
+    it('renders high-contrast variant', () => {
+      render(
+        <Chip data-testid="eds-chip" variant="high-contrast">
+          Label
+        </Chip>,
+      )
+      expect(screen.getByTestId('eds-chip')).toHaveAttribute(
+        'data-variant',
+        'high-contrast',
+      )
+    })
+  })
+
+  describe('Selected', () => {
+    it('renders check icon when selected', () => {
+      render(<Chip selected>Label</Chip>)
+      expect(screen.getByTestId('eds-icon')).toBeInTheDocument()
+    })
+
+    it('does not render check icon when not selected', () => {
+      render(<Chip>Label</Chip>)
+      expect(screen.queryByTestId('eds-icon')).not.toBeInTheDocument()
+    })
+
+    it('sets data-selected when selected', () => {
+      render(
+        <Chip data-testid="eds-chip" selected>
+          Label
+        </Chip>,
+      )
+      expect(screen.getByTestId('eds-chip')).toHaveAttribute('data-selected')
+    })
+
+    it('does not set data-selected when not selected', () => {
+      render(<Chip data-testid="eds-chip">Label</Chip>)
+      expect(screen.getByTestId('eds-chip')).not.toHaveAttribute(
+        'data-selected',
+      )
+    })
+  })
+
+  describe('Deletable', () => {
+    it('renders close icon when deletable', () => {
+      render(<Chip deletable>Label</Chip>)
+      expect(screen.getByTestId('eds-icon')).toBeInTheDocument()
+    })
+
+    it('does not render close icon when not deletable', () => {
+      render(<Chip>Label</Chip>)
+      expect(screen.queryByTestId('eds-icon')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Dropdown', () => {
+    it('renders dropdown icon when dropdown is true', () => {
+      render(<Chip dropdown>Label</Chip>)
+      expect(screen.getByTestId('eds-icon')).toBeInTheDocument()
+    })
+
+    it('deletable takes priority over dropdown', () => {
+      render(
+        <Chip deletable dropdown>
+          Label
+        </Chip>,
+      )
+      const icons = screen.getAllByTestId('eds-icon')
+      expect(icons).toHaveLength(1)
+    })
+  })
+
+  describe('Click behavior', () => {
+    it('handles click events', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Chip onClick={handleClick}>Label</Chip>)
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('triggers onClick on Enter key', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Chip onClick={handleClick}>Label</Chip>)
+      screen.getByRole('button').focus()
+      await user.keyboard('{Enter}')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has no accessibility violations (default)', async () => {
+      const { container } = render(<Chip>Label</Chip>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (with onClick)', async () => {
+      const { container } = render(<Chip onClick={jest.fn()}>Label</Chip>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (deletable)', async () => {
+      const { container } = render(<Chip deletable>Label</Chip>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (all variants)', async () => {
+      const { container } = render(
+        <>
+          <Chip variant="default">Default</Chip>
+          <Chip variant="outlined">Outlined</Chip>
+          <Chip variant="high-contrast">High contrast</Chip>
+        </>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (selected)', async () => {
+      const { container } = render(<Chip selected>Selected</Chip>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (dropdown)', async () => {
+      const { container } = render(<Chip dropdown>Options</Chip>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
@@ -139,6 +139,34 @@ describe('Chip (next)', () => {
         'data-selected',
       )
     })
+
+    it('sets aria-pressed for toggleable chips', () => {
+      const { rerender } = render(<Chip>Label</Chip>)
+      expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false')
+      rerender(<Chip selected>Label</Chip>)
+      expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('does not set aria-pressed for deletable or dropdown chips', () => {
+      const { rerender } = render(<Chip onDelete={jest.fn()}>Label</Chip>)
+      expect(screen.getByRole('button')).not.toHaveAttribute('aria-pressed')
+      rerender(<Chip dropdown>Label</Chip>)
+      expect(screen.getByRole('button')).not.toHaveAttribute('aria-pressed')
+    })
+
+    it('sets aria-expanded on dropdown chips based on selected', () => {
+      const { rerender } = render(<Chip dropdown>Label</Chip>)
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+      rerender(
+        <Chip dropdown selected>
+          Label
+        </Chip>,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+    })
   })
 
   describe('Deletable', () => {
@@ -225,6 +253,15 @@ describe('Chip (next)', () => {
       await user.keyboard('{Enter}')
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
+
+    it('triggers onClick on Space key', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Chip onClick={handleClick}>Label</Chip>)
+      screen.getByRole('button').focus()
+      await user.keyboard(' ')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('Accessibility', () => {
@@ -261,6 +298,29 @@ describe('Chip (next)', () => {
 
     it('has no accessibility violations (dropdown)', async () => {
       const { container } = render(<Chip dropdown>Options</Chip>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (dropdown open)', async () => {
+      const { container } = render(
+        <Chip dropdown selected>
+          Options
+        </Chip>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations (all tones)', async () => {
+      const { container } = render(
+        <>
+          <Chip tone="neutral">Neutral</Chip>
+          <Chip tone="accent">Accent</Chip>
+          <Chip tone="success">Success</Chip>
+          <Chip tone="info">Info</Chip>
+          <Chip tone="warning">Warning</Chip>
+          <Chip tone="danger">Danger</Chip>
+        </>,
+      )
       expect(await axe(container)).toHaveNoViolations()
     })
   })

--- a/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.test.tsx
@@ -142,14 +142,54 @@ describe('Chip (next)', () => {
   })
 
   describe('Deletable', () => {
-    it('renders close icon when deletable', () => {
-      render(<Chip deletable>Label</Chip>)
-      expect(screen.getByTestId('eds-icon')).toBeInTheDocument()
+    it('renders close icon when onDelete is provided', () => {
+      const { container } = render(<Chip onDelete={jest.fn()}>Label</Chip>)
+      expect(container.querySelector('.delete')).toBeInTheDocument()
     })
 
-    it('does not render close icon when not deletable', () => {
-      render(<Chip>Label</Chip>)
-      expect(screen.queryByTestId('eds-icon')).not.toBeInTheDocument()
+    it('does not render close icon when onDelete is omitted', () => {
+      const { container } = render(<Chip>Label</Chip>)
+      expect(container.querySelector('.delete')).not.toBeInTheDocument()
+    })
+
+    it('fires onDelete when close icon is clicked', async () => {
+      const user = userEvent.setup()
+      const onDelete = jest.fn()
+      const { container } = render(<Chip onDelete={onDelete}>Label</Chip>)
+      await user.click(container.querySelector('.delete')!)
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops propagation — chip onClick does not fire when close is clicked', async () => {
+      const user = userEvent.setup()
+      const onClick = jest.fn()
+      const onDelete = jest.fn()
+      const { container } = render(
+        <Chip onClick={onClick} onDelete={onDelete}>
+          Label
+        </Chip>,
+      )
+      await user.click(container.querySelector('.delete')!)
+      expect(onDelete).toHaveBeenCalledTimes(1)
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('fires onDelete on Backspace when focused', async () => {
+      const user = userEvent.setup()
+      const onDelete = jest.fn()
+      render(<Chip onDelete={onDelete}>Label</Chip>)
+      screen.getByRole('button').focus()
+      await user.keyboard('{Backspace}')
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('fires onDelete on Delete key when focused', async () => {
+      const user = userEvent.setup()
+      const onDelete = jest.fn()
+      render(<Chip onDelete={onDelete}>Label</Chip>)
+      screen.getByRole('button').focus()
+      await user.keyboard('{Delete}')
+      expect(onDelete).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -159,14 +199,15 @@ describe('Chip (next)', () => {
       expect(screen.getByTestId('eds-icon')).toBeInTheDocument()
     })
 
-    it('deletable takes priority over dropdown', () => {
-      render(
-        <Chip deletable dropdown>
+    it('onDelete takes priority over dropdown', () => {
+      const { container } = render(
+        <Chip onDelete={jest.fn()} dropdown>
           Label
         </Chip>,
       )
-      const icons = screen.getAllByTestId('eds-icon')
-      expect(icons).toHaveLength(1)
+      expect(container.querySelector('.delete')).toBeInTheDocument()
+      expect(container.querySelector('[data-icon-name="arrow_drop_down"]'))
+        .not.toBeInTheDocument
     })
   })
 
@@ -201,7 +242,7 @@ describe('Chip (next)', () => {
     })
 
     it('has no accessibility violations (deletable)', async () => {
-      const { container } = render(<Chip deletable>Label</Chip>)
+      const { container } = render(<Chip onDelete={jest.fn()}>Label</Chip>)
       expect(await axe(container)).toHaveNoViolations()
     })
 

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -1,0 +1,69 @@
+import { forwardRef } from 'react'
+import { close, check, arrow_drop_down } from '@equinor/eds-icons'
+import type { ChipProps } from './Chip.types'
+import { Icon } from '../Icon'
+import { TypographyNext } from '../../Typography'
+
+export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
+  {
+    tone = 'neutral',
+    variant = 'default',
+    selected = false,
+    deletable = false,
+    dropdown = false,
+    onClick,
+    children,
+    className,
+    onKeyDown,
+    ...rest
+  },
+  ref,
+) {
+  const classes = ['eds-chip', className].filter(Boolean).join(' ')
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && onClick) {
+      onClick(event as unknown as React.MouseEvent<HTMLDivElement>)
+    }
+    onKeyDown?.(event)
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={classes}
+      data-variant={variant}
+      data-color-appearance={tone}
+      data-font-family="ui"
+      data-font-size="md"
+      data-selectable-space="sm"
+      data-space-proportions="squished"
+      data-selected={selected || undefined}
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      {...rest}
+    >
+      {selected && <Icon data={check} size="sm" aria-hidden className="icon" />}
+      <TypographyNext
+        as="span"
+        className="label"
+        family="ui"
+        size="md"
+        lineHeight="squished"
+        baseline="center"
+      >
+        {children}
+      </TypographyNext>
+      {deletable && (
+        <Icon data={close} size="sm" aria-hidden className="icon" />
+      )}
+      {!deletable && dropdown && (
+        <Icon data={arrow_drop_down} size="sm" aria-hidden className="icon" />
+      )}
+    </div>
+  )
+})
+
+Chip.displayName = 'Chip'

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -1,5 +1,10 @@
 import { forwardRef } from 'react'
-import { close, check, arrow_drop_down, arrow_drop_up } from '@equinor/eds-icons'
+import {
+  close,
+  check,
+  arrow_drop_down,
+  arrow_drop_up,
+} from '@equinor/eds-icons'
 import type { ChipProps } from './Chip.types'
 import { Icon } from '../Icon'
 import { TypographyNext } from '../../Typography'

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -9,7 +9,7 @@ import type { ChipProps } from './Chip.types'
 import { Icon } from '../Icon'
 import { TypographyNext } from '../../Typography'
 
-export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
+export const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
   {
     tone = 'neutral',
     variant = 'default',
@@ -28,7 +28,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
   const deletable = typeof onDelete === 'function'
   const toggleable = !deletable && !dropdown
 
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (deletable) {
       onDelete?.(event)
     } else {
@@ -36,18 +36,8 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
     }
   }
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      if (deletable) {
-        onDelete?.(event)
-      } else if (onClick) {
-        onClick(event as unknown as React.MouseEvent<HTMLDivElement>)
-      }
-    } else if (
-      deletable &&
-      (event.key === 'Backspace' || event.key === 'Delete')
-    ) {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (deletable && (event.key === 'Backspace' || event.key === 'Delete')) {
       event.preventDefault()
       onDelete?.(event)
     }
@@ -55,8 +45,9 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
   }
 
   return (
-    <div
+    <button
       ref={ref}
+      type="button"
       className={classes}
       data-variant={variant}
       data-color-appearance={tone}
@@ -65,8 +56,6 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
       data-selectable-space="sm"
       data-space-proportions="squished"
       data-selected={selected || undefined}
-      role="button"
-      tabIndex={0}
       aria-pressed={toggleable ? selected : undefined}
       aria-expanded={dropdown ? selected : undefined}
       onClick={handleClick}
@@ -94,7 +83,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
           className="icon"
         />
       )}
-    </div>
+    </button>
   )
 })
 

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react'
-import { close, check, arrow_drop_down } from '@equinor/eds-icons'
+import { close, check, arrow_drop_down, arrow_drop_up } from '@equinor/eds-icons'
 import type { ChipProps } from './Chip.types'
 import { Icon } from '../Icon'
 import { TypographyNext } from '../../Typography'
@@ -9,7 +9,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
     tone = 'neutral',
     variant = 'default',
     selected = false,
-    deletable = false,
+    onDelete,
     dropdown = false,
     onClick,
     children,
@@ -20,12 +20,22 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
   ref,
 ) {
   const classes = ['eds-chip', className].filter(Boolean).join(' ')
+  const deletable = typeof onDelete === 'function'
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' && onClick) {
       onClick(event as unknown as React.MouseEvent<HTMLDivElement>)
     }
+    if (deletable && (event.key === 'Backspace' || event.key === 'Delete')) {
+      event.preventDefault()
+      onDelete?.(event as unknown as React.MouseEvent<HTMLElement>)
+    }
     onKeyDown?.(event)
+  }
+
+  const handleDelete = (event: React.MouseEvent<HTMLSpanElement>) => {
+    event.stopPropagation()
+    onDelete?.(event)
   }
 
   return (
@@ -45,7 +55,9 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
       onKeyDown={handleKeyDown}
       {...rest}
     >
-      {selected && <Icon data={check} size="sm" aria-hidden className="icon" />}
+      {selected && !dropdown && !deletable && (
+        <Icon data={check} aria-hidden className="icon" />
+      )}
       <TypographyNext
         as="span"
         className="label"
@@ -57,10 +69,16 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
         {children}
       </TypographyNext>
       {deletable && (
-        <Icon data={close} size="sm" aria-hidden className="icon" />
+        <span className="delete" aria-hidden onClick={handleDelete}>
+          <Icon data={close} className="icon" />
+        </span>
       )}
       {!deletable && dropdown && (
-        <Icon data={arrow_drop_down} size="sm" aria-hidden className="icon" />
+        <Icon
+          data={selected ? arrow_drop_up : arrow_drop_down}
+          aria-hidden
+          className="icon"
+        />
       )}
     </div>
   )

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -22,20 +22,23 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
   const classes = ['eds-chip', className].filter(Boolean).join(' ')
   const deletable = typeof onDelete === 'function'
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Enter' && onClick) {
-      onClick(event as unknown as React.MouseEvent<HTMLDivElement>)
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (deletable) {
+      onDelete?.(event)
+    } else {
+      onClick?.(event)
     }
-    if (deletable && (event.key === 'Backspace' || event.key === 'Delete')) {
-      event.preventDefault()
-      onDelete?.(event as unknown as React.MouseEvent<HTMLElement>)
-    }
-    onKeyDown?.(event)
   }
 
-  const handleDelete = (event: React.MouseEvent<HTMLSpanElement>) => {
-    event.stopPropagation()
-    onDelete?.(event)
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter') {
+      if (deletable) {
+        onDelete?.(event as unknown as React.MouseEvent<HTMLElement>)
+      } else if (onClick) {
+        onClick(event as unknown as React.MouseEvent<HTMLDivElement>)
+      }
+    }
+    onKeyDown?.(event)
   }
 
   return (
@@ -51,7 +54,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
       data-selected={selected || undefined}
       role="button"
       tabIndex={0}
-      onClick={onClick}
+      onClick={handleClick}
       onKeyDown={handleKeyDown}
       {...rest}
     >
@@ -68,11 +71,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
       >
         {children}
       </TypographyNext>
-      {deletable && (
-        <span className="delete" aria-hidden onClick={handleDelete}>
-          <Icon data={close} className="icon" />
-        </span>
-      )}
+      {deletable && <Icon data={close} title="Remove" className="icon" />}
       {!deletable && dropdown && (
         <Icon
           data={selected ? arrow_drop_up : arrow_drop_down}

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -21,6 +21,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
 ) {
   const classes = ['eds-chip', className].filter(Boolean).join(' ')
   const deletable = typeof onDelete === 'function'
+  const toggleable = !deletable && !dropdown
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (deletable) {
@@ -31,7 +32,8 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
       if (deletable) {
         onDelete?.(event as unknown as React.MouseEvent<HTMLElement>)
       } else if (onClick) {
@@ -54,6 +56,8 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
       data-selected={selected || undefined}
       role="button"
       tabIndex={0}
+      aria-pressed={toggleable ? selected : undefined}
+      aria-expanded={dropdown ? selected : undefined}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       {...rest}

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -40,10 +40,16 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       if (deletable) {
-        onDelete?.(event as unknown as React.MouseEvent<HTMLElement>)
+        onDelete?.(event)
       } else if (onClick) {
         onClick(event as unknown as React.MouseEvent<HTMLDivElement>)
       }
+    } else if (
+      deletable &&
+      (event.key === 'Backspace' || event.key === 'Delete')
+    ) {
+      event.preventDefault()
+      onDelete?.(event)
     }
     onKeyDown?.(event)
   }

--- a/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
@@ -52,9 +52,10 @@ export type ChipProps = {
    */
   selected?: boolean
   /**
-   * Shows a trailing close icon that removes the chip. The callback fires
-   * when the close icon is clicked — click propagation is stopped so the
-   * chip's `onClick` does not also fire. Omit to render a non-deletable chip.
+   * Shows a trailing close icon and turns the entire chip into a delete
+   * button — clicking anywhere on the chip fires this callback, and
+   * Backspace/Delete while focused does the same. When provided, `onClick`
+   * is ignored (a deletable chip has only one action).
    *
    * @example
    * ```tsx

--- a/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react'
+import type { HTMLAttributes, MouseEvent, ReactNode } from 'react'
 
 /**
  * Color tone for theming
@@ -37,8 +37,8 @@ export type ChipProps = {
    */
   variant?: ChipVariant
   /**
-   * Selected state. Shows a leading check icon when true.
-   * Use with `onClick` to toggle selection.
+   * Selected state. For default chips this shows a leading check icon.
+   * For dropdown chips this flips the trailing arrow up to indicate the menu is open.
    *
    * @default false
    *
@@ -52,14 +52,20 @@ export type ChipProps = {
    */
   selected?: boolean
   /**
-   * Shows a trailing close icon indicating the chip can be removed.
-   * Use with `onClick` to handle deletion.
-   * @default false
+   * Shows a trailing close icon that removes the chip. The callback fires
+   * when the close icon is clicked — click propagation is stopped so the
+   * chip's `onClick` does not also fire. Omit to render a non-deletable chip.
+   *
+   * @example
+   * ```tsx
+   * <Chip onDelete={() => removeFilter(id)}>Active</Chip>
+   * ```
    */
-  deletable?: boolean
+  onDelete?: (event: MouseEvent<HTMLElement>) => void
   /**
-   * Shows a trailing dropdown arrow icon.
-   * The actual dropdown/popover behavior is the consumer's responsibility.
+   * Shows a trailing dropdown arrow icon. Combine with `selected` to flip
+   * the arrow up while the menu is open. The actual dropdown/popover
+   * behavior is the consumer's responsibility.
    * @default false
    */
   dropdown?: boolean

--- a/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
@@ -1,5 +1,5 @@
 import type {
-  HTMLAttributes,
+  ButtonHTMLAttributes,
   KeyboardEvent,
   MouseEvent,
   ReactNode,
@@ -81,4 +81,4 @@ export type ChipProps = {
    * Chip content
    */
   children?: ReactNode
-} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'type'>

--- a/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
@@ -1,0 +1,70 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+/**
+ * Color tone for theming
+ * - `neutral`: Neutral gray tones (default)
+ * - `accent`: Brand/action color
+ * - `success`: Positive/confirmation
+ * - `info`: Informational
+ * - `warning`: Caution/alerts
+ * - `danger`: Destructive/error
+ */
+export type ChipTone =
+  | 'neutral'
+  | 'accent'
+  | 'success'
+  | 'info'
+  | 'warning'
+  | 'danger'
+
+/**
+ * Chip visual style variants
+ * - `default`: Solid muted fill background
+ * - `outlined`: Transparent background with border
+ * - `high-contrast`: Dark emphasis fill with light text
+ */
+export type ChipVariant = 'default' | 'outlined' | 'high-contrast'
+
+export type ChipProps = {
+  /**
+   * Color tone for theming
+   * @default 'neutral'
+   */
+  tone?: ChipTone
+  /**
+   * Visual style variant
+   * @default 'default'
+   */
+  variant?: ChipVariant
+  /**
+   * Selected state. Shows a leading check icon when true.
+   * Use with `onClick` to toggle selection.
+   *
+   * @default false
+   *
+   * @example
+   * ```tsx
+   * const [selected, setSelected] = useState(false)
+   * <Chip selected={selected} onClick={() => setSelected(!selected)}>
+   *   Filter
+   * </Chip>
+   * ```
+   */
+  selected?: boolean
+  /**
+   * Shows a trailing close icon indicating the chip can be removed.
+   * Use with `onClick` to handle deletion.
+   * @default false
+   */
+  deletable?: boolean
+  /**
+   * Shows a trailing dropdown arrow icon.
+   * The actual dropdown/popover behavior is the consumer's responsibility.
+   * @default false
+   */
+  dropdown?: boolean
+  /**
+   * Chip content
+   */
+  children?: ReactNode
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>

--- a/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
@@ -1,4 +1,9 @@
-import type { HTMLAttributes, MouseEvent, ReactNode } from 'react'
+import type {
+  HTMLAttributes,
+  KeyboardEvent,
+  MouseEvent,
+  ReactNode,
+} from 'react'
 
 /**
  * Color tone for theming
@@ -62,7 +67,9 @@ export type ChipProps = {
    * <Chip onDelete={() => removeFilter(id)}>Active</Chip>
    * ```
    */
-  onDelete?: (event: MouseEvent<HTMLElement>) => void
+  onDelete?: (
+    event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+  ) => void
   /**
    * Shows a trailing dropdown arrow icon. Combine with `selected` to flip
    * the arrow up while the menu is open. The actual dropdown/popover

--- a/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.types.ts
@@ -68,7 +68,7 @@ export type ChipProps = {
    * ```
    */
   onDelete?: (
-    event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+    event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
   ) => void
   /**
    * Shows a trailing dropdown arrow icon. Combine with `selected` to flip

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -1,6 +1,7 @@
 @layer eds-components {
   .eds-chip {
     cursor: pointer;
+    user-select: none;
 
     display: inline-flex;
     gap: var(--eds-typography-gap-horizontal);

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -84,15 +84,6 @@
       margin-inline: calc(-1 * var(--eds-selectable-space-vertical) / 2);
     }
 
-    /* ===== DELETE ===== */
-
-    & .delete {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      color: inherit;
-    }
-
   }
 }
 

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -1,0 +1,112 @@
+@layer eds-components {
+  .eds-chip {
+    cursor: pointer;
+
+    display: inline-flex;
+    gap: var(--eds-typography-gap-horizontal);
+    align-items: center;
+
+    box-sizing: border-box;
+    padding-block: var(--eds-selectable-space-vertical);
+    padding-inline: var(--eds-selectable-space-horizontal);
+    border: none;
+    border-radius: var(--eds-spacing-border-radius-pill, 100vmax);
+
+    transition:
+      background-color 150ms ease-in-out,
+      outline-color 150ms ease-in-out,
+      color 150ms ease-in-out;
+
+    /* ===== DEFAULT VARIANT (solid muted fill) ===== */
+
+    &[data-variant='default'] {
+      color: var(--eds-color-text-subtle);
+      background-color: var(--eds-color-bg-fill-muted-default);
+      outline: none;
+    }
+
+    &[data-variant='default']:hover {
+      background-color: var(--eds-color-bg-fill-muted-hover);
+    }
+
+    &[data-variant='default']:active {
+      background-color: var(--eds-color-bg-fill-muted-active);
+    }
+
+    /* ===== OUTLINED VARIANT (border + transparent bg) ===== */
+
+    &[data-variant='outlined'] {
+      color: var(--eds-color-text-subtle);
+      background-color: transparent;
+      outline: var(--eds-border-width-default, 1px) solid
+        var(--eds-color-border-strong);
+      outline-offset: calc(-1 * var(--eds-border-width-default, 1px));
+    }
+
+    &[data-variant='outlined']:hover {
+      background-color: var(--eds-color-bg-fill-muted-hover);
+    }
+
+    &[data-variant='outlined']:active {
+      background-color: var(--eds-color-bg-fill-muted-hover);
+    }
+
+    /* ===== HIGH-CONTRAST VARIANT (emphasis fill + light text) ===== */
+
+    &[data-variant='high-contrast'] {
+      color: var(--eds-color-text-strong-on-emphasis);
+      background-color: var(--eds-color-bg-fill-emphasis-default);
+      outline: none;
+    }
+
+    &[data-variant='high-contrast']:hover {
+      background-color: var(--eds-color-bg-fill-emphasis-hover);
+    }
+
+    &[data-variant='high-contrast']:active {
+      background-color: var(--eds-color-bg-fill-emphasis-active);
+    }
+
+    /* ===== FOCUS STATE ===== */
+
+    &:focus-visible {
+      box-shadow:
+        0 0 0 var(--eds-sizing-stroke-thin) var(--eds-color-bg-canvas),
+        0 0 0 calc(var(--eds-sizing-stroke-thin) * 2)
+          var(--eds-color-border-focus);
+    }
+
+    /* ===== ICONS ===== */
+
+    & .eds-icon {
+      flex-shrink: 0;
+      margin-block: calc(-1 * var(--eds-selectable-space-vertical));
+      margin-inline: calc(-1 * var(--eds-selectable-space-vertical) / 2);
+    }
+
+  }
+}
+
+/*
+ * Outside @layer to override typography.css [data-font-family] { display: block }.
+ * data-font-family/data-font-size on the chip container establishes the typography
+ * context for gap and icon sizing tokens.
+ */
+.eds-chip {
+  display: inline-flex;
+}
+
+/*
+ * Label needs inline-flex to center custom icons with text.
+ * text-box: normal disables baseline trimming — chip handles sizing via
+ * padding + flexbox centering.
+ */
+.eds-chip > .label {
+  display: inline-flex;
+  gap: var(--eds-typography-gap-horizontal);
+  align-items: center;
+
+  padding-block: 0;
+
+  text-box: normal;
+}

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -84,7 +84,6 @@
       margin-block: calc(-1 * var(--eds-selectable-space-vertical));
       margin-inline: calc(-1 * var(--eds-selectable-space-vertical) / 2);
     }
-
   }
 }
 

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -84,6 +84,15 @@
       margin-inline: calc(-1 * var(--eds-selectable-space-vertical) / 2);
     }
 
+    /* ===== DELETE ===== */
+
+    & .delete {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: inherit;
+    }
+
   }
 }
 

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -49,7 +49,7 @@
     }
 
     &[data-variant='outlined']:active {
-      background-color: var(--eds-color-bg-fill-muted-hover);
+      background-color: var(--eds-color-bg-fill-muted-active);
     }
 
     /* ===== HIGH-CONTRAST VARIANT (emphasis fill + light text) ===== */

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -13,6 +13,9 @@
     border: none;
     border-radius: var(--eds-spacing-border-radius-pill, 100vmax);
 
+    font: inherit;
+    color: inherit;
+
     transition:
       background-color 150ms ease-in-out,
       outline-color 150ms ease-in-out,

--- a/packages/eds-core-react/src/components/next/Chip/index.ts
+++ b/packages/eds-core-react/src/components/next/Chip/index.ts
@@ -1,0 +1,2 @@
+export { Chip } from './Chip'
+export type { ChipProps, ChipTone, ChipVariant } from './Chip.types'

--- a/packages/eds-core-react/src/components/next/index.css
+++ b/packages/eds-core-react/src/components/next/index.css
@@ -29,4 +29,5 @@
 @import './Link/link.css';
 @import './Tooltip/tooltip.css';
 @import './Banner/banner.css';
+@import './Chip/chip.css';
 

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -54,3 +54,6 @@ export type {
 
 export { Slot } from './Slot'
 export type { SlotProps } from './Slot'
+
+export { Chip } from './Chip'
+export type { ChipProps, ChipTone, ChipVariant } from './Chip'


### PR DESCRIPTION
## Summary

New Chip component for EDS 2.0 (`@equinor/eds-core-react/next`).
Always interactive (`role="button"`); the consumer controls behaviour via props.

### Props
| Prop | Type | Default | Notes |
|------|------|---------|-------|
| `tone` | `'neutral' \| 'accent' \| 'success' \| 'info' \| 'warning' \| 'danger'` | `'neutral'` | |
| `variant` | `'default' \| 'outlined' \| 'high-contrast'` | `'default'` | |
| `selected` | `boolean` | `false` | Leading check on default chips; flips the arrow up on dropdown chips |
| `onDelete` | `(event) => void` | — | Makes the whole chip a delete button; shows trailing X |
| `dropdown` | `boolean` | `false` | Shows trailing arrow; pair with `selected` for the open state |

### Behaviour
- **Selectable (default):** `selected` toggles a leading check and `aria-pressed`
- **Deletable:** `onDelete` turns the whole chip into a remove button (click or Backspace/Delete); `onClick` is ignored while `onDelete` is set
- **Dropdown:** arrow flips ↓/↑ based on `selected`, mirrored by `aria-expanded` — consumer owns the menu
- **Custom:** mix arbitrary leading/trailing children with any of the above

### A11y
- `role="button"` + Enter/Space activation
- `aria-pressed` (toggleable) / `aria-expanded` (dropdown) / `aria-label="Remove"` via the close icon title
- No nested-interactive violations
- Respects `data-density="spacious|comfortable"` — icons scale with typography context

## Test plan
- [x] 57 unit tests (rendering, tones, variants, selected, deletable, dropdown, keyboard, axe)
- [x] Lint passes
- [x] Visual verification in Storybook (spacious/comfortable density, all four types)
- [x] Figma token comparison — all values match
- [ ] Review Figma Code Connect mapping