### PR TITLE
docs: remove broken Casted story reference from Input docs

### DIFF
--- a/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
@@ -77,10 +77,6 @@ Use `startAdornment` and `endAdornment` for elements (icons, buttons, etc.).
 
 <Canvas of={ComponentStories.WithAdornments} />
 
-### Casted as textarea
-
-<Canvas of={ComponentStories.Casted} />
-
 ### Override background color
 
 Wrap the Input in a container that sets the `--eds-color-neutral-1` CSS variable to customize the background color. This overrides the base color token that the Input's background references.


### PR DESCRIPTION
## Summary
- Remove reference to non-existent `Casted` story in Input docs MDX
- The story was removed when TextArea was extracted into its own component, but the MDX reference was left behind
- This fixes the Storybook error: `Unexpected of={undefined}, did you mistype a CSF file reference?`

## Test plan
- [x] Verify Input docs page renders without errors in Storybook