### PR TITLE
refactor: add asChild prop to Button (next)

### DIFF
--- a/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
@@ -106,7 +106,7 @@ Use `asChild` to render Button styles on a child element, such as an `<a>` or a 
   <a href="/page">Link as button</a>
 </Button>
 
-<Button asChild variant="outlined">
+<Button asChild variant="secondary">
   <NextLink href="/page">Router button</NextLink>
 </Button>
 ```

--- a/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
@@ -97,6 +97,22 @@ Use `round` on icon-only buttons to create circular buttons.
 
 <Canvas of={ComponentStories.CircularIconOnly} />
 
+### As Child
+
+Use `asChild` to render Button styles on a child element, such as an `<a>` or a router link (React Router, Next.js, etc.).
+
+```tsx
+<Button asChild>
+  <a href="/page">Link as button</a>
+</Button>
+
+<Button asChild variant="outlined">
+  <NextLink href="/page">Router button</NextLink>
+</Button>
+```
+
+<Canvas of={ComponentStories.AsChild} />
+
 ### Density Modes
 
 Comparison of all button sizes across density modes. Use `data-density` on a parent container to control density.

--- a/packages/eds-core-react/src/components/next/Button/Button.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.stories.tsx
@@ -377,6 +377,40 @@ export const CircularIconOnly: Story = {
   },
 }
 
+// ===== asChild =====
+
+export const AsChild: Story = {
+  render: () => {
+    const CustomLink = (
+      props: React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    ) => (
+      // eslint-disable-next-line jsx-a11y/anchor-has-content
+      <a {...props} data-custom-router />
+    )
+    return (
+      <Wrapper direction="row">
+        <Button asChild>
+          <a href="/page">Link as button</a>
+        </Button>
+        <Button asChild variant="secondary">
+          <CustomLink href="/page">Router link</CustomLink>
+        </Button>
+        <Button asChild variant="ghost">
+          <a href="/page">Ghost link</a>
+        </Button>
+      </Wrapper>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use `asChild` to render Button styles on a child element, such as an `<a>` or a router link component.',
+      },
+    },
+  },
+}
+
 // ===== Density Comparison =====
 
 export const DensityComparison: Story = {

--- a/packages/eds-core-react/src/components/next/Button/Button.test.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.test.tsx
@@ -449,6 +449,69 @@ describe('Button (next)', () => {
     })
   })
 
+  describe('asChild', () => {
+    it('renders child element instead of <button>', () => {
+      render(
+        <Button asChild>
+          <a href="/page">Link as button</a>
+        </Button>,
+      )
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+      expect(screen.getByRole('link')).toHaveTextContent('Link as button')
+    })
+
+    it('merges className onto child', () => {
+      render(
+        <Button asChild className="custom">
+          <a href="/page" className="child-class">
+            Link
+          </a>
+        </Button>,
+      )
+      const link = screen.getByRole('link')
+      expect(link).toHaveClass('eds-button', 'custom', 'child-class')
+    })
+
+    it('merges data attributes onto child', () => {
+      render(
+        <Button asChild variant="secondary" tone="danger">
+          <a href="/page">Link</a>
+        </Button>,
+      )
+      const link = screen.getByRole('link')
+      expect(link).toHaveAttribute('data-variant', 'secondary')
+      expect(link).toHaveAttribute('data-color-appearance', 'danger')
+    })
+
+    it('preserves child href', () => {
+      render(
+        <Button asChild>
+          <a href="/my-route">Router link</a>
+        </Button>,
+      )
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/my-route')
+    })
+
+    it('forwards ref to child element', () => {
+      const ref = { current: null as HTMLElement | null }
+      render(
+        <Button asChild ref={ref as React.Ref<HTMLButtonElement>}>
+          <a href="/">Link</a>
+        </Button>,
+      )
+      expect(ref.current).toBeInstanceOf(HTMLAnchorElement)
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <Button asChild>
+          <a href="/page">Accessible link button</a>
+        </Button>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+
   describe('Round (icon-only buttons)', () => {
     it('does not set data-round on non-icon buttons', () => {
       render(<Button>Label Button</Button>)

--- a/packages/eds-core-react/src/components/next/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.tsx
@@ -32,21 +32,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const typographySize = sizeToTypography[size]
     const selectableSpace = sizeToSelectableSpace[size]
 
-    const content = icon ? (
-      children
-    ) : (
-      <TypographyNext
-        as="span"
-        className="eds-button__label"
-        family="ui"
-        size={typographySize}
-        lineHeight="squished"
-        baseline="center"
-      >
-        {children}
-      </TypographyNext>
-    )
-
     const sharedProps = {
       ref,
       className: classes,
@@ -66,7 +51,20 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <button type={type} {...sharedProps}>
-        {content}
+        {icon ? (
+          children
+        ) : (
+          <TypographyNext
+            as="span"
+            className="eds-button__label"
+            family="ui"
+            size={typographySize}
+            lineHeight="squished"
+            baseline="center"
+          >
+            {children}
+          </TypographyNext>
+        )}
       </button>
     )
   },

--- a/packages/eds-core-react/src/components/next/Button/Button.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react'
 import type { ButtonProps } from './Button.types'
 import { TypographyNext } from '../../Typography'
+import { Slot } from '../Slot'
 
 const SIZE_MAPPING = {
   small: 'sm',
@@ -18,6 +19,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       tone = 'accent',
       icon = false,
       round = false,
+      asChild,
       children,
       className,
       disabled,
@@ -30,34 +32,41 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const typographySize = sizeToTypography[size]
     const selectableSpace = sizeToSelectableSpace[size]
 
-    return (
-      <button
-        ref={ref}
-        type={type}
-        className={classes}
-        disabled={disabled}
-        data-variant={variant}
-        data-selectable-space={selectableSpace}
-        data-space-proportions="squished"
-        data-color-appearance={disabled ? 'neutral' : tone}
-        data-icon-only={icon || undefined}
-        data-round={icon && round ? true : undefined}
-        {...rest}
+    const content = icon ? (
+      children
+    ) : (
+      <TypographyNext
+        as="span"
+        className="eds-button__label"
+        family="ui"
+        size={typographySize}
+        lineHeight="squished"
+        baseline="center"
       >
-        {icon ? (
-          children
-        ) : (
-          <TypographyNext
-            as="span"
-            className="eds-button__label"
-            family="ui"
-            size={typographySize}
-            lineHeight="squished"
-            baseline="center"
-          >
-            {children}
-          </TypographyNext>
-        )}
+        {children}
+      </TypographyNext>
+    )
+
+    const sharedProps = {
+      ref,
+      className: classes,
+      disabled,
+      'data-variant': variant,
+      'data-selectable-space': selectableSpace,
+      'data-space-proportions': 'squished' as const,
+      'data-color-appearance': disabled ? 'neutral' : tone,
+      'data-icon-only': icon || undefined,
+      'data-round': icon && round ? true : undefined,
+      ...rest,
+    }
+
+    if (asChild) {
+      return <Slot {...sharedProps}>{children}</Slot>
+    }
+
+    return (
+      <button type={type} {...sharedProps}>
+        {content}
       </button>
     )
   },

--- a/packages/eds-core-react/src/components/next/Button/Button.types.ts
+++ b/packages/eds-core-react/src/components/next/Button/Button.types.ts
@@ -24,6 +24,10 @@ export type ButtonSize = 'small' | 'default'
 export type ButtonTone = 'accent' | 'neutral' | 'danger'
 
 export type ButtonProps = {
+  /** Render as child element instead of `<button>`, merging Button styles onto the child.
+   * Useful for rendering links that look like buttons, or integrating with router links.
+   */
+  asChild?: boolean
   /**
    * Button variant - controls visual style
    * @default 'primary'

--- a/packages/eds-core-react/src/components/next/Button/button.css
+++ b/packages/eds-core-react/src/components/next/Button/button.css
@@ -13,6 +13,8 @@
     border: none;
     border-radius: var(--eds-spacing-border-radius-rounded, 4px);
 
+    /* Typography — ensures correct font for asChild elements */
+    font-family: var(--eds-typography-ui-body-font-family);
     text-decoration: none;
 
     outline: none;
@@ -37,12 +39,14 @@
     gap: var(--eds-typography-gap-horizontal);
     min-height: 2.25rem; /* 36px */
     padding-inline: var(--eds-selectable-space-horizontal);
+    font-size: var(--eds-typography-ui-body-md-font-size);
   }
 
   .eds-button[data-selectable-space='sm'] {
     gap: var(--eds-typography-gap-horizontal);
     min-height: 1.5rem; /* 24px */
     padding-inline: var(--eds-selectable-space-horizontal);
+    font-size: var(--eds-typography-ui-body-sm-font-size);
   }
 
   /* Comfortable density */

--- a/packages/eds-core-react/src/components/next/Slot/README.md
+++ b/packages/eds-core-react/src/components/next/Slot/README.md
@@ -51,8 +51,10 @@ Consumer usage:
 </Button>
 ```
 
-## Constraints
+## Known limitations
 
 - Requires exactly one valid React element child when `asChild` is used
 - Returns `null` silently if the child is invalid
 - Does not support multiple children or text-only children
+- **`disabled` on non-form elements**: The `disabled` HTML attribute and `:disabled` CSS pseudo-class only apply to form elements (`<button>`, `<input>`, etc.). When using `asChild` with e.g. `<a>`, `disabled` will be forwarded as an attribute but `:disabled` styles won't trigger. Data-attribute styles (like `data-color-appearance="neutral"`) still apply.
+- **`ref` type mismatch**: Components are typed with a specific ref type (e.g. `forwardRef<HTMLButtonElement>`), but with `asChild` the ref actually points to the child element (e.g. `HTMLAnchorElement`). This is a known TypeScript limitation with the `asChild` pattern.


### PR DESCRIPTION
## Summary
- Add `asChild` prop to the Button component (EDS 2.0/next) using the existing `Slot` utility
- Follows the same pattern already established in the Link component
- Enables rendering Button styles on child elements like `<a>`, router links, or custom components

## Test plan
- [x] All 67 Button tests pass (6 new `asChild` tests added)
- [x] jest-axe accessibility checks pass
- [x] ESLint passes
- [x] Verify in Storybook that existing Button variants still render correctly

Closes #4746