### PR TITLE
chore: resolve code scanning alerts (sanitization, shell injection)

### DIFF
--- a/apps/eds-color-palette-generator/scripts/generate-palette-overview.ts
+++ b/apps/eds-color-palette-generator/scripts/generate-palette-overview.ts
@@ -26,7 +26,7 @@ interface ContrastRow {
 const outPath = path.join(__dirname, '..', 'PALETTE_OVERVIEW.md')
 
 function mdEscape(text: string) {
-  return text.replace(/\|/g, '\\|')
+  return text.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
 }
 
 function formatNumber(n: number, digits = 2) {

--- a/packages/eds-tokens-build/src/__tests__/test-utils.ts
+++ b/packages/eds-tokens-build/src/__tests__/test-utils.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { existsSync, mkdirSync, rmSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
@@ -28,7 +28,7 @@ export function setupTestWorkspace(): string {
 
   // Copy fixtures to workspace (use rsync for better handling of existing files)
   const fixturesPath = path.resolve(__dirname, 'fixtures')
-  execSync(`rsync -a "${fixturesPath}/" "${testWorkspace}/"`)
+  execFileSync('rsync', ['-a', `${fixturesPath}/`, `${testWorkspace}/`])
 
   return testWorkspace
 }
@@ -47,7 +47,7 @@ export function cleanupTestWorkspace(testWorkspace: string): void {
  */
 export function runScript(scriptName: string, testWorkspace: string): void {
   const scriptPath = path.resolve(__dirname, `../../dist/scripts/${scriptName}`)
-  execSync(`node "${scriptPath}"`, {
+  execFileSync('node', [scriptPath], {
     stdio: 'pipe',
     cwd: testWorkspace,
   })


### PR DESCRIPTION
## Summary

Addresses two open [code scanning alerts](https://github.com/equinor/design-system/security/code-scanning):

- **#41 (HIGH) `js/incomplete-sanitization`** — `mdEscape` in `generate-palette-overview.ts` replaced only `|` without also escaping backslashes, which could produce malformed markdown. Now escapes `\` before `|`.
- **#31 (MEDIUM) `js/shell-command-injection-from-environment`** — test utilities in `eds-tokens-build` built shell commands via string interpolation (`execSync(\`rsync -a \"\${...}\"\`)`). Switched to `execFileSync` with argument arrays so paths are not interpreted by a shell.

Alert #33 (prototype-polluting-assignment in `useToken.ts`) is being handled separately (dismissed as a false positive — input is a typed \`ComponentToken\` from trusted tokens package).

## Test plan

- [x] `pnpm run lint` on changed files — no errors
- [x] `pnpm run test:run` in `eds-tokens-build` — 27/27 passing
- [ ] CodeQL re-scan on merge confirms alerts #31 and #41 are resolved