### PR TITLE
chore: migrate npm publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -1,4 +1,6 @@
 name: Publish core-react
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:
@@ -19,9 +21,6 @@ on:
           - development
           - production
         default: 'development'
-permissions:
-  contents: read
-  id-token: write
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -57,7 +56,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -79,6 +78,9 @@ jobs:
     name: Publish utils to npm
     runs-on: ubuntu-latest
     needs: [packages, setup]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use "dist" cache
         id: dist-cache
@@ -91,7 +93,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
@@ -114,6 +116,9 @@ jobs:
     name: Publish core-react to npm
     runs-on: ubuntu-latest
     needs: [publish-utils-package, setup]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use "dist" cache
         id: dist-cache
@@ -126,7 +131,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -101,9 +102,8 @@ jobs:
       - name: Publish to npm
         id: publish-to-npm
         if: needs.setup.outputs.tag != 'beta'
-        run: |
-          pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
-          pnpm --filter @equinor/eds-utils publish --access public --tag ${{ needs.setup.outputs.tag }} --no-git-checks
+        working-directory: packages/eds-utils
+        run: npm publish --access public --provenance --tag ${{ needs.setup.outputs.tag }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:
@@ -127,6 +127,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -164,9 +165,8 @@ jobs:
           cat package.json | grep -A 15 '"exports"'
       - name: Publish to npm
         id: publish-to-npm
-        run: |
-          pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
-          pnpm --filter @equinor/eds-core-react publish --access public --tag ${{ needs.setup.outputs.tag }} --no-git-checks
+        working-directory: packages/eds-core-react
+        run: npm publish --access public --provenance --tag ${{ needs.setup.outputs.tag }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:

--- a/.github/workflows/publish_data_grid.yaml
+++ b/.github/workflows/publish_data_grid.yaml
@@ -2,7 +2,6 @@
 name: Publish data-grid-react
 permissions:
   contents: read
-  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -57,7 +56,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -79,6 +78,9 @@ jobs:
     name: Publish data grid to npm
     runs-on: ubuntu-latest
     needs: [setup, packages]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use "dist" cache
         id: dist-cache
@@ -91,7 +93,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm

--- a/.github/workflows/publish_data_grid.yaml
+++ b/.github/workflows/publish_data_grid.yaml
@@ -2,6 +2,7 @@
 name: Publish data-grid-react
 permissions:
   contents: read
+  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -91,6 +92,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -98,9 +100,8 @@ jobs:
           run_install: false
       - name: Publish to npm
         id: publish-to-npm
-        run: |
-          pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
-          pnpm --filter @equinor/eds-data-grid-react publish --access public --tag ${{ needs.setup.outputs.tag }} --no-git-checks
+        working-directory: packages/eds-data-grid-react
+        run: npm publish --access public --provenance --tag ${{ needs.setup.outputs.tag }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:

--- a/.github/workflows/publish_icons.yaml
+++ b/.github/workflows/publish_icons.yaml
@@ -2,7 +2,6 @@
 name: Publish icons
 permissions:
   contents: read
-  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -49,7 +48,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -68,6 +67,9 @@ jobs:
     name: Publish icons to npm
     runs-on: ubuntu-latest
     needs: [packages, setup]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use "dist" cache
         id: dist-cache
@@ -80,7 +82,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm

--- a/.github/workflows/publish_icons.yaml
+++ b/.github/workflows/publish_icons.yaml
@@ -2,6 +2,7 @@
 name: Publish icons
 permissions:
   contents: read
+  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -80,6 +81,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -87,9 +89,8 @@ jobs:
           run_install: false
       - name: Publish to npm
         id: publish-to-npm
-        run: |
-          pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
-          pnpm --filter ./packages/eds-icons publish --access public --no-git-checks --tag ${{ needs.setup.outputs.tag }}
+        working-directory: packages/eds-icons
+        run: npm publish --access public --provenance --tag ${{ needs.setup.outputs.tag }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:

--- a/.github/workflows/publish_lab.yaml
+++ b/.github/workflows/publish_lab.yaml
@@ -2,7 +2,6 @@
 name: Publish lab-react
 permissions:
   contents: read
-  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -57,7 +56,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -79,6 +78,9 @@ jobs:
     name: Publish utils to npm
     runs-on: ubuntu-latest
     needs: [packages, setup]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use "dist" cache
         id: dist-cache
@@ -91,7 +93,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
@@ -112,6 +114,9 @@ jobs:
     name: Publish lab to npm
     runs-on: ubuntu-latest
     needs: [publish-utils-package, setup]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use "dist" cache
         id: dist-cache
@@ -124,7 +129,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm

--- a/.github/workflows/publish_lab.yaml
+++ b/.github/workflows/publish_lab.yaml
@@ -2,6 +2,7 @@
 name: Publish lab-react
 permissions:
   contents: read
+  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -91,6 +92,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -98,9 +100,8 @@ jobs:
           run_install: false
       - name: Publish to npm
         id: publish-to-npm
-        run: |
-          pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
-          pnpm --filter @equinor/eds-utils publish --access public --tag ${{ needs.setup.outputs.tag }} --no-git-checks
+        working-directory: packages/eds-utils
+        run: npm publish --access public --provenance --tag ${{ needs.setup.outputs.tag }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:
@@ -124,6 +125,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -131,9 +133,8 @@ jobs:
           run_install: false
       - name: Publish to npm
         id: publish-to-npm
-        run: |
-          pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
-          pnpm --filter @equinor/eds-lab-react publish --access public --tag ${{ needs.setup.outputs.tag }} --no-git-checks
+        working-directory: packages/eds-lab-react
+        run: npm publish --access public --provenance --tag ${{ needs.setup.outputs.tag }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -1,6 +1,7 @@
 name: Publish tokens
 permissions:
   contents: read
+  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -80,6 +81,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -87,9 +89,8 @@ jobs:
           run_install: false
       - name: Publish to npm
         id: publish-to-npm
-        run: |
-          pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
-          pnpm --filter @equinor/eds-tokens publish --access public --tag ${{ needs.setup.outputs.tag }} --no-git-checks
+        working-directory: packages/eds-tokens
+        run: npm publish --access public --provenance --tag ${{ needs.setup.outputs.tag }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2
         with:

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -1,7 +1,6 @@
 name: Publish tokens
 permissions:
   contents: read
-  id-token: write
 on:
   workflow_dispatch:
     inputs:
@@ -48,7 +47,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
       - name: Setup pnpm
         id: setup-pnpm
         uses: pnpm/action-setup@v6
@@ -68,6 +67,9 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: [packages, setup]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use "dist" cache
         id: dist-cache
@@ -80,7 +82,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.12.0'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         id: setup-pnpm


### PR DESCRIPTION
## Summary

- Migrates all five publish workflows (`publish_core_react`, `publish_icons`, `publish_tokens`, `publish_data_grid`, `publish_lab`) from `NPM_TOKEN` to GitHub Actions OIDC via npm [Trusted Publishing](https://docs.npmjs.com/trusted-publishers).
- Adds `id-token: write` permission, sets `registry-url` on `actions/setup-node`, and switches from `pnpm publish` (token-based) to `npm publish --provenance`.
- Resolves equinor/design-system-internal#242.

## Why

npm now warns against the "bypass 2FA" setting on our granular access token. Trusted Publishing uses short-lived OIDC tokens exchanged at publish time, eliminating long-lived secrets entirely and enabling package provenance attestation.

## Rollout plan

This PR alone does **not** change how publishing works — each package must first be configured with a Trusted Publisher on npmjs.com before its workflow can run successfully.

- [x] Configure Trusted Publisher for `@equinor/eds-icons`
- [x] Configure Trusted Publisher for `@equinor/eds-tokens`
- [x] Configure Trusted Publisher for `@equinor/eds-utils`
- [x] Configure Trusted Publisher for `@equinor/eds-data-grid-react`
- [x] Configure Trusted Publisher for `@equinor/eds-lab-react`
- [x] Configure Trusted Publisher for `@equinor/eds-core-react`

Note: `@equinor/eds-utils` is published from both `publish_core_react.yaml` and `publish_lab.yaml`, so it needs two Trusted Publisher entries (npm allows multiple per package).

## Test plan

Run each workflow manually via `workflow_dispatch` on this branch with `npm-tag: next` after its Trusted Publisher is configured, and verify:

- [ ] `publish_icons` succeeds; `@equinor/eds-icons` has provenance badge on npmjs.com
- [ ] `publish_tokens` succeeds; `@equinor/eds-tokens` has provenance badge
- [ ] `publish_data_grid` succeeds; `@equinor/eds-data-grid-react` has provenance badge
- [ ] `publish_lab` succeeds; both `@equinor/eds-utils` and `@equinor/eds-lab-react` have provenance badges
- [ ] `publish_core_react` succeeds; `@equinor/eds-core-react` has provenance badge

## Post-merge cleanup

- [ ] Remove `NPM_TOKEN` repo secret
- [x] For each package on npmjs.com, switch "Publishing access" to "Require 2FA and disallow tokens"

Refs equinor/design-system-internal#242