### PR TITLE
ci: match beta manifest key in trigger-publish core-react check

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -97,9 +97,7 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           run_install: false
-      # eds-utils follows the stable release channel only. On beta runs we
-      # skip the publish step so the job still completes successfully and
-      # downstream publish-core-package can proceed.
+      # Skip on beta runs — eds-utils has no beta channel
       - name: Publish to npm
         id: publish-to-npm
         if: needs.setup.outputs.tag != 'beta'

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -97,8 +97,12 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           run_install: false
+      # eds-utils follows the stable release channel only. On beta runs we
+      # skip the publish step so the job still completes successfully and
+      # downstream publish-core-package can proceed.
       - name: Publish to npm
         id: publish-to-npm
+        if: needs.setup.outputs.tag != 'beta'
         run: |
           pnpm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
           pnpm --filter @equinor/eds-utils publish --access public --tag ${{ needs.setup.outputs.tag }} --no-git-checks

--- a/.github/workflows/trigger_publish.yml
+++ b/.github/workflows/trigger_publish.yml
@@ -135,8 +135,10 @@ jobs:
           echo "### Package detection results:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Check eds-core-react
-          if echo "$MANIFEST_DIFF" | grep -E '^[+-].*"packages/eds-core-react":'; then
+          # Check eds-core-react (matches both the stable "packages/eds-core-react"
+          # key and the beta "packages/eds-core-react/src/components/next" key,
+          # so beta-only releases still trigger the publish workflow)
+          if echo "$MANIFEST_DIFF" | grep -E '^[+-].*"packages/eds-core-react(/src/components/next)?":'; then
             echo "core-react=true" >> $GITHUB_OUTPUT
             echo "✅ eds-core-react changed"
             echo "- ✅ **eds-core-react** changed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Fix regex in `trigger_publish.yml` so beta-only releases trigger `publish_core_react.yaml`.
- Root cause of PR #4816 merging without kicking off an npm publish.

## What was broken

`check-releases` greps the `release-please-manifest.json` diff for `"packages/eds-core-react":`. That only matches the **stable** manifest key. Beta-only releases bump the separate key `"packages/eds-core-react/src/components/next":`, which does not contain the substring `"packages/eds-core-react":` (there's no closing quote + colon after `eds-core-react`).

So on a beta-only release, `check-releases.outputs.core-react = "false"`, and both `trigger-core-react-stable` and `trigger-core-react-beta` are skipped — even though `detect-release.outputs.has-beta-release = "true"`. That's why [PR #4816](https://github.com/equinor/design-system/pull/4816) (2.5.0-beta.0) merged without triggering the publish workflow (see the skipped jobs in [this run](https://github.com/equinor/design-system/actions/runs/24841671093)).

## Fix

Relax the regex to `"packages/eds-core-react(/src/components/next)?":` so it matches both manifest keys. Minimal change, surgical — the existing `detect-release` job still handles the stable/beta channel distinction via CHANGELOG paths, so each `trigger-core-react-*` job only runs for its own channel.

## Test plan

- [ ] Next beta release PR triggers `publish_core_react.yaml` with `npm-tag=beta` automatically.
- [ ] Next stable release PR still triggers `publish_core_react.yaml` with `npm-tag=latest`.
- [ ] Regex does not match unrelated keys like a hypothetical `"packages/eds-core-react-anything":`.