### PR TITLE
refactor: migrate Field off TypographyNext

### DIFF
--- a/packages/eds-core-react/src/components/next/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`Checkbox (next) matches snapshot 1`] = `
     </span>
     <label
       class="eds-field__label"
+      data-baseline="center"
       for="test-id"
     >
       checkbox

--- a/packages/eds-core-react/src/components/next/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -66,12 +66,6 @@ exports[`Checkbox (next) matches snapshot 1`] = `
     </span>
     <label
       class="eds-field__label"
-      data-baseline="center"
-      data-font-family="ui"
-      data-font-size="md"
-      data-font-weight="normal"
-      data-line-height="default"
-      data-tracking="normal"
       for="test-id"
     >
       checkbox

--- a/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
@@ -8,7 +8,7 @@ export const FieldDescription = forwardRef<
   return (
     <p
       ref={ref}
-      data-baseline="grid"
+      data-baseline="center"
       className={['eds-field__description', className]
         .filter(Boolean)
         .join(' ')}

--- a/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
@@ -8,6 +8,7 @@ export const FieldDescription = forwardRef<
   return (
     <p
       ref={ref}
+      data-baseline="grid"
       className={['eds-field__description', className]
         .filter(Boolean)
         .join(' ')}

--- a/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
@@ -1,5 +1,4 @@
 import { forwardRef } from 'react'
-import { TypographyNext } from '../../Typography'
 import type { FieldDescriptionProps } from './Field.types'
 
 export const FieldDescription = forwardRef<
@@ -7,21 +6,15 @@ export const FieldDescription = forwardRef<
   FieldDescriptionProps
 >(function FieldDescription({ children, className, ...rest }, ref) {
   return (
-    <TypographyNext
+    <p
       ref={ref}
-      as="p"
-      family="ui"
-      size="sm"
-      baseline="center"
-      lineHeight="default"
-      tracking="normal"
       className={['eds-field__description', className]
         .filter(Boolean)
         .join(' ')}
       {...rest}
     >
       {children}
-    </TypographyNext>
+    </p>
   )
 })
 

--- a/packages/eds-core-react/src/components/next/Field/Field.HelperMessage.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.HelperMessage.tsx
@@ -1,5 +1,4 @@
 import { forwardRef } from 'react'
-import { TypographyNext } from '../../Typography'
 import type { HelperMessageProps } from './Field.HelperMessage.types'
 
 /**
@@ -23,15 +22,9 @@ export const HelperMessage = forwardRef<
   HelperMessageProps
 >(function HelperMessage({ children, className, role, id, ...rest }, ref) {
   return (
-    <TypographyNext
+    <p
       ref={ref}
-      as="p"
       id={id}
-      family="ui"
-      size="sm"
-      baseline="grid"
-      lineHeight="default"
-      tracking="normal"
       role={role}
       className={['eds-field__helper-message', className]
         .filter(Boolean)
@@ -39,7 +32,7 @@ export const HelperMessage = forwardRef<
       {...rest}
     >
       {children}
-    </TypographyNext>
+    </p>
   )
 })
 

--- a/packages/eds-core-react/src/components/next/Field/Field.HelperMessage.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.HelperMessage.tsx
@@ -24,6 +24,7 @@ export const HelperMessage = forwardRef<
   return (
     <p
       ref={ref}
+      data-baseline="grid"
       id={id}
       role={role}
       className={['eds-field__helper-message', className]

--- a/packages/eds-core-react/src/components/next/Field/Field.Label.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.Label.tsx
@@ -1,29 +1,17 @@
 import { forwardRef } from 'react'
-import { TypographyNext } from '../../Typography'
 import type { FieldLabelProps } from './Field.types'
 
 export const FieldLabel = forwardRef<HTMLLabelElement, FieldLabelProps>(
   function FieldLabel({ children, className, indicator, ...rest }, ref) {
     return (
-      <TypographyNext
+      <label
         ref={ref}
-        as="label"
-        family="ui"
-        size="md"
-        baseline="center"
-        lineHeight="default"
-        weight="normal"
-        tracking="normal"
         className={['eds-field__label', className].filter(Boolean).join(' ')}
         {...rest}
       >
         {children}
-        {indicator && (
-          <span className="eds-field__indicator" data-font-size="sm">
-            {indicator}
-          </span>
-        )}
-      </TypographyNext>
+        {indicator && <span className="eds-field__indicator">{indicator}</span>}
+      </label>
     )
   },
 )

--- a/packages/eds-core-react/src/components/next/Field/Field.Label.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.Label.tsx
@@ -6,6 +6,7 @@ export const FieldLabel = forwardRef<HTMLLabelElement, FieldLabelProps>(
     return (
       <label
         ref={ref}
+        data-baseline="center"
         className={['eds-field__label', className].filter(Boolean).join(' ')}
         {...rest}
       >

--- a/packages/eds-core-react/src/components/next/Field/field.css
+++ b/packages/eds-core-react/src/components/next/Field/field.css
@@ -1,24 +1,28 @@
 @layer eds-components {
   .eds-field {
-    /* Layout - use CSS variable for configurable width */
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--eds-generic-gap-vertical);
-    width: var(--eds-field-width, 100%);
     /* Private color variables */
     --_eds-field-label-color: var(--eds-color-text-strong);
     --_eds-field-description-color: var(--eds-color-text-subtle);
     --_eds-field-indicator-color: var(--eds-color-text-neutral-subtle);
     --_eds-field-helper-color: var(--eds-color-text-subtle);
+
+    /* Layout - use CSS variable for configurable width */
+    display: flex;
+    flex-direction: column;
+    gap: var(--eds-generic-gap-vertical);
+    align-items: flex-start;
+
+    width: var(--eds-field-width, 100%);
+
+    /* Shared font-family — inherits to all text children */
+    font-family: var(--eds-typography-ui-body-font-family);
   }
 
   /* Horizontal layout for toggle inputs (checkbox, radio, switch) */
   .eds-field:is([data-position='start'], [data-position='end']) {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: center;
+    flex-flow: row wrap;
     gap: var(--eds-generic-gap-horizontal);
+    align-items: center;
   }
 
   .eds-field[data-position='end'] {
@@ -35,13 +39,18 @@
     display: inline-flex;
     flex-wrap: wrap;
     align-items: center;
+
+    font-size: var(--eds-typography-ui-body-md-font-size);
+    line-height: var(--eds-typography-ui-body-md-line-height-default);
     color: var(--_eds-field-label-color);
   }
 
   .eds-field__indicator {
     margin-inline-start: var(--eds-selectable-space-horizontal);
+
+    font-size: var(--eds-typography-ui-body-sm-font-size);
+    line-height: var(--eds-typography-ui-body-sm-line-height-default);
     color: var(--_eds-field-indicator-color);
-    font-size: var(--eds-typography-font-size);
     vertical-align: middle;
   }
 
@@ -50,10 +59,22 @@
     color: var(--_eds-field-description-color);
   }
 
-  /* HelperMessage styling */
   .eds-field__helper-message {
     margin: 0;
     color: var(--_eds-field-helper-color);
+  }
+
+  .eds-field__description,
+  .eds-field__helper-message {
+    font-size: var(--eds-typography-ui-body-sm-font-size);
+    line-height: var(--eds-typography-ui-body-sm-line-height-default);
+
+    @supports (text-box: trim-both ex alphabetic) {
+      padding-top: var(--eds-padding-top-baseline);
+      padding-bottom: 0;
+
+      text-box: trim-both ex alphabetic;
+    }
   }
 
   /* Reduce gap before helper message to 3xs spacing.

--- a/packages/eds-core-react/src/components/next/Field/field.css
+++ b/packages/eds-core-react/src/components/next/Field/field.css
@@ -35,10 +35,10 @@
     flex-basis: 100%;
   }
 
+  /* Label uses data-baseline="center" for text-box trim + grid-snap padding —
+     see [data-baseline='center'] rule in eds-tokens/src/css/typography.css */
   .eds-field__label {
-    display: inline-flex;
-    flex-wrap: wrap;
-    align-items: center;
+    display: block;
 
     font-size: var(--eds-typography-ui-body-md-font-size);
     line-height: var(--eds-typography-ui-body-md-line-height-default);

--- a/packages/eds-core-react/src/components/next/Field/field.css
+++ b/packages/eds-core-react/src/components/next/Field/field.css
@@ -42,6 +42,7 @@
 
     font-size: var(--eds-typography-ui-body-md-font-size);
     line-height: var(--eds-typography-ui-body-md-line-height-default);
+    font-weight: var(--eds-typography-ui-body-md-font-weight-normal);
     color: var(--_eds-field-label-color);
   }
 
@@ -61,26 +62,20 @@
 
   .eds-field__helper-message {
     margin: 0;
+    /* Tighten spacing above helper-message to 3xs (overrides parent gap).
+       Longhand follows shorthand to win the cascade. */
+    margin-block-start: calc(
+      var(--eds-spacing-vertical-3xs) - var(--eds-generic-gap-vertical)
+    );
     color: var(--_eds-field-helper-color);
   }
 
+  /* data-baseline="grid" on these elements handles text-box trim via
+     [data-baseline='grid'] in eds-tokens/src/css/typography.css */
   .eds-field__description,
   .eds-field__helper-message {
     font-size: var(--eds-typography-ui-body-sm-font-size);
     line-height: var(--eds-typography-ui-body-sm-line-height-default);
-
-    @supports (text-box: trim-both ex alphabetic) {
-      padding-top: var(--eds-padding-top-baseline);
-      padding-bottom: 0;
-
-      text-box: trim-both ex alphabetic;
-    }
-  }
-
-  /* Reduce gap before helper message to 3xs spacing.
-     Applied to the preceding sibling (not helper message) to avoid [data-font-family] margin: 0 override. */
-  .eds-field > :has(+ .eds-field__helper-message) {
-    margin-block-end: calc(var(--eds-spacing-vertical-3xs) - var(--eds-generic-gap-vertical));
   }
 
   /* Only helper message changes color when disabled */

--- a/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`Radio (next) matches snapshot 1`] = `
     </span>
     <label
       class="eds-field__label"
+      data-baseline="center"
       for="test-id"
     >
       radio

--- a/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
@@ -51,12 +51,6 @@ exports[`Radio (next) matches snapshot 1`] = `
     </span>
     <label
       class="eds-field__label"
-      data-baseline="center"
-      data-font-family="ui"
-      data-font-size="md"
-      data-font-weight="normal"
-      data-line-height="default"
-      data-tracking="normal"
       for="test-id"
     >
       radio

--- a/packages/eds-core-react/src/components/next/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Switch/__snapshots__/Switch.test.tsx.snap
@@ -30,12 +30,6 @@ exports[`Switch (next) matches snapshot 1`] = `
     </span>
     <label
       class="eds-field__label"
-      data-baseline="center"
-      data-font-family="ui"
-      data-font-size="md"
-      data-font-weight="normal"
-      data-line-height="default"
-      data-tracking="normal"
       for="test-id"
     >
       switch

--- a/packages/eds-core-react/src/components/next/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Switch/__snapshots__/Switch.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`Switch (next) matches snapshot 1`] = `
     </span>
     <label
       class="eds-field__label"
+      data-baseline="center"
       for="test-id"
     >
       switch

--- a/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
     </div>
     <p
       class="eds-field__description"
+      data-baseline="grid"
       id="test-id-description"
     >
       Description text
@@ -43,6 +44,7 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
     </div>
     <p
       class="eds-field__helper-message"
+      data-baseline="grid"
       id="test-id-helper-message"
     >
       Helper message

--- a/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
     >
       <label
         class="eds-field__label"
+        data-baseline="center"
         for="test-id-input"
       >
         Label

--- a/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
     </div>
     <p
       class="eds-field__description"
-      data-baseline="grid"
+      data-baseline="center"
       id="test-id-description"
     >
       Description text

--- a/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
@@ -10,12 +10,6 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
     >
       <label
         class="eds-field__label"
-        data-baseline="center"
-        data-font-family="ui"
-        data-font-size="md"
-        data-font-weight="normal"
-        data-line-height="default"
-        data-tracking="normal"
         for="test-id-input"
       >
         Label
@@ -23,11 +17,6 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
     </div>
     <p
       class="eds-field__description"
-      data-baseline="center"
-      data-font-family="ui"
-      data-font-size="sm"
-      data-line-height="default"
-      data-tracking="normal"
       id="test-id-description"
     >
       Description text
@@ -53,11 +42,6 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
     </div>
     <p
       class="eds-field__helper-message"
-      data-baseline="grid"
-      data-font-family="ui"
-      data-font-size="sm"
-      data-line-height="default"
-      data-tracking="normal"
       id="test-id-helper-message"
     >
       Helper message


### PR DESCRIPTION
Closes #4837. Part of #4655.

Follows the direction in [#4647](https://github.com/equinor/design-system/discussions/4647): each component owns its typography in CSS, via tokens.

## Summary

- `Field.Label`, `Field.Description`, `Field.HelperMessage` render as native `label` / `p` elements — no `TypographyNext` wrapper
- Typography applied in `field.css` via `--eds-typography-ui-body-*` tokens
- `font-family` set once on `.eds-field` root (inherits)
- `font-size` / `line-height` set per sub-element — `label` uses `md`, `indicator` / `description` / `helper-message` use `sm`
- `description` and `helper-message` share a selector-list block for the `sm` preset and `text-box: trim-both ex alphabetic` under `@supports` (baseline-grid alignment when wrapping)
- Indicator's `data-font-size="sm"` attribute removed — sizing comes from CSS now

## Notes on repetition

The CSS still repeats `font-size` / `line-height` once per size-tier (once for `md`, twice for `sm` — sharing via selector list). This matches Button's pattern and the "accept repetition" option in #4647. The broader mechanism question (PostCSS mixin vs utility classes vs `adoptedStyleSheets`) is better taken up after Chip (#4836) and Banner.Message (#4835) land — three datapoints inform that choice better than one.

## Test plan

- [x] `Field.test.tsx` — 29 / 29 pass
- [x] Visual check in Storybook across TextField, Checkbox, Radio, Switch, Autocomplete (all consumers of Field)
- [x] Check both density modes (`spacious`, `comfortable`)
- [x] Verify indicator still renders in `Field.Label` with correct size