### PR TITLE
feat: add Divider component to next/

### DIFF
--- a/packages/eds-core-react/src/components/next/Divider/Divider.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.figma.tsx
@@ -1,0 +1,10 @@
+import figma from '@figma/code-connect'
+import { Divider } from './Divider'
+
+figma.connect(
+  Divider,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=4540-103914',
+  {
+    example: () => <Divider />,
+  },
+)

--- a/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Divider } from '.'
+
+const meta: Meta<typeof Divider> = {
+  title: 'EDS 2.0 (beta)/Divider',
+  component: Divider,
+  tags: ['beta'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+⚠️ **Beta Component** - This component is under active development.
+
+\`\`\`tsx
+import { Divider } from '@equinor/eds-core-react/next'
+\`\`\`
+        `,
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Divider>
+
+export const Introduction: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <p>Above the divider</p>
+      <Divider />
+      <p>Below the divider</p>
+    </div>
+  ),
+}

--- a/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Divider } from '.'
 
 const meta: Meta<typeof Divider> = {
-  title: 'EDS 2.0 (beta)/Divider',
+  title: 'EDS 2.0 (beta)/Surface/Divider',
   component: Divider,
   tags: ['beta'],
   parameters: {

--- a/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TypographyNext } from '../../Typography'
 import { Divider } from '.'
 
 const meta: Meta<typeof Divider> = {
@@ -14,6 +15,9 @@ const meta: Meta<typeof Divider> = {
 \`\`\`tsx
 import { Divider } from '@equinor/eds-core-react/next'
 \`\`\`
+
+A thin horizontal rule that separates related content. Renders as a native
+\`<hr>\` with \`role="separator"\`.
         `,
       },
     },
@@ -24,12 +28,45 @@ export default meta
 
 type Story = StoryObj<typeof Divider>
 
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingBlock: 'var(--eds-spacing-vertical-md)',
+    }}
+  >
+    <TypographyNext as="span" family="ui" size="md" baseline="center">
+      {label}
+    </TypographyNext>
+    <TypographyNext
+      as="span"
+      family="ui"
+      size="md"
+      baseline="center"
+      style={{ color: 'var(--eds-color-text-subtle)' }}
+    >
+      {value}
+    </TypographyNext>
+  </div>
+)
+
 export const Introduction: Story = {
   render: () => (
-    <div style={{ width: 320 }}>
-      <p>Above the divider</p>
+    <div
+      style={{
+        width: 360,
+        paddingInline: 'var(--eds-spacing-horizontal-lg)',
+      }}
+    >
+      <Row label="Language" value="English" />
       <Divider />
-      <p>Below the divider</p>
+      <Row label="Theme" value="System" />
+      <Divider />
+      <Row label="Notifications" value="Enabled" />
+      <Divider />
+      <Row label="Time zone" value="Europe/Oslo" />
     </div>
   ),
 }

--- a/packages/eds-core-react/src/components/next/Divider/Divider.test.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { Divider } from '.'
@@ -17,7 +18,7 @@ describe('Divider (next)', () => {
     })
 
     it('forwards ref', () => {
-      const ref = { current: null as HTMLHRElement | null }
+      const ref = createRef<HTMLHRElement>()
       render(<Divider ref={ref} />)
       expect(ref.current).toBeInstanceOf(HTMLHRElement)
     })

--- a/packages/eds-core-react/src/components/next/Divider/Divider.test.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { Divider } from '.'
+
+describe('Divider (next)', () => {
+  describe('Rendering', () => {
+    it('renders an hr with the eds-divider class', () => {
+      render(<Divider />)
+      const divider = screen.getByRole('separator')
+      expect(divider.tagName).toBe('HR')
+      expect(divider).toHaveClass('eds-divider')
+    })
+
+    it('applies custom className', () => {
+      render(<Divider className="custom" />)
+      expect(screen.getByRole('separator')).toHaveClass('eds-divider', 'custom')
+    })
+
+    it('forwards ref', () => {
+      const ref = { current: null as HTMLHRElement | null }
+      render(<Divider ref={ref} />)
+      expect(ref.current).toBeInstanceOf(HTMLHRElement)
+    })
+
+    it('spreads additional props', () => {
+      render(<Divider data-testid="my-divider" data-custom="value" />)
+      expect(screen.getByTestId('my-divider')).toHaveAttribute(
+        'data-custom',
+        'value',
+      )
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has the separator role by default (native <hr>)', () => {
+      render(<Divider />)
+      expect(screen.getByRole('separator')).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <>
+          <p>Some text</p>
+          <Divider />
+          <p>More text</p>
+        </>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Divider/Divider.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.tsx
@@ -1,0 +1,12 @@
+import { forwardRef } from 'react'
+import type { DividerProps } from './Divider.types'
+
+export const Divider = forwardRef<HTMLHRElement, DividerProps>(function Divider(
+  { className, ...rest },
+  ref,
+) {
+  const classes = ['eds-divider', className].filter(Boolean).join(' ')
+  return <hr ref={ref} className={classes} {...rest} />
+})
+
+Divider.displayName = 'Divider'

--- a/packages/eds-core-react/src/components/next/Divider/Divider.types.ts
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.types.ts
@@ -1,0 +1,3 @@
+import type { HTMLAttributes } from 'react'
+
+export type DividerProps = HTMLAttributes<HTMLHRElement>

--- a/packages/eds-core-react/src/components/next/Divider/divider.css
+++ b/packages/eds-core-react/src/components/next/Divider/divider.css
@@ -1,11 +1,12 @@
 @layer eds-components {
   .eds-divider {
     display: block;
+
     width: 100%;
     height: 0;
     margin: 0;
     border: 0;
     border-top: var(--eds-sizing-stroke-thin) solid
-      var(--eds-color-border-medium);
+      var(--eds-color-border-subtle);
   }
 }

--- a/packages/eds-core-react/src/components/next/Divider/divider.css
+++ b/packages/eds-core-react/src/components/next/Divider/divider.css
@@ -1,12 +1,14 @@
 @layer eds-components {
   .eds-divider {
+    --_stroke: var(--eds-sizing-stroke-thin);
+    --_color: var(--eds-color-border-subtle);
+
     display: block;
 
-    width: 100%;
-    height: 0;
+    inline-size: 100%;
+    block-size: 0;
     margin: 0;
     border: 0;
-    border-top: var(--eds-sizing-stroke-thin) solid
-      var(--eds-color-border-subtle);
+    border-block-start: var(--_stroke) solid var(--_color);
   }
 }

--- a/packages/eds-core-react/src/components/next/Divider/divider.css
+++ b/packages/eds-core-react/src/components/next/Divider/divider.css
@@ -1,0 +1,11 @@
+@layer eds-components {
+  .eds-divider {
+    display: block;
+    width: 100%;
+    height: 0;
+    margin: 0;
+    border: 0;
+    border-top: var(--eds-sizing-stroke-thin) solid
+      var(--eds-color-border-medium);
+  }
+}

--- a/packages/eds-core-react/src/components/next/Divider/index.ts
+++ b/packages/eds-core-react/src/components/next/Divider/index.ts
@@ -1,0 +1,2 @@
+export { Divider } from './Divider'
+export type { DividerProps } from './Divider.types'

--- a/packages/eds-core-react/src/components/next/index.css
+++ b/packages/eds-core-react/src/components/next/index.css
@@ -33,4 +33,5 @@
 @import './Tooltip/tooltip.css';
 @import './Banner/banner.css';
 @import './Chip/chip.css';
+@import './Divider/divider.css';
 

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -57,3 +57,6 @@ export type { SlotProps } from './Slot'
 
 export { Chip } from './Chip'
 export type { ChipProps, ChipTone, ChipVariant } from './Chip'
+
+export { Divider } from './Divider'
+export type { DividerProps } from './Divider'


### PR DESCRIPTION
## Summary

Adds the base EDS 2.0 **Divider** as a minimal `<hr>` styled with `--eds-color-border-subtle` and `--eds-sizing-stroke-thin`. Part of Slice 2.

- Closes #4700

## From Figma ([node 4540-103914](https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/%F0%9F%94%B9-EDS-Core-Components?node-id=4540-103914))

- 1px horizontal line using `--eds-color-border-subtle` (mode-aware)
- No variants, no properties — atomic base component

## Design decisions (please review)

- **Minimal API** — `DividerProps = HTMLAttributes<HTMLHRElement>`. No custom props.
- **Breaking change vs 1.0** — dropped `color` / `variant` / `size` props. Consumers migrating from 1.0 will need an update; spacing is now delegated to parent layout (`gap`).
- **No `orientation` prop** — the Figma node only shows horizontal. Held off on speculative vertical support; happy to add if reviewers want it.

## Test plan

- [x] `pnpm test --testPathPatterns="next/Divider"` — 6/6 passing (render, className, ref, prop spread, role=separator, axe)
- [x] `pnpm run lint ./packages/eds-core-react/src/components/next/Divider` — clean
- [x] `pnpm run build:core-react` — clean
- [x] Storybook visual check (`EDS 2.0 (beta)/Divider`)