### PR TITLE
chore: scope js-yaml override and bump webpackbar to fix docs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,9 @@
       "@isaacs/brace-expansion": ">=5.0.1",
       "diff": ">=4.0.4",
       "js-yaml": ">=4.1.1",
-      "lodash": ">=4.18.0"
+      "gray-matter>js-yaml": "^3.14.1",
+      "lodash": ">=4.18.0",
+      "webpackbar": "^7.0.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,9 @@ overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   diff: '>=4.0.4'
   js-yaml: '>=4.1.1'
+  gray-matter>js-yaml: ^3.14.1
   lodash: '>=4.18.0'
+  webpackbar: ^7.0.0
 
 importers:
 
@@ -4753,6 +4755,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  ansis@3.17.0:
+    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
+    engines: {node: '>=14'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -5959,10 +5965,6 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -6303,10 +6305,6 @@ packages:
   feed@4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
-
-  figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
 
   file-entry-cache@11.1.2:
     resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==}
@@ -7385,6 +7383,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -7758,9 +7760,6 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
-
-  markdown-table@2.0.0:
-    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -9461,10 +9460,6 @@ packages:
   renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
 
-  repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
-    engines: {node: '>=0.10'}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -10771,11 +10766,17 @@ packages:
       webpack-cli:
         optional: true
 
-  webpackbar@6.0.1:
-    resolution: {integrity: sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==}
+  webpackbar@7.0.0:
+    resolution: {integrity: sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
+      '@rspack/core': '*'
       webpack: 3 || 4 || 5
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   websocket-driver@0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
@@ -12407,7 +12408,7 @@ snapshots:
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2))(webpack@5.106.2)
       webpack: 5.106.2
-      webpackbar: 6.0.1(webpack@5.106.2)
+      webpackbar: 7.0.0(webpack@5.106.2)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -15737,6 +15738,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  ansis@3.17.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -17138,8 +17141,6 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  escape-string-regexp@1.0.5: {}
-
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -17705,10 +17706,6 @@ snapshots:
     dependencies:
       xml-js: 1.6.11
 
-  figures@3.2.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
   file-entry-cache@11.1.2:
     dependencies:
       flat-cache: 6.1.22
@@ -18026,7 +18023,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 3.14.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -19076,6 +19073,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -19412,10 +19414,6 @@ snapshots:
   mark.js@8.11.1: {}
 
   markdown-extensions@2.0.0: {}
-
-  markdown-table@2.0.0:
-    dependencies:
-      repeat-string: 1.6.1
 
   markdown-table@3.0.4: {}
 
@@ -21552,8 +21550,6 @@ snapshots:
       lodash: 4.18.1
       strip-ansi: 6.0.1
 
-  repeat-string@1.6.1: {}
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -23159,17 +23155,14 @@ snapshots:
       - uglify-js
     optional: true
 
-  webpackbar@6.0.1(webpack@5.106.2):
+  webpackbar@7.0.0(webpack@5.106.2):
     dependencies:
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
+      ansis: 3.17.0
       consola: 3.4.2
-      figures: 3.2.0
-      markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.10.0
+    optionalDependencies:
       webpack: 5.106.2
-      wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the Radix `docs` build failure that has been blocking dev deploys on most branches since the Dependabot overrides PR (#4809).

Two stacked bugs:

**1. `js-yaml` override too broad** — `pnpm.overrides` forced `js-yaml >=4.1.1` globally, which dragged `gray-matter@4.0.3` (uses `yaml.safeLoad`) onto v4 where `safeLoad` was removed. Docusaurus crashes on the first front-matter parse:

```
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead.
    at gray-matter/lib/parse.js:12:17
```

Fix: scope the v3 patch to gray-matter only via `"gray-matter>js-yaml": "^3.14.1"`. The lockfile resolves to `js-yaml@3.14.2` (latest available v3.14.x).

**Security note:** CVE-2023-2251 (prototype pollution) — the alert that drove the original `>=4.1.1` override — was **not** backported to the v3 line, so `gray-matter` is now on a technically unpatched js-yaml. Practical risk here is low: `gray-matter` uses `yaml.safeLoad()` (restricted loader, does not execute the YAML tags the CVE targets), and the input is developer-controlled Markdown front-matter, not untrusted user data. Worth being aware of — Dependabot may re-flag the transitive path. If it does, document the exception with this rationale rather than re-broadening the override.

**2. `webpackbar@6.0.1` incompatible with `webpack@5.106.2`** — once #1 was fixed, the next failure surfaced:

```
ValidationError: ProgressPlugin options has an unknown property 'name', 'color', 'reporters', 'reporter'
    at webpackbar/.../ProgressPlugin.js:237
```

Webpack tightened the ProgressPlugin schema; webpackbar 6 still passes its old options. Bumping to `webpackbar@^7.0.0` resolves it (still declares `webpack: 3 || 4 || 5` as peer). Bonus: v7 drops several transitive deps (`chalk`, `figures`, `wrap-ansi`, `markdown-table`, `escape-string-regexp`) in favour of a single lightweight `ansis` lib.

## Verification

Ran the full Radix `docs` build chain locally:
```
pnpm run build:token-sync && pnpm run build:tokens-build && pnpm run build:icons \
  && pnpm run build:tokens && pnpm run build:utils && pnpm run build:core-react \
  && pnpm run build:docs
```
→ exits 0, `[SUCCESS] Generated static files in "build"`.

## Follow-up

Filed #4858 — CI does not currently run `build:docs` or the color-palette-generator app build, which is why both bugs slipped through with green PR checks. Long-term fix is to build the Radix Dockerfiles in CI so any failure that would break Radix breaks CI first.

## Test plan

- [x] Radix `docs` build for this branch passes in dev
- [x] Dependabot alerts for js-yaml and webpackbar remain closed (or if re-flagged on the gray-matter path, see security note above)
- [x] No regression in Storybook / core-react bundles