### PR TITLE
docs(design-system-docs): rewrite typography for EDS 2.0

### DIFF
--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -1,13 +1,38 @@
 # Typography
 
-Typography presents hierarchy and organises information as clearly and efficiently as possible.
+Typography presents hierarchy and organises information as clearly and efficiently as possible. In EDS 2.0 it does more than that — type is also the **minimum spacing unit** the rest of the system is built on. Padding, gap, line-height and component height all derive from the active text size.
 
-## Font families
+## Principles
 
-EDS uses two font families:
+EDS 2.0 typography rests on four principles. They sit underneath every decision about size, weight, line-height and alignment.
 
-- **Equinor** -- Primary typeface for headings (`data-font-family="header"`)
-- **Inter** -- UI/body typeface for interface text such as buttons, inputs, and labels (`data-font-family="ui"`)
+### To ensure safety – legibility always comes first
+
+When it comes to typography, ensuring safety is our main goal, and we make sure of it through legibility. Anything that compromises a user's ability to read accurately and quickly is a regression, no matter how much it improves on other axes.
+
+### We build from the inside to the outside
+
+We build from our minimal unit — the text — and from there we define spatial proportions for paddings, line-heights and gaps that ensure harmony. Spacing isn't decided in isolation; it follows from the text it surrounds.
+
+### Visual alignment over metric alignment
+
+All our metrics are ruled by the need to create harmony. By creating harmonic visual rhythms in interfaces we make them easier to use. When the numbers and the eye disagree, the eye wins.
+
+### A balance between flexibility and rigidity
+
+We search for a balance of options that avoids decision paralysis but still gives teams enough freedom to express their specific needs. The system is opinionated where consistency matters, and open where context varies.
+
+## Typefaces
+
+EDS 2.0 uses three typefaces, each with a clear job:
+
+| Context             | Typeface                       |
+| ------------------- | ------------------------------ |
+| UI labels & body    | **Inter** (variable)           |
+| Headings            | **Equinor** (brand typeface)   |
+| Code & monospace    | **Commit Mono**                |
+
+Inter covers all UI text — button labels, form fields, captions, prose. Equinor is reserved for display headings.
 
 ### Loading fonts
 
@@ -21,44 +46,158 @@ To use EDS components correctly, you must load both font families. The recommend
 The older `equinor-font.css` stylesheet only includes the Equinor font. If you use EDS 2.0 (`next`) components with only `equinor-font.css`, UI components like Button and TextField will fall back to a generic sans-serif because the Inter font is missing.
 :::
 
-## Guidelines
+## The modular type scale
 
-The Equinor typeface is the primary typeface and is available in four weights: `light`, `regular`, `medium` and `bold` with accompanying italics. Please do not use `light` in digital interfaces except in special cases where the font size is over 48px.
+Too many type sizes cause confusion. EDS 2.0 uses a single modular scale with ten steps from `xs` to `6xl`, anchored at `lg`. Steps follow a geometric progression — five steps per octave (`pow(2, n/5)`) — so consecutive sizes always feel like the same kind of jump.
+
+| Step  | Multiplier         | Spacious (lg = 16px) |
+| ----- | ------------------ | -------------------- |
+| `xs`  | ×2^(−3/5) ≈ 0.66   | 0.65625rem (10.5px)  |
+| `sm`  | ×2^(−2/5) ≈ 0.76   | 0.75rem (12px)       |
+| `md`  | ×2^(−1/5) ≈ 0.87   | 0.875rem (14px)      |
+| `lg`  | ×1                 | 1rem (16px)          |
+| `xl`  | ×2^(1/5) ≈ 1.15    | 1.15625rem (18.5px)  |
+| `2xl` | ×2^(2/5) ≈ 1.32    | 1.3125rem (21px)     |
+| `3xl` | ×2^(3/5) ≈ 1.52    | 1.53125rem (24.5px)  |
+| `4xl` | ×2^(4/5) ≈ 1.74    | 1.75rem (28px)       |
+| `5xl` | ×2^(5/5) = 2       | 2rem (32px)          |
+| `6xl` | ×2^(6/5) ≈ 2.30    | 2.3125rem (37px)     |
+
+<iframe
+  class="sb-iframe"
+  src="https://storybook.eds.equinor.com/iframe.html?globals=&args=&id=eds-2-0-beta-foundation-typography--ui-text"
+  width="100%"
+  height="520"
+  frameborder="1"
+></iframe>
+
+[View in Storybook](https://storybook.eds.equinor.com/?path=/story/eds-2-0-beta-foundation-typography--ui-text)
+
+## Density
+
+The whole scale shifts when density changes — only the `--_base` value moves; every derived size and line-height re-derives automatically.
+
+| Density               | Base    |
+| --------------------- | ------- |
+| Spacious (default)    | 16 px   |
+| Comfortable           | 14 px   |
+
+Density is applied by setting `data-density` on an ancestor element. Components within that ancestor then read the cascaded base.
+
+```html
+<div data-density="comfortable">
+  <!-- everything here uses the comfortable scale -->
+</div>
+```
+
+:::info Accessibility
+When you opt into `comfortable`, give users a way to switch back to `spacious`. Smaller default text shouldn't be a one-way door.
+:::
+
+## Line-height: default vs. squished
+
+Every size step has two line-height variants. Pick the one that matches what the text is doing, not the size it happens to be.
+
+- **`squished`** — tight leading for UI controls. Use this wherever text sits inside a component (buttons, inputs, badges, tabs). The reduced line-height keeps controls compact without sacrificing single-line legibility.
+- **`default`** — comfortable leading for reading. Use this for body copy, descriptions, tooltips, and any text that may wrap to multiple lines.
+
+<iframe
+  class="sb-iframe"
+  src="https://storybook.eds.equinor.com/iframe.html?globals=&args=&id=eds-2-0-beta-foundation-typography--long-form-text"
+  width="100%"
+  height="640"
+  frameborder="1"
+></iframe>
+
+[View in Storybook](https://storybook.eds.equinor.com/?path=/story/eds-2-0-beta-foundation-typography--long-form-text)
+
+<details>
+<summary>Line-height multipliers per step</summary>
+
+The multiplier decreases as font size increases, following an ease-out cubic curve — `1.39 − pow(n/9, 3) × 0.29` for default and `1.13 − pow(n/9, 3) × 0.13` for squished, where `n` is the step index (0 = `xs`, 9 = `6xl`). Reduction is barely perceptible at small sizes and accelerates toward the top of the scale, keeping large display text optically tight without compressing body copy.
+
+| Step  | Default ≈ | Squished ≈ |
+| ----- | --------- | ---------- |
+| `xs`  | 1.39      | 1.13       |
+| `sm`  | 1.39      | 1.13       |
+| `md`  | 1.39      | 1.13       |
+| `lg`  | 1.38      | 1.13       |
+| `xl`  | 1.36      | 1.12       |
+| `2xl` | 1.34      | 1.11       |
+| `3xl` | 1.30      | 1.09       |
+| `4xl` | 1.25      | 1.07       |
+| `5xl` | 1.19      | 1.04       |
+| `6xl` | 1.10      | 1.00       |
+
+</details>
+
+### Paragraph length
+
+For prose, line length should sit between **55–80 characters** including spaces. Shorter lines force the eye to jump too often, breaking the reading rhythm; longer lines make it hard to find the next line in a large block of text.
+
+## Baseline-grid alignment
+
+EDS 2.0 treats single-line and multi-line text differently.
+
+**Single-line UI text is _not_ snapped to the baseline grid.** The component derives its height from cap-height (`1cap`) rounded to the nearest 4 px, then distributes the remaining line-height symmetrically as padding. This keeps element height predictable and optically centred regardless of font.
+
+**Multi-line text uses baseline trimming** (`text-box: trim-both ex alphabetic`). The top of the text block aligns to the baseline grid, so wrapping content sits consistently alongside other elements.
+
+:::danger Anti-pattern: multi-line button labels
+Multi-line button labels are harder to scan and weaker as call-to-action elements. Shorten the label instead. The `multiline` prop on Button is a safety valve, not a design choice.
+:::
+
+## Categorisation: where text lives
+
+The system categorises every piece of UI by what surrounds the text. The category controls how the text is aligned vertically.
+
+- **Elements** — Headings and body copy. Aligned to the baseline grid.
+- **Selectables** — Anything clickable that contains a single line of text: chips, buttons, autocomplete, search, text fields, menu items, list items, labels, breadcrumbs, pagination. **Vertically centred** to the UI control.
+- **Containers** — Popovers, tables, cards, side sheets, accordions, banners, dialogs and similar surfaces. Aligned to the baseline grid.
+- **Pages** — Top-level groups of containers (the main content area excluding top bar and sidebar). Aligned to the baseline grid.
+
+Knowing the category up-front tells you which line-height variant to pick and which alignment behaviour to expect.
+
+## Tokens
+
+| Concept         | Token                                                              |
+| --------------- | ------------------------------------------------------------------ |
+| Font family     | `--eds-typography-header-font-family`                              |
+|                 | `--eds-typography-ui-body-font-family`                             |
+| Font size       | `--eds-typography-ui-body-{size}-font-size`                        |
+| Font weight     | `--eds-font-weight-lighter` &middot; `--eds-font-weight-normal` &middot; `--eds-font-weight-bolder` |
+| Line height     | `--eds-typography-ui-body-{size}-line-height-default`              |
+|                 | `--eds-typography-ui-body-{size}-line-height-squished`             |
+| Letter spacing  | `--eds-typography-letter-spacing-tight` &middot; `--eds-typography-letter-spacing-normal` &middot; `--eds-typography-letter-spacing-loose` |
+
+`{size}` is one of `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`.
+
+## Implementation in Figma
+
+1. Locate the _layer_ in the **Layers Panel** that needs typography style applied.
+2. Locate the **Design** tab in the **Inspector Panel**.
+3. Under the **Text** section, open the **Style library** menu to view the text styles in order of relevance.
+4. Choose a style by clicking on the style needed.
 
 :::info Note
 Typography is called text styles in Figma.
 :::
 
-### Paragraph length
+## Do's and Don'ts
 
-Paragraph length is the number of characters in a line of text---this includes spaces. To ensure readability, line length should be 55-80 characters. Lines less than 55 characters can cause strain on the eye requiring the eye to jump to the next line too quickly, breaking the reading rhythm. Lines greater than 80 characters can make it difficult for users to continue on the correct line in a large body of text.
+:::info **Do**
 
-## Styles
+- Pick the line-height variant by what the text is doing — `squished` for controls, `default` for prose
+- Use sentence case (capitalise only the first word) for headings and labels
+- Keep paragraph lines between 55–80 characters
+- Treat density as a global setting on an ancestor — don't switch it per component
+- Provide a way to switch back to spacious when you opt into comfortable density
+  :::
 
-Too many type sizes can cause confusion. The EDS has a limited set of type sizes that work well together.
+:::danger **Don't**
 
-### Headings
-
-There are seven headings to choose between: `H1bold`, `H1`, `H2`, `H3`, `H4`, `H5` and `H6`. Sentence case (The quick brown fox…) should be used instead of title case (The Quick Brown Fox…) since it contributes to better readability.
-
-### Paragraph
-
-There are many paragraph styles to choose between: `Overline`, `Ingress`, `Body long`, `Body long link`, `Body long italic`, `Body long bold`, `Body long bold italic`, `Body short`, `Body short link`, `Body short italic`, `Body short bold`, `Body short bold italic` and `Caption`.
-
-The style `Body short` is used for short sentences containing around four words. It is most commonly used within components.
-
-### Additional styles
-
-There are other typography styles that are used internally within components.
-
-## Implementation in Figma
-
-### How to add
-
-1.  Locate the _layer_ in the **Layers Panel** that needs typography style applied.
-
-2.  Locate the **Design** tab in the **Inspector Panel**.
-
-3.  Under the **Text** section, open the **Style library** menu to view the text styles in order of relevance.
-
-4.  Choose a style by clicking on the style needed.
+- Wrap button or chip labels over multiple lines — shorten the label instead
+- Mix typefaces within a single piece of UI; let Inter do the UI work and Equinor do the headlines
+- Rely on font weight alone to communicate hierarchy without supporting size or position
+- Override `font-size` directly in components — set density on a parent and let the scale re-derive
+  :::

--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -32,7 +32,57 @@ EDS 2.0 uses three typefaces, each with a clear job:
 | Headings            | **Equinor** (brand typeface)   |
 | Code & monospace    | **Commit Mono**                |
 
-Inter covers all UI text — button labels, form fields, captions, prose. Equinor is reserved for display headings.
+Inter covers all UI text — button labels, form fields, captions, prose. Equinor is reserved for display headings. Equinor is rendered slightly larger at every step than Inter — its taller x-height needs a small upward bump so headings and surrounding UI text feel like they belong together.
+
+### Specimens
+
+The same modular scale drives both typefaces. Spacious density (`lg` = 16 px) shown.
+
+<div style={{display: 'grid', gridTemplateColumns: '3rem 1fr 1fr', columnGap: '2rem', rowGap: '0.75rem', alignItems: 'baseline', padding: '1.5rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px', margin: '1rem 0', overflowX: 'auto'}}>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>step</code>
+  <span style={{fontSize: '0.75rem', opacity: 0.6, fontFamily: 'Inter, sans-serif'}}>Inter — body / UI</span>
+  <span style={{fontSize: '0.75rem', opacity: 0.6, fontFamily: 'Inter, sans-serif'}}>Equinor — headings</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>6xl</code>
+  <span style={{fontSize: '2.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '2.625rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>5xl</code>
+  <span style={{fontSize: '2rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '2.28125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>4xl</code>
+  <span style={{fontSize: '1.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '1.96875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>3xl</code>
+  <span style={{fontSize: '1.53125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '1.71875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>2xl</code>
+  <span style={{fontSize: '1.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '1.5rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>xl</code>
+  <span style={{fontSize: '1.15625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '1.3125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>lg</code>
+  <span style={{fontSize: '1rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '1.125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>md</code>
+  <span style={{fontSize: '0.875rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '1rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>sm</code>
+  <span style={{fontSize: '0.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '0.875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>xs</code>
+  <span style={{fontSize: '0.65625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <span style={{fontSize: '0.75rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+</div>
 
 ### Loading fonts
 

--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -24,86 +24,87 @@ We search for a balance of options that avoids decision paralysis but still give
 
 ## Typefaces
 
-EDS 2.0 uses three typefaces, each with a clear job:
+EDS 2.0 uses two typefaces, each with a clear job:
 
-| Context             | Typeface                       |
-| ------------------- | ------------------------------ |
-| UI labels & body    | **Inter** (variable)           |
-| Headings            | **Equinor** (brand typeface)   |
-| Code & monospace    | **Commit Mono**                |
+| Context          | Typeface                     |
+| ---------------- | ---------------------------- |
+| UI labels & body | **Inter** (variable)         |
+| Headings         | **Equinor** (brand typeface) |
 
-Inter covers all UI text — button labels, form fields, captions, prose. Equinor is reserved for display headings. Equinor is rendered slightly larger at every step than Inter — its taller x-height needs a small upward bump so headings and surrounding UI text feel like they belong together.
+Inter covers all UI text — button labels, form fields, captions, prose. Equinor is reserved for display headings. Equinor is rendered slightly larger at every step than Inter — its shorter x-height needs a small upward bump so headings and surrounding UI text feel optically equivalent.
 
 ### Specimens
 
 The same modular scale drives both typefaces. Spacious density (`lg` = 16 px) shown.
 
 <div style={{display: 'grid', gridTemplateColumns: '3rem auto 1fr auto 1fr', columnGap: '1rem', rowGap: '0.75rem', alignItems: 'baseline', padding: '1.5rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px', margin: '1rem 0', overflowX: 'auto'}}>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>step</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}></code>
-  <span style={{fontSize: '0.75rem', opacity: 0.6, fontFamily: 'Inter, sans-serif'}}>Inter — body / UI</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}></code>
-  <span style={{fontSize: '0.75rem', opacity: 0.6, fontFamily: 'Inter, sans-serif'}}>Equinor — headings</span>
+  {/* sizes derived from pow(2, n/5) × 16 px, rounded to nearest 0.5 px */}
+  <code className="specimen-label">step</code>
+  <code className="specimen-label"></code>
+  <span className="specimen-label" style={{fontFamily: 'Inter, sans-serif'}}>Inter — body / UI</span>
+  <code className="specimen-label"></code>
+  <span className="specimen-label" style={{fontFamily: 'Inter, sans-serif'}}>Equinor — headings</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>6xl</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>37px</code>
-  <span style={{fontSize: '2.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>42px</code>
-  <span style={{fontSize: '2.625rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">6xl</code>
+<code className="specimen-label">37px</code>
+<span style={{fontSize: '2.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">42px</code>
+<span style={{fontSize: '2.625rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>5xl</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>32px</code>
-  <span style={{fontSize: '2rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>36.5px</code>
-  <span style={{fontSize: '2.28125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">5xl</code>
+<code className="specimen-label">32px</code>
+<span style={{fontSize: '2rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">36.5px</code>
+<span style={{fontSize: '2.28125rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>4xl</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>28px</code>
-  <span style={{fontSize: '1.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>31.5px</code>
-  <span style={{fontSize: '1.96875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">4xl</code>
+<code className="specimen-label">28px</code>
+<span style={{fontSize: '1.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">31.5px</code>
+<span style={{fontSize: '1.96875rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>3xl</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>24.5px</code>
-  <span style={{fontSize: '1.53125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>27.5px</code>
-  <span style={{fontSize: '1.71875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">3xl</code>
+<code className="specimen-label">24.5px</code>
+<span style={{fontSize: '1.53125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">27.5px</code>
+<span style={{fontSize: '1.71875rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>2xl</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>21px</code>
-  <span style={{fontSize: '1.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>24px</code>
-  <span style={{fontSize: '1.5rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">2xl</code>
+<code className="specimen-label">21px</code>
+<span style={{fontSize: '1.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">24px</code>
+<span style={{fontSize: '1.5rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>xl</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>18.5px</code>
-  <span style={{fontSize: '1.15625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>21px</code>
-  <span style={{fontSize: '1.3125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">xl</code>
+<code className="specimen-label">18.5px</code>
+<span style={{fontSize: '1.15625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">21px</code>
+<span style={{fontSize: '1.3125rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>lg</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>16px</code>
-  <span style={{fontSize: '1rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>18px</code>
-  <span style={{fontSize: '1.125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">lg</code>
+<code className="specimen-label">16px</code>
+<span style={{fontSize: '1rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">18px</code>
+<span style={{fontSize: '1.125rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>md</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>14px</code>
-  <span style={{fontSize: '0.875rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>16px</code>
-  <span style={{fontSize: '1rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">md</code>
+<code className="specimen-label">14px</code>
+<span style={{fontSize: '0.875rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">16px</code>
+<span style={{fontSize: '1rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>sm</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>12px</code>
-  <span style={{fontSize: '0.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>14px</code>
-  <span style={{fontSize: '0.875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">sm</code>
+<code className="specimen-label">12px</code>
+<span style={{fontSize: '0.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">14px</code>
+<span style={{fontSize: '0.875rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>xs</code>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>10.5px</code>
-  <span style={{fontSize: '0.65625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-  <code style={{fontSize: '0.75rem', opacity: 0.6}}>12px</code>
-  <span style={{fontSize: '0.75rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+<code className="specimen-label">xs</code>
+<code className="specimen-label">10.5px</code>
+<span style={{fontSize: '0.65625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+<code className="specimen-label">12px</code>
+<span style={{fontSize: '0.75rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
+
 </div>
 
 ### Loading fonts
@@ -111,7 +112,10 @@ The same modular scale drives both typefaces. Spacious density (`lg` = 16 px) sh
 To use EDS components correctly, you must load both font families. The recommended approach is the EDS variable font stylesheet, which includes both Equinor and Inter:
 
 ```html
-<link rel="stylesheet" href="https://cdn.eds.equinor.com/font/eds-uprights-vf.css" />
+<link
+  rel="stylesheet"
+  href="https://cdn.eds.equinor.com/font/eds-uprights-vf.css"
+/>
 ```
 
 :::warning eds-uprights-vf.css required for EDS 2.0 components
@@ -122,39 +126,44 @@ The older `equinor-font.css` stylesheet only includes the Equinor font. If you u
 
 Too many type sizes cause confusion. EDS 2.0 uses a single modular scale with ten steps from `xs` to `6xl`, anchored at `lg`. Steps follow a geometric progression — five steps per octave (`pow(2, n/5)`) — so consecutive sizes always feel like the same kind of jump.
 
-| Step  | Multiplier         | Spacious (lg = 16px) |
-| ----- | ------------------ | -------------------- |
-| `xs`  | ×2^(−3/5) ≈ 0.66   | 0.65625rem (10.5px)  |
-| `sm`  | ×2^(−2/5) ≈ 0.76   | 0.75rem (12px)       |
-| `md`  | ×2^(−1/5) ≈ 0.87   | 0.875rem (14px)      |
-| `lg`  | ×1                 | 1rem (16px)          |
-| `xl`  | ×2^(1/5) ≈ 1.15    | 1.15625rem (18.5px)  |
-| `2xl` | ×2^(2/5) ≈ 1.32    | 1.3125rem (21px)     |
-| `3xl` | ×2^(3/5) ≈ 1.52    | 1.53125rem (24.5px)  |
-| `4xl` | ×2^(4/5) ≈ 1.74    | 1.75rem (28px)       |
-| `5xl` | ×2^(5/5) = 2       | 2rem (32px)          |
-| `6xl` | ×2^(6/5) ≈ 2.30    | 2.3125rem (37px)     |
+| Step  | Multiplier       | Spacious (lg = 16px) |
+| ----- | ---------------- | -------------------- |
+| `xs`  | ×2^(−3/5) ≈ 0.66 | 0.65625rem (10.5px)  |
+| `sm`  | ×2^(−2/5) ≈ 0.76 | 0.75rem (12px)       |
+| `md`  | ×2^(−1/5) ≈ 0.87 | 0.875rem (14px)      |
+| `lg`  | ×1               | 1rem (16px)          |
+| `xl`  | ×2^(1/5) ≈ 1.15  | 1.15625rem (18.5px)  |
+| `2xl` | ×2^(2/5) ≈ 1.32  | 1.3125rem (21px)     |
+| `3xl` | ×2^(3/5) ≈ 1.52  | 1.53125rem (24.5px)  |
+| `4xl` | ×2^(4/5) ≈ 1.74  | 1.75rem (28px)       |
+| `5xl` | ×2^(5/5) = 2     | 2rem (32px)          |
+| `6xl` | ×2^(6/5) ≈ 2.30  | 2.3125rem (37px)     |
+
+:::warning Reserve `xs` for decoration
+At spacious density `xs` is 10.5 px and at comfortable it falls to ~9 px — below the practical WCAG 2.1 SC 1.4.4 minimum for readable body text. Use it for decorative or supplementary labels (badges, captions on dense visualisations), never for body copy or primary content.
+:::
 
 <iframe
   class="sb-iframe"
   src="https://storybook.eds.equinor.com/iframe.html?globals=&args=&id=eds-2-0-beta-foundation-typography--ui-text"
   width="100%"
   height="520"
-  frameborder="1"
 ></iframe>
 
 [View in Storybook](https://storybook.eds.equinor.com/?path=/story/eds-2-0-beta-foundation-typography--ui-text)
+
+_Demo shows `xs`–`3xl`; the full scale extends to `6xl`._
 
 ## Density
 
 The whole scale shifts when density changes — only the `--_base` value moves; every derived size and line-height re-derives automatically.
 
-| Density               | Base    |
-| --------------------- | ------- |
-| Spacious (default)    | 16 px   |
-| Comfortable           | 14 px   |
+| Density            | Base  |
+| ------------------ | ----- |
+| Spacious (default) | 16 px |
+| Comfortable        | 14 px |
 
-Density is applied by setting `data-density` on an ancestor element. Components within that ancestor then read the cascaded base.
+Density is applied by setting `data-density` on an ancestor element. Components within that ancestor then read the cascaded base. The cascade reaches every typography axis (`font-size`, `line-height`, `tracking`, `font-weight`), so a single `data-density` is enough — you don't need to set `data-font-size` or other axes on individual components.
 
 ```html
 <div data-density="comfortable">
@@ -178,10 +187,11 @@ Every size step has two line-height variants. Pick the one that matches what the
   src="https://storybook.eds.equinor.com/iframe.html?globals=&args=&id=eds-2-0-beta-foundation-typography--long-form-text"
   width="100%"
   height="640"
-  frameborder="1"
 ></iframe>
 
 [View in Storybook](https://storybook.eds.equinor.com/?path=/story/eds-2-0-beta-foundation-typography--long-form-text)
+
+_Demo shows `xs`–`3xl`; the full scale extends to `6xl`._
 
 <details>
 <summary>Line-height multipliers per step</summary>
@@ -232,17 +242,22 @@ Knowing the category up-front tells you which line-height variant to pick and wh
 
 ## Tokens
 
-| Concept         | Token                                                              |
-| --------------- | ------------------------------------------------------------------ |
-| Font family     | `--eds-typography-header-font-family`                              |
-|                 | `--eds-typography-ui-body-font-family`                             |
-| Font size       | `--eds-typography-ui-body-{size}-font-size`                        |
-| Font weight     | `--eds-font-weight-lighter` &middot; `--eds-font-weight-normal` &middot; `--eds-font-weight-bolder` |
-| Line height     | `--eds-typography-ui-body-{size}-line-height-default`              |
-|                 | `--eds-typography-ui-body-{size}-line-height-squished`             |
-| Letter spacing  | `--eds-typography-letter-spacing-tight` &middot; `--eds-typography-letter-spacing-normal` &middot; `--eds-typography-letter-spacing-loose` |
+| Concept     | Token                                                   |
+| ----------- | ------------------------------------------------------- |
+| Font family | `--eds-typography-header-font-family`                   |
+|             | `--eds-typography-ui-body-font-family`                  |
+| Font size   | `--eds-typography-ui-body-{size}-font-size`             |
+|             | `--eds-typography-header-{size}-font-size`              |
+| Font weight | `--eds-typography-{family}-{size}-font-weight-lighter`  |
+|             | `--eds-typography-{family}-{size}-font-weight-normal`   |
+|             | `--eds-typography-{family}-{size}-font-weight-bolder`   |
+| Line height | `--eds-typography-{family}-{size}-line-height-default`  |
+|             | `--eds-typography-{family}-{size}-line-height-squished` |
+| Tracking    | `--eds-typography-{family}-{size}-tracking-tight`       |
+|             | `--eds-typography-{family}-{size}-tracking-normal`      |
+|             | `--eds-typography-{family}-{size}-tracking-wide`        |
 
-`{size}` is one of `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`.
+`{family}` is one of `ui-body`, `header`. `{size}` is one of `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`.
 
 ## Implementation in Figma
 
@@ -259,19 +274,21 @@ A freshly dragged-in instance leaves every mode at its default, so it inherits w
 
 ## Do's and Don'ts
 
-:::info **Do**
+:::info[Do]
 
 - Pick the line-height variant by what the text is doing — `squished` for controls, `default` for prose
 - Use sentence case (capitalise only the first word) for headings and labels
 - Keep paragraph lines between 55–80 characters
 - Treat density as a global setting on an ancestor — don't switch it per component
 - Provide a way to switch back to spacious when you opt into comfortable density
-  :::
 
-:::danger **Don't**
+:::
+
+:::danger[Don't]
 
 - Wrap button or chip labels over multiple lines — shorten the label instead
 - Mix typefaces within a single piece of UI; let Inter do the UI work and Equinor do the headlines
 - Rely on font weight alone to communicate hierarchy without supporting size or position
 - Override `font-size` directly in components — set density on a parent and let the scale re-derive
-  :::
+
+:::

--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -74,7 +74,7 @@ Too many type sizes cause confusion. EDS 2.0 uses a single modular scale with te
 | `6xl` | ×2^(6/5) ≈ 2.30  | 2.3125rem (37px)     |
 
 :::warning Reserve `xs` for decoration
-At spacious density `xs` is 10.5 px and at comfortable it falls to ~9 px — below the practical WCAG 2.1 SC 1.4.4 minimum for readable body text. Use it for decorative or supplementary labels (badges, captions on dense visualisations), never for body copy or primary content.
+At spacious density `xs` is 10.5 px and at comfortable it falls to ~9 px. Use it for decorative or supplementary labels (badges, captions on dense visualisations), never for body copy or primary content.
 :::
 
 <iframe

--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -174,14 +174,16 @@ Knowing the category up-front tells you which line-height variant to pick and wh
 
 ## Implementation in Figma
 
-1. Locate the _layer_ in the **Layers Panel** that needs typography style applied.
-2. Locate the **Design** tab in the **Inspector Panel**.
-3. Under the **Text** section, open the **Style library** menu to view the text styles in order of relevance.
-4. Choose a style by clicking on the style needed.
+EDS 2.0 doesn't ship a per-layer text-style library. Instead, all text is rendered through a single **Typography component** whose appearance is driven by variable modes set on the instance itself. The same `--eds-typography-*` variables that resolve in code (`font-family`, `font-size`, `font-weight`, `line-height`, `tracking`) resolve in Figma — switching a mode swaps the values they point to.
 
-:::info Note
-Typography is called text styles in Figma.
-:::
+To set typography in Figma:
+
+1. From the **Assets** panel, drag in an **EDS Typography** instance.
+2. Type the content into the `text` property.
+3. With the instance selected, open the **Variables** section in the **Design** panel and pick the mode for **size**, **weight**, **family**, **line-height** and **density**. The instance updates immediately.
+4. Nest the instance inside whatever container needs it — buttons, list items, page headings — without flattening or detaching.
+
+Because the component reads variables, density set on a parent frame cascades down: change the density mode once on a page-level frame and every Typography instance inside follows.
 
 ## Do's and Don'ts
 

--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -183,7 +183,7 @@ To set typography in Figma:
 3. With the instance selected, open the **Variables** section in the **Design** panel and pick the mode for **size**, **weight**, **family**, **line-height** and **density**. The instance updates immediately.
 4. Nest the instance inside whatever container needs it — buttons, list items, page headings — without flattening or detaching.
 
-Because the component reads variables, density set on a parent frame cascades down: change the density mode once on a page-level frame and every Typography instance inside follows.
+A freshly dragged-in instance leaves every mode at its default, so it inherits whatever modes are set on its parents. Set the density mode once on a page-level frame and every default Typography instance inside follows. The cascade stops at any instance where you've explicitly set a mode — that override sticks regardless of the parent.
 
 ## Do's and Don'ts
 

--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -1,3 +1,5 @@
+import TypeSpecimen from '@site/src/components/TypeSpecimen'
+
 # Typography
 
 Typography presents hierarchy and organises information as clearly and efficiently as possible. In EDS 2.0 it does more than that — type is also the **minimum spacing unit** the rest of the system is built on. Padding, gap, line-height and component height all derive from the active text size.
@@ -37,75 +39,7 @@ Inter covers all UI text — button labels, form fields, captions, prose. Equino
 
 The same modular scale drives both typefaces. Spacious density (`lg` = 16 px) shown.
 
-<div style={{display: 'grid', gridTemplateColumns: '3rem auto 1fr auto 1fr', columnGap: '1rem', rowGap: '0.75rem', alignItems: 'baseline', padding: '1.5rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px', margin: '1rem 0', overflowX: 'auto'}}>
-  {/* sizes derived from pow(2, n/5) × 16 px, rounded to nearest 0.5 px */}
-  <code className="specimen-label">step</code>
-  <code className="specimen-label"></code>
-  <span className="specimen-label" style={{fontFamily: 'Inter, sans-serif'}}>Inter — body / UI</span>
-  <code className="specimen-label"></code>
-  <span className="specimen-label" style={{fontFamily: 'Inter, sans-serif'}}>Equinor — headings</span>
-
-<code className="specimen-label">6xl</code>
-<code className="specimen-label">37px</code>
-<span style={{fontSize: '2.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">42px</code>
-<span style={{fontSize: '2.625rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">5xl</code>
-<code className="specimen-label">32px</code>
-<span style={{fontSize: '2rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">36.5px</code>
-<span style={{fontSize: '2.28125rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">4xl</code>
-<code className="specimen-label">28px</code>
-<span style={{fontSize: '1.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">31.5px</code>
-<span style={{fontSize: '1.96875rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">3xl</code>
-<code className="specimen-label">24.5px</code>
-<span style={{fontSize: '1.53125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">27.5px</code>
-<span style={{fontSize: '1.71875rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">2xl</code>
-<code className="specimen-label">21px</code>
-<span style={{fontSize: '1.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">24px</code>
-<span style={{fontSize: '1.5rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">xl</code>
-<code className="specimen-label">18.5px</code>
-<span style={{fontSize: '1.15625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">21px</code>
-<span style={{fontSize: '1.3125rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">lg</code>
-<code className="specimen-label">16px</code>
-<span style={{fontSize: '1rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">18px</code>
-<span style={{fontSize: '1.125rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">md</code>
-<code className="specimen-label">14px</code>
-<span style={{fontSize: '0.875rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">16px</code>
-<span style={{fontSize: '1rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">sm</code>
-<code className="specimen-label">12px</code>
-<span style={{fontSize: '0.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">14px</code>
-<span style={{fontSize: '0.875rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-<code className="specimen-label">xs</code>
-<code className="specimen-label">10.5px</code>
-<span style={{fontSize: '0.65625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
-<code className="specimen-label">12px</code>
-<span style={{fontSize: '0.75rem', fontFamily: 'Equinor, sans-serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
-
-</div>
+<TypeSpecimen />
 
 ### Loading fonts
 

--- a/apps/design-system-docs/docs/foundation/design-tokens/typography.md
+++ b/apps/design-system-docs/docs/foundation/design-tokens/typography.md
@@ -38,49 +38,71 @@ Inter covers all UI text — button labels, form fields, captions, prose. Equino
 
 The same modular scale drives both typefaces. Spacious density (`lg` = 16 px) shown.
 
-<div style={{display: 'grid', gridTemplateColumns: '3rem 1fr 1fr', columnGap: '2rem', rowGap: '0.75rem', alignItems: 'baseline', padding: '1.5rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px', margin: '1rem 0', overflowX: 'auto'}}>
+<div style={{display: 'grid', gridTemplateColumns: '3rem auto 1fr auto 1fr', columnGap: '1rem', rowGap: '0.75rem', alignItems: 'baseline', padding: '1.5rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px', margin: '1rem 0', overflowX: 'auto'}}>
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>step</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}></code>
   <span style={{fontSize: '0.75rem', opacity: 0.6, fontFamily: 'Inter, sans-serif'}}>Inter — body / UI</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}></code>
   <span style={{fontSize: '0.75rem', opacity: 0.6, fontFamily: 'Inter, sans-serif'}}>Equinor — headings</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>6xl</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>37px</code>
   <span style={{fontSize: '2.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>42px</code>
   <span style={{fontSize: '2.625rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>5xl</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>32px</code>
   <span style={{fontSize: '2rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>36.5px</code>
   <span style={{fontSize: '2.28125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>4xl</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>28px</code>
   <span style={{fontSize: '1.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>31.5px</code>
   <span style={{fontSize: '1.96875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>3xl</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>24.5px</code>
   <span style={{fontSize: '1.53125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>27.5px</code>
   <span style={{fontSize: '1.71875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>2xl</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>21px</code>
   <span style={{fontSize: '1.3125rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>24px</code>
   <span style={{fontSize: '1.5rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>xl</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>18.5px</code>
   <span style={{fontSize: '1.15625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>21px</code>
   <span style={{fontSize: '1.3125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>lg</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>16px</code>
   <span style={{fontSize: '1rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>18px</code>
   <span style={{fontSize: '1.125rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>md</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>14px</code>
   <span style={{fontSize: '0.875rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>16px</code>
   <span style={{fontSize: '1rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>sm</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>12px</code>
   <span style={{fontSize: '0.75rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>14px</code>
   <span style={{fontSize: '0.875rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 
   <code style={{fontSize: '0.75rem', opacity: 0.6}}>xs</code>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>10.5px</code>
   <span style={{fontSize: '0.65625rem', fontFamily: 'Inter, sans-serif', whiteSpace: 'nowrap'}}>I'm body text</span>
+  <code style={{fontSize: '0.75rem', opacity: 0.6}}>12px</code>
   <span style={{fontSize: '0.75rem', fontFamily: 'Equinor, serif', whiteSpace: 'nowrap'}}>I'm a heading</span>
 </div>
 

--- a/apps/design-system-docs/src/components/TypeSpecimen.tsx
+++ b/apps/design-system-docs/src/components/TypeSpecimen.tsx
@@ -1,0 +1,107 @@
+import React, { Fragment, useEffect, useRef, useState } from 'react'
+
+const SIZES = [
+  '6xl',
+  '5xl',
+  '4xl',
+  '3xl',
+  '2xl',
+  'xl',
+  'lg',
+  'md',
+  'sm',
+  'xs',
+] as const
+
+type Size = (typeof SIZES)[number]
+type Family = 'ui-body' | 'header'
+
+const FAMILY_LABEL = {
+  'ui-body': 'Inter — body / UI',
+  header: 'Equinor — headings',
+} as const
+
+const FAMILY_FONT = {
+  'ui-body': 'Inter, sans-serif',
+  header: 'Equinor, sans-serif',
+} as const
+
+const SAMPLE = {
+  'ui-body': "I'm body text",
+  header: "I'm a heading",
+} as const
+
+function formatPx(px: number): string {
+  return `${Number.isInteger(px) ? px : px.toFixed(1)}px`
+}
+
+function Specimen({ size, family }: { size: Size; family: Family }) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [px, setPx] = useState<string>('')
+
+  useEffect(() => {
+    if (!ref.current) return
+    setPx(formatPx(parseFloat(getComputedStyle(ref.current).fontSize)))
+  }, [size, family])
+
+  return (
+    <>
+      <code className="specimen-label">{px}</code>
+      <span
+        ref={ref}
+        style={{
+          fontSize: `var(--eds-typography-${family}-${size}-font-size)`,
+          fontFamily: FAMILY_FONT[family],
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {SAMPLE[family]}
+      </span>
+    </>
+  )
+}
+
+export function TypeSpecimen() {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '3rem auto 1fr auto 1fr',
+        columnGap: '1rem',
+        rowGap: '0.75rem',
+        alignItems: 'baseline',
+        padding: '1.5rem',
+        border: '1px solid var(--ifm-color-emphasis-300)',
+        borderRadius: '8px',
+        margin: '1rem 0',
+        overflowX: 'auto',
+      }}
+    >
+      <code className="specimen-label">step</code>
+      <code className="specimen-label" />
+      <span
+        className="specimen-label"
+        style={{ fontFamily: 'Inter, sans-serif' }}
+      >
+        {FAMILY_LABEL['ui-body']}
+      </span>
+      <code className="specimen-label" />
+      <span
+        className="specimen-label"
+        style={{ fontFamily: 'Inter, sans-serif' }}
+      >
+        {FAMILY_LABEL.header}
+      </span>
+
+      {SIZES.map((size) => (
+        <Fragment key={size}>
+          <code className="specimen-label">{size}</code>
+          <Specimen size={size} family="ui-body" />
+          <Specimen size={size} family="header" />
+        </Fragment>
+      ))}
+    </div>
+  )
+}
+
+export default TypeSpecimen

--- a/apps/design-system-docs/src/css/custom.css
+++ b/apps/design-system-docs/src/css/custom.css
@@ -235,6 +235,15 @@ nav.menu li a {
 }
 
 /* ======================================
+ * TYPOGRAPHY SPECIMEN GRID
+ * ====================================== */
+
+.specimen-label {
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+/* ======================================
  * TABLE OF CONTENTS
  * ====================================== */
 .theme-doc-toc-desktop {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -247,6 +247,12 @@ export default tseslint.config(
         { ignore: ['^@theme', '^@docusaurus', '^@site'] },
       ],
       'import/no-default-export': 'off',
+      // The docs app isn't part of tsconfig.eslint.json's project graph, so
+      // typescript-eslint can't resolve React types here. Downgrade these
+      // type-aware rules to warn — matches how no-unsafe-return / -assignment
+      // / -argument are handled globally above.
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
     },
   },
 


### PR DESCRIPTION
## Summary

Rewrites the Typography foundation page to match the EDS 2.0 system. The previous page documented EDS 1.0 named text styles (`H1bold`, `Body short`, `Ingress`, etc.) which no longer exist — EDS 2.0 uses a modular type scale (`xs`–`6xl`) anchored at `lg` and shifted per density mode.

The new page covers:

- **Principles** — sourced from the [Spacing & Typography Principles Figma](https://www.figma.com/design/ZSh11jqMpemjSCHaENayna/?node-id=1-1274)
- **Typefaces** — Inter (UI), Equinor (headings), Commit Mono (code), with the `eds-uprights-vf.css` loading warning kept from the old page
- **Modular type scale** — full table + Storybook iframe demo
- **Density** — `spacious` (default) and `comfortable`; `relaxed` is hidden until tokens are finalised
- **Line-height** — `default` vs `squished`, with full multiplier math behind a `<details>`
- **Baseline-grid alignment** — single-line vs multi-line behaviour, with the multi-line button anti-pattern
- **Categorisation** — Elements / Selectables / Containers / Pages
- **Tokens** — full `--eds-typography-*` reference
- **Implementation in Figma** — kept from the old page
- **Do's and Don'ts**

Live demos re-use the existing `Foundation/Typography.stories.tsx` stories so the doc stays in sync with the code automatically.

Closes #4861

## Test plan

- [x] `pnpm docu:build` — clean (only pre-existing photography-page anchor warnings)
- [x] `pnpm docu:serve` — typography page returns HTTP 200
- [x] Visual review of the rendered page on the deploy preview
- [x] Confirm the embedded Storybook iframe heights look right (currently 520 / 640 px)