### PR TITLE
fix: correct Chip height to match Figma design spec

### DIFF
--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -2,7 +2,7 @@
   .eds-chip {
     /* Typography metrics — same compensation pattern as Button */
     --_label-line-height: var(--eds-typography-ui-body-md-line-height-squished);
-    --_label-height: round(1cap, 4px);
+    --_label-height: round(1cap, 4px); /* Figma has a cap-rounded value but it is not exposed as a CSS token; 1cap gives the same result (Inter metrics + 4px grid) */
     --_padding-block: var(--eds-selectable-space-vertical);
     /*
      * Reduce block padding by half the line-height overflow so the visual

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -1,5 +1,19 @@
 @layer eds-components {
   .eds-chip {
+    /* Typography metrics — same compensation pattern as Button */
+    --_label-line-height: var(--eds-typography-ui-body-md-line-height-squished);
+    --_label-height: round(1cap, 4px);
+    --_padding-block: var(--eds-selectable-space-vertical);
+    /*
+     * Reduce block padding by half the line-height overflow so the visual
+     * height equals (padding × 2 + cap-height) instead of (padding × 2 + line-height).
+     * e.g. 8px − (16px − 12px) / 2 = 6px → total 28px
+     */
+    --_padding-adjusted: calc(
+      var(--_padding-block) -
+        (var(--_label-line-height) - var(--_label-height)) / 2
+    );
+
     cursor: pointer;
     user-select: none;
 
@@ -8,7 +22,8 @@
     align-items: center;
 
     box-sizing: border-box;
-    padding-block: var(--eds-selectable-space-vertical);
+    min-height: calc(var(--_padding-block) * 2 + var(--_label-height));
+    padding-block: var(--_padding-adjusted);
     padding-inline: var(--eds-selectable-space-horizontal);
     border: none;
     border-radius: var(--eds-spacing-border-radius-pill, 100vmax);
@@ -84,8 +99,8 @@
 
     & .eds-icon {
       flex-shrink: 0;
-      margin-block: calc(-1 * var(--eds-selectable-space-vertical));
-      margin-inline: calc(-1 * var(--eds-selectable-space-vertical) / 2);
+      margin-block: calc(-1 * var(--_padding-adjusted));
+      margin-inline: calc(-1 * var(--_padding-adjusted) / 2);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Chip rendered at 32px (spacious) / 24px (comfortable) due to `padding-block` including the full line-height rather than just the cap-height
- Applies the same line-height compensation pattern already used by Button: subtract half the `(line-height − cap-height)` overflow from each side of the padding block
- Fixes spacious chips to 28px and comfortable chips to 20px, matching the Figma spec (node 3853-3622)

## What changed

`chip.css` — three pseudo-private custom properties added at the component root:

- `--_label-line-height` — squished line-height for the UI body-md text
- `--_label-height` — cap-height snapped to 4px grid (`round(1cap, 4px)`)
- `--_padding-block` — raw selectable-space-vertical token
- `--_padding-adjusted` — `padding-block − (line-height − cap-height) / 2`

`min-height` is set as a floor so the chip never shrinks below `padding × 2 + cap-height`.

Icon margins updated to use `--_padding-adjusted` so icons stay flush with the chip edge.

## Test plan

- [ ] Default chip: 28px spacious, 20px comfortable
- [ ] Deletable chip: same heights, delete icon correctly flush
- [ ] Dropdown chip: same heights, arrow icon correctly flush
- [ ] Label is vertically centred in both densities