### PR TITLE
fix(design-system-docs): bridge data-theme to data-color-scheme

### DIFF
--- a/apps/design-system-docs/docusaurus.config.ts
+++ b/apps/design-system-docs/docusaurus.config.ts
@@ -23,6 +23,8 @@ const config: Config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
 
+  clientModules: ['./src/clientModules/syncColorScheme.ts'],
+
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],

--- a/apps/design-system-docs/src/clientModules/syncColorScheme.ts
+++ b/apps/design-system-docs/src/clientModules/syncColorScheme.ts
@@ -1,0 +1,29 @@
+/**
+ * Bridges Docusaurus's `data-theme` attribute to EDS's `data-color-scheme`
+ * attribute on <html>, so EDS design tokens (which key off
+ * `[data-color-scheme="dark"]`) flip in lockstep with the Docusaurus theme
+ * toggle. Without this, the page background follows the toggle but EDS-driven
+ * surfaces stay light, producing low-contrast chips on a dark canvas.
+ */
+
+if (typeof document !== 'undefined') {
+  const root = document.documentElement
+
+  const sync = () => {
+    const theme = root.getAttribute('data-theme')
+    if (theme === 'dark' || theme === 'light') {
+      root.setAttribute('data-color-scheme', theme)
+    } else {
+      root.removeAttribute('data-color-scheme')
+    }
+  }
+
+  sync()
+
+  new MutationObserver(sync).observe(root, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  })
+}
+
+export {}


### PR DESCRIPTION
Closes #4872.

## Summary

Docusaurus's dark-mode toggle keys off `data-theme="dark"` on `<html>`, while EDS tokens key off `data-color-scheme="dark"` (with a `@media (prefers-color-scheme: dark)` fallback). The two attribute systems were never connected, so the page background (driven by EDS tokens) and Infima-styled elements like inline code chips could flip independently. Most visibly on the typography docs page, code chips kept their light `#f6f7f8` background against a dark canvas whenever the user's OS preference and the Docusaurus toggle disagreed.

This adds a tiny client module that mirrors `data-theme` onto `data-color-scheme` on `<html>` and observes future toggles via `MutationObserver`. After this change, the Docusaurus toggle is the single source of truth for both systems and overrides the OS preference once a value is set.

### Why it looked fine locally but broke in prod

Local development was almost certainly tested with macOS in dark mode and the toggle also in dark — both flipped through their separate mechanisms and *appeared* in sync. End users in prod hit the mismatched cases: most commonly OS dark + default Docusaurus light, where EDS canvas goes dark via `prefers-color-scheme` while Infima keeps its light defaults.

## How to test for prod

The Docusaurus dev server (`pnpm start`) and production build use different pipelines, so verify against the prod artifact:

```bash
cd apps/design-system-docs
pnpm build
pnpm serve   # http://localhost:3000
```

Then walk through the matrix that broke before — open DevTools and watch `<html>` attributes:

- [ ] **macOS Light + toggle Dark** → `<html>` has both `data-theme="dark"` and `data-color-scheme="dark"`. Page bg dark, inline code chips dark.
- [ ] **macOS Dark + first load (no toggle yet)** → clear `localStorage` and reload. Page lands in Docusaurus default (light); both attributes are `"light"`. Page bg light, chips light. (This is the case that was broken in prod.)
- [ ] **macOS Dark + toggle Dark** → both attributes `"dark"`. All consistent.
- [ ] **macOS Dark + toggle Light** → both attributes `"light"`. EDS tokens stay light despite OS preference (toggle is now authoritative).
- [ ] Visit `/docs/Next/foundation/design-tokens/typography/` in dark mode and confirm the Headings (`h1`, `h2`, …) and Paragraph styles inline chips are legible.