### PR TITLE
chore: re-add eds-tokens to release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "last-release-sha": "0ef704b8671ea72a129e6d81aa0870511659aa38",
   "tag-separator": "@",
   "packages": {
     "packages/eds-core-react": {
@@ -79,6 +78,26 @@
         "Dockerfile.storybook",
         "nginx.conf",
         "README.md"
+      ]
+    },
+    "packages/eds-tokens": {
+      "release-type": "node",
+      "package-name": "@equinor/eds-tokens",
+      "component": "eds-tokens",
+      "exclude-paths": [
+        "tokens",
+        "build-generate-variables",
+        "scripts",
+        ".vscode",
+        ".gitignore",
+        "rollup.config.js",
+        "tsconfig.json",
+        "vite.generate-variables.config.ts",
+        "palette-config.json",
+        "token-config.json",
+        "tokens.json",
+        "README.md",
+        "CLAUDE.md"
       ]
     },
     "packages/eds-utils": {

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -4,5 +4,6 @@
   "packages/eds-data-grid-react": "1.3.0",
   "packages/eds-icons": "1.5.0",
   "packages/eds-lab-react": "0.11.0",
+  "packages/eds-tokens": "2.2.0",
   "packages/eds-utils": "2.2.0"
 }

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -1,9 +1,9 @@
 {
-  "packages/eds-core-react": "2.6.0",
-  "packages/eds-core-react/src/components/next": "2.6.0-beta.0",
+  "packages/eds-core-react": "2.7.0",
+  "packages/eds-core-react/src/components/next": "2.7.0-beta.0",
   "packages/eds-data-grid-react": "1.3.0",
-  "packages/eds-icons": "1.5.0",
+  "packages/eds-icons": "1.6.0",
   "packages/eds-lab-react": "0.11.0",
-  "packages/eds-tokens": "2.2.0",
-  "packages/eds-utils": "2.2.0"
+  "packages/eds-tokens": "2.2.1",
+  "packages/eds-utils": "2.2.1"
 }


### PR DESCRIPTION
## Summary

- Re-adds `packages/eds-tokens` to release-please config and manifest at `2.2.0`
- Removes the global `last-release-sha` override so eds-tokens' changelog starts from its own `eds-tokens@v2.2.0` tag

## Context

`eds-tokens` was temporarily removed from release-please in f3244fcf so we could publish `2.3.0-beta.0` manually, letting the mobile team validate the new TypeScript output. Mobile team confirmed today that the API works as expected, so we can release `2.3.0` as stable.

`scripts/` is added to `exclude-paths` (build-time guard scripts shouldn't trigger releases), matching the pattern used for `rollup.config.js` etc.

## Why remove `last-release-sha`?

It's a global override that limits release-please to commits since `0ef704b8`. If left in place when eds-tokens is re-added, the 2.3.0 changelog would skip everything between `eds-tokens@v2.2.0` (2026-02-17) and `0ef704b8` — including the beta features and most of the fixes.

## What gets released after merge

Release-please will rebuild #4856 (or open a fresh release PR) including:

- `eds-tokens 2.2.0 → 2.3.0` with full changelog: spacing tokens (#4587), nested TypeScript output (#4538), concept tokens in semantic outputs (#4641), elevation shadow tokens (#4783), and recent fixes (#4831, #4864, #4873)
- existing entries for `eds-core-react 2.5.1`, `eds-core-react-next 2.6.0-beta.0`, `eds-icons 1.4.1` unchanged

## Manual steps after the release PR merges

```bash
npm deprecate '@equinor/eds-tokens@2.3.0-beta.0' "Use @latest instead"
npm deprecate '@equinor/eds-tokens@2.3.0-beta.1' "Use @latest instead"
npm deprecate '@equinor/eds-tokens@2.3.0-beta.2' "Use @latest instead"
```

Closes #4591

## Test plan

- [ ] CI passes
- [ ] After merge, verify release-please opens/updates a release PR that includes `eds-tokens 2.3.0` with a complete changelog from `v2.2.0`