### PR TITLE
fix(eds-tokens-sync): externalize dotenv and node built-ins for Rolldown

### DIFF
--- a/packages/eds-tokens-sync/vite.config.ts
+++ b/packages/eds-tokens-sync/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rolldownOptions: {
-      external: ['fs', 'path'], // Keep only Node.js built-ins as external
+      external: [/^node:/, 'fs', 'path', 'os', 'dotenv', 'dotenv/config'],
     },
   },
   plugins: [dts({ rollupTypes: true })],


### PR DESCRIPTION
## Problem

`pnpm run update-tokens` (and every per-file variant — `update-tokens:foundations`, `update-tokens:color-static`, `update-tokens:color-dynamic`, `update-tokens:spacing-primitives`, `update-tokens:spacing-modes`, plus the `update-figma:*` counterparts) has been broken on `main` since the Vite 8 bump on April 8 (#4759). Symptom: a hard error during module load, before any Figma work happens.

```
Error: Calling `require` for "fs" in an environment that doesn't expose the `require` function.
    at .../packages/eds-tokens-sync/dist/color-BXdZrUk8.js:11:8
```

### Root cause

Vite 8 swapped Rollup for Rolldown as the bundler. The previous `external: ['fs', 'path']` only covered two of the Node built-ins that `dotenv` pulls in via CJS `require()`. With dotenv bundled into the ESM output, Rolldown emits a runtime helper that uses `require()` if available and otherwise throws. The package is `"type": "module"`, so `require` is not in scope and the helper throws on the first `require("fs")` call.

This blocks Figma → tokens sync (and the reverse) entirely. It surfaces only when someone actually runs the sync, which is rare — the workflows are `workflow_dispatch`-only and no one had attempted a sync since the Vite 8 bump.

The 5xl tracking-wide typography bug reported in #4876 cannot be fixed end-to-end without this working first.

## Plan

Three options were considered:

| Option | Approach | Verdict |
|---|---|---|
| **A. Externalize dotenv + Node built-ins** | Single config change; dotenv resolves via Node's normal resolver at runtime. | ✅ Chosen — minimal change, smallest blast radius |
| B. Move `import 'dotenv/config'` from `src/scripts/*.ts` into the unbundled `bin/*.js` shims | Library code becomes env-agnostic. | Architecturally cleaner but touches 4 files for no robustness benefit |
| C. Inject `createRequire` via a Rolldown banner | Keeps CJS-in-ESM bundled. | Workaround, fragile if Rolldown's runtime changes again |

A is the standard fix for this class of bundler regression and the smallest blast radius.

## Solution

Extend the `external` array in `packages/eds-tokens-sync/vite.config.ts`:

```diff
     rolldownOptions: {
-      external: ['fs', 'path'], // Keep only Node.js built-ins as external
+      external: [/^node:/, 'fs', 'path', 'os', 'dotenv', 'dotenv/config'],
     },
```

- `'os'` covers the missed Node built-in dotenv calls.
- `'dotenv'` and `'dotenv/config'` keep dotenv itself out of the bundle so Node resolves it via `node_modules` at runtime.
- `/^node:/` covers `node:fs`-style imports preemptively to avoid revisiting this config.

## Verification

- Sync package rebuilt: bundled chunk drops from 61 kB → 52 kB (dotenv stripped). `grep require\(` over the new dist returns 0.
- `node -e "import('./dist/sync_figma_to_tokens.js')"` — module loads cleanly (previously threw on the first `require("fs")`).
- End-to-end: `pnpm run update-tokens:spacing-modes` connects to Figma, fetches variables, and writes JSON files to `tokens/FQQqyumcpPQoiFRCjdS9GM/` successfully.

## Side effects

- **Runtime resolution.** The bundled dist now contains a literal `import "dotenv/config"` that Node resolves at runtime. dotenv is already a `devDependency` of `eds-tokens-sync`, so no `package.json` change is required.
- **CI workflows.** `sync-figma-to-tokens.yml` and `sync-tokens-to-figma.yml` are `workflow_dispatch`-only — they have not been failing scheduled runs. They will work again on next manual dispatch. Both rely on `_setup.yml`, which runs `pnpm install` (devDependencies included), so dotenv will be present.
- **Pent-up Figma changes.** Sync has been broken for ~4 weeks. The first successful run will surface any Figma variable changes published since April 8, not just the #4876 fix. Heads-up: coordinate with the design team before pulling.
- **Sibling vite configs not touched.** The Vite 8 / Rolldown migration affected 4 vite configs. The others don't bundle CJS deps with the same pattern, though `apps/eds-color-palette-generator/vite.config.ts` is worth a smoke test eventually.

## Test plan

- [ ] `pnpm install && pnpm --filter @equinor/eds-tokens-sync run build`
- [ ] `cd packages/eds-tokens && pnpm run update-tokens:spacing-modes` completes without `require()` error and writes synced JSON
- [ ] After merge, manually dispatch the **Sync Figma to tokens** workflow once and confirm it produces a sync PR

Closes #4880