### PR TITLE
feat: Accordion EDS 2.0

### DIFF
--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.figma.tsx
@@ -6,13 +6,13 @@ figma.connect(
   'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=6600-15092&m=dev',
   {
     props: {
-      open: figma.enum('Open', { On: true, Off: false }),
+      defaultOpen: figma.enum('Open', { On: true, Off: false }),
       title: figma.string('Title'),
       content: figma.string('Content'),
     },
-    example: ({ open, title, content }) => (
+    example: ({ defaultOpen, title, content }) => (
       <Accordion>
-        <Accordion.Item defaultOpen={open}>
+        <Accordion.Item defaultOpen={defaultOpen}>
           <Accordion.Header>{title}</Accordion.Header>
           <Accordion.Panel>{content}</Accordion.Panel>
         </Accordion.Item>

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.figma.tsx
@@ -1,0 +1,22 @@
+import figma from '@figma/code-connect'
+import { Accordion } from '.'
+
+figma.connect(
+  Accordion,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=6600-15092&m=dev',
+  {
+    props: {
+      open: figma.enum('Open', { On: true, Off: false }),
+      title: figma.string('Title'),
+      content: figma.string('Content'),
+    },
+    example: ({ open, title, content }) => (
+      <Accordion>
+        <Accordion.Item defaultOpen={open}>
+          <Accordion.Header>{title}</Accordion.Header>
+          <Accordion.Panel>{content}</Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
+    ),
+  },
+)

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
+import { Accordion } from './Accordion'
+import type { AccordionProps } from './Accordion.types'
+
+const meta: Meta<typeof Accordion> = {
+  title: 'EDS 2.0 (beta)/Data Display/Accordion',
+  component: Accordion,
+  tags: ['beta'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+⚠️ **Beta Component** - This component is under active development.
+
+Built on the native \`<details>\`/\`<summary>\` elements for free accessibility,
+keyboard support and CSS-only open/close animation.
+
+\`\`\`tsx
+import { Accordion } from '@equinor/eds-core-react/next'
+
+<Accordion>
+  <Accordion.Item>
+    <Accordion.Header>Title</Accordion.Header>
+    <Accordion.Panel>Content</Accordion.Panel>
+  </Accordion.Item>
+</Accordion>
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    exclusive: {
+      control: 'boolean',
+      description:
+        'When true, only one item can be open at a time (native HTML group via the `name` attribute).',
+    },
+  },
+  args: {
+    exclusive: false,
+  },
+}
+
+export default meta
+
+export const Introduction: StoryFn<AccordionProps> = (args) => (
+  <Accordion {...args}>
+    <Accordion.Item defaultOpen>
+      <Accordion.Header>First section</Accordion.Header>
+      <Accordion.Panel>
+        Accordions help manage information density while keeping pages
+        scannable.
+      </Accordion.Panel>
+    </Accordion.Item>
+    <Accordion.Item>
+      <Accordion.Header>Second section</Accordion.Header>
+      <Accordion.Panel>
+        Each section is a native &lt;details&gt; element, so keyboard and screen
+        reader behaviour comes for free.
+      </Accordion.Panel>
+    </Accordion.Item>
+    <Accordion.Item>
+      <Accordion.Header>Third section</Accordion.Header>
+      <Accordion.Panel>
+        Set <code>exclusive</code> on the root to only allow one open at a time.
+      </Accordion.Panel>
+    </Accordion.Item>
+  </Accordion>
+)
+
+export const Exclusive: StoryObj<AccordionProps> = {
+  args: { exclusive: true },
+  render: (args) => (
+    <Accordion {...args}>
+      <Accordion.Item>
+        <Accordion.Header>Only one open at a time</Accordion.Header>
+        <Accordion.Panel>
+          Opening another section closes this one automatically.
+        </Accordion.Panel>
+      </Accordion.Item>
+      <Accordion.Item>
+        <Accordion.Header>Try me</Accordion.Header>
+        <Accordion.Panel>
+          The exclusive grouping uses the native HTML <code>name</code>{' '}
+          attribute on <code>&lt;details&gt;</code>.
+        </Accordion.Panel>
+      </Accordion.Item>
+      <Accordion.Item>
+        <Accordion.Header>And me</Accordion.Header>
+        <Accordion.Panel>No JS state machine needed.</Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
+  ),
+}
+
+export const Controlled: StoryFn = () => {
+  const [open, setOpen] = useState(true)
+  return (
+    <Accordion>
+      <Accordion.Item open={open} onOpenChange={setOpen}>
+        <Accordion.Header>Controlled item</Accordion.Header>
+        <Accordion.Panel>
+          Open state is held by the parent component. Currently:{' '}
+          <strong>{open ? 'open' : 'closed'}</strong>.
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
+  )
+}

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
-import { Accordion } from './Accordion'
-import type { AccordionProps } from './Accordion.types'
+import { Accordion } from '.'
+import type { AccordionProps } from '.'
 
 const meta: Meta<typeof Accordion> = {
   title: 'EDS 2.0 (beta)/Data Display/Accordion',

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
@@ -4,7 +4,7 @@ import { Accordion } from '.'
 import type { AccordionProps } from '.'
 
 const meta: Meta<typeof Accordion> = {
-  title: 'EDS 2.0 (beta)/Data Display/Accordion',
+  title: 'EDS 2.0 (beta)/Surface/Accordion',
   component: Accordion,
   tags: ['beta'],
   parameters: {
@@ -130,6 +130,38 @@ const SchemePreview = () => (
       </Accordion.Panel>
     </Accordion.Item>
   </Accordion>
+)
+
+const DensityPreview = () => (
+  <Accordion>
+    <Accordion.Item defaultOpen>
+      <Accordion.Header>First section</Accordion.Header>
+      <Accordion.Panel>
+        Spacing and sizes pick up the ancestor <code>data-density</code> value.
+      </Accordion.Panel>
+    </Accordion.Item>
+    <Accordion.Item>
+      <Accordion.Header>Second section</Accordion.Header>
+      <Accordion.Panel>Content hidden until opened.</Accordion.Panel>
+    </Accordion.Item>
+  </Accordion>
+)
+
+/**
+ * Accordion respects the `data-density` attribute on an ancestor element so
+ * spacing and sizing tokens stay coordinated with sibling components.
+ */
+export const Density: StoryFn = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+    <div data-density="spacious">
+      <h3 style={{ margin: '0 0 12px' }}>Spacious (default)</h3>
+      <DensityPreview />
+    </div>
+    <div data-density="comfortable">
+      <h3 style={{ margin: '0 0 12px' }}>Comfortable</h3>
+      <DensityPreview />
+    </div>
+  </div>
 )
 
 /**

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
@@ -108,3 +108,59 @@ export const Controlled: StoryFn = () => {
     </Accordion>
   )
 }
+
+const SchemePreview = () => (
+  <Accordion>
+    <Accordion.Item defaultOpen>
+      <Accordion.Header>Open by default</Accordion.Header>
+      <Accordion.Panel>
+        Title is held at <code>--eds-color-text-accent-subtle</code> when open.
+        Content uses <code>--eds-color-text-subtle</code>.
+      </Accordion.Panel>
+    </Accordion.Item>
+    <Accordion.Item>
+      <Accordion.Header>Closed</Accordion.Header>
+      <Accordion.Panel>Hidden until opened.</Accordion.Panel>
+    </Accordion.Item>
+    <Accordion.Item>
+      <Accordion.Header>Hover or focus me</Accordion.Header>
+      <Accordion.Panel>
+        Hover bg <code>--eds-color-bg-fill-muted-default</code>; focus outline{' '}
+        <code>--eds-color-border-focus</code>.
+      </Accordion.Panel>
+    </Accordion.Item>
+  </Accordion>
+)
+
+/**
+ * Side-by-side preview of the Accordion in both color schemes — used to
+ * verify dark theme since Storybook's own dark-mode toggle is unreliable.
+ */
+export const ColorSchemes: StoryFn = () => (
+  <div style={{ display: 'flex', gap: 32, alignItems: 'flex-start' }}>
+    <div
+      data-color-scheme="light"
+      style={{
+        flex: 1,
+        padding: 24,
+        background: 'var(--eds-color-bg-canvas)',
+        color: 'var(--eds-color-text-strong)',
+      }}
+    >
+      <h3 style={{ marginTop: 0 }}>Light</h3>
+      <SchemePreview />
+    </div>
+    <div
+      data-color-scheme="dark"
+      style={{
+        flex: 1,
+        padding: 24,
+        background: 'var(--eds-color-bg-canvas)',
+        color: 'var(--eds-color-text-strong)',
+      }}
+    >
+      <h3 style={{ marginTop: 0 }}>Dark</h3>
+      <SchemePreview />
+    </div>
+  </div>
+)

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.test.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.test.tsx
@@ -77,8 +77,27 @@ describe('Accordion (next)', () => {
       expect(item).not.toHaveAttribute('open')
     })
 
-    it('supports controlled open with onOpenChange', async () => {
+    it('calls onOpenChange with the new value (uncontrolled)', async () => {
       const user = userEvent.setup()
+      const onOpenChange = jest.fn()
+      render(
+        <Accordion>
+          <Accordion.Item onOpenChange={onOpenChange}>
+            <Accordion.Header>Title</Accordion.Header>
+            <Accordion.Panel>Content</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      )
+      await user.click(screen.getByText('Title'))
+      expect(onOpenChange).toHaveBeenLastCalledWith(true)
+      await user.click(screen.getByText('Title'))
+      expect(onOpenChange).toHaveBeenLastCalledWith(false)
+    })
+
+    it('supports controlled open/close with onOpenChange', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = jest.fn()
+
       const Controlled = () => {
         const [open, setOpen] = useState(false)
         return (
@@ -86,7 +105,10 @@ describe('Accordion (next)', () => {
             <Accordion.Item
               data-testid="item"
               open={open}
-              onOpenChange={setOpen}
+              onOpenChange={(next) => {
+                onOpenChange(next)
+                setOpen(next)
+              }}
             >
               <Accordion.Header>Title</Accordion.Header>
               <Accordion.Panel>Content</Accordion.Panel>
@@ -96,9 +118,39 @@ describe('Accordion (next)', () => {
       }
       render(<Controlled />)
       const item = screen.getByTestId('item')
+
       expect(item).not.toHaveAttribute('open')
       await user.click(screen.getByText('Title'))
       expect(item).toHaveAttribute('open')
+      expect(onOpenChange).toHaveBeenLastCalledWith(true)
+
+      await user.click(screen.getByText('Title'))
+      expect(item).not.toHaveAttribute('open')
+      expect(onOpenChange).toHaveBeenLastCalledWith(false)
+    })
+
+    it('does not double-fire onOpenChange when the parent drives open', () => {
+      const onOpenChange = jest.fn()
+      const { rerender } = render(
+        <Accordion>
+          <Accordion.Item open={false} onOpenChange={onOpenChange}>
+            <Accordion.Header>Title</Accordion.Header>
+            <Accordion.Panel>Content</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      )
+
+      // Parent flips the controlled prop — the resulting toggle event should
+      // not call onOpenChange, because the change originated from the parent.
+      rerender(
+        <Accordion>
+          <Accordion.Item open onOpenChange={onOpenChange}>
+            <Accordion.Header>Title</Accordion.Header>
+            <Accordion.Panel>Content</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      )
+      expect(onOpenChange).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.test.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.test.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+import { Accordion } from '.'
+
+const renderBasic = (
+  itemProps: React.ComponentProps<typeof Accordion.Item> = {},
+) =>
+  render(
+    <Accordion data-testid="root">
+      <Accordion.Item data-testid="item" {...itemProps}>
+        <Accordion.Header>Title</Accordion.Header>
+        <Accordion.Panel>Content</Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>,
+  )
+
+describe('Accordion (next)', () => {
+  describe('Rendering', () => {
+    it('renders header and panel', () => {
+      renderBasic()
+      expect(screen.getByText('Title')).toBeInTheDocument()
+      expect(screen.getByText('Content')).toBeInTheDocument()
+    })
+
+    it('renders item as <details>', () => {
+      renderBasic()
+      expect(screen.getByTestId('item').tagName).toBe('DETAILS')
+    })
+
+    it('applies custom className to root', () => {
+      render(
+        <Accordion data-testid="root" className="custom">
+          <Accordion.Item>
+            <Accordion.Header>Title</Accordion.Header>
+            <Accordion.Panel>Content</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      )
+      expect(screen.getByTestId('root')).toHaveClass('eds-accordion', 'custom')
+    })
+
+    it('forwards ref on root', () => {
+      const ref = { current: null as HTMLDivElement | null }
+      render(
+        <Accordion ref={ref}>
+          <Accordion.Item>
+            <Accordion.Header>Title</Accordion.Header>
+            <Accordion.Panel>Content</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      )
+      expect(ref.current).toBeInstanceOf(HTMLDivElement)
+    })
+  })
+
+  describe('Open state', () => {
+    it('is closed by default', () => {
+      renderBasic()
+      expect(screen.getByTestId('item')).not.toHaveAttribute('open')
+    })
+
+    it('respects defaultOpen', () => {
+      renderBasic({ defaultOpen: true })
+      expect(screen.getByTestId('item')).toHaveAttribute('open')
+    })
+
+    it('toggles on header click (uncontrolled)', async () => {
+      const user = userEvent.setup()
+      renderBasic()
+      const item = screen.getByTestId('item')
+      await user.click(screen.getByText('Title'))
+      expect(item).toHaveAttribute('open')
+      await user.click(screen.getByText('Title'))
+      expect(item).not.toHaveAttribute('open')
+    })
+
+    it('supports controlled open with onOpenChange', async () => {
+      const user = userEvent.setup()
+      const Controlled = () => {
+        const [open, setOpen] = useState(false)
+        return (
+          <Accordion>
+            <Accordion.Item
+              data-testid="item"
+              open={open}
+              onOpenChange={setOpen}
+            >
+              <Accordion.Header>Title</Accordion.Header>
+              <Accordion.Panel>Content</Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
+        )
+      }
+      render(<Controlled />)
+      const item = screen.getByTestId('item')
+      expect(item).not.toHaveAttribute('open')
+      await user.click(screen.getByText('Title'))
+      expect(item).toHaveAttribute('open')
+    })
+  })
+
+  describe('Exclusive group', () => {
+    it('shares a name across items when exclusive is set', () => {
+      render(
+        <Accordion exclusive>
+          <Accordion.Item data-testid="one">
+            <Accordion.Header>One</Accordion.Header>
+            <Accordion.Panel>A</Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item data-testid="two">
+            <Accordion.Header>Two</Accordion.Header>
+            <Accordion.Panel>B</Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>,
+      )
+      const first = screen.getByTestId('one').getAttribute('name')
+      const second = screen.getByTestId('two').getAttribute('name')
+      expect(first).toBeTruthy()
+      expect(first).toBe(second)
+    })
+
+    it('omits the name attribute when not exclusive', () => {
+      renderBasic()
+      expect(screen.getByTestId('item')).not.toHaveAttribute('name')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has no violations when closed', async () => {
+      const { container } = renderBasic()
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no violations when open', async () => {
+      const { container } = renderBasic({ defaultOpen: true })
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
@@ -89,7 +89,6 @@ const AccordionHeader = forwardRef<HTMLElement, AccordionHeaderProps>(
         ref={ref}
         className={className}
         data-selectable-space="md"
-        data-font-size="md"
         {...rest}
       >
         <span
@@ -102,9 +101,6 @@ const AccordionHeader = forwardRef<HTMLElement, AccordionHeaderProps>(
         <span
           className="title"
           data-color-appearance="accent"
-          data-font-family="ui"
-          data-font-size="md"
-          data-line-height="squished"
           data-baseline="center"
         >
           {children}
@@ -122,9 +118,6 @@ const AccordionPanel = forwardRef<HTMLDivElement, AccordionPanelProps>(
         ref={ref}
         className={['panel', className].filter(Boolean).join(' ')}
         data-selectable-space="md"
-        data-font-family="ui"
-        data-font-size="md"
-        data-line-height="default"
         {...rest}
       >
         {children}

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
@@ -56,8 +56,14 @@ const AccordionItem = forwardRef<HTMLDetailsElement, AccordionItemProps>(
 
     const handleToggle = (event: SyntheticEvent<HTMLDetailsElement>) => {
       const next = event.currentTarget.open
-      if (!isControlled) setUncontrolledOpen(next)
-      onOpenChange?.(next)
+      if (isControlled) {
+        // Native `toggle` also fires when React syncs `open` from the prop — skip
+        // those so onOpenChange only reflects actual user toggles.
+        if (next !== controlledOpen) onOpenChange?.(next)
+      } else {
+        setUncontrolledOpen(next)
+        onOpenChange?.(next)
+      }
     }
 
     return (

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
@@ -1,0 +1,147 @@
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useId,
+  useState,
+  type SyntheticEvent,
+} from 'react'
+import { chevron_down } from '@equinor/eds-icons'
+import { Icon } from '../Icon'
+import type {
+  AccordionHeaderProps,
+  AccordionItemProps,
+  AccordionPanelProps,
+  AccordionProps,
+} from './Accordion.types'
+
+const GroupContext = createContext<string | undefined>(undefined)
+
+const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(
+  function Accordion({ exclusive, className, children, ...rest }, ref) {
+    const generatedName = useId()
+    const groupName = exclusive ? generatedName : undefined
+
+    return (
+      <div
+        ref={ref}
+        className={['eds-accordion', className].filter(Boolean).join(' ')}
+        {...rest}
+      >
+        <GroupContext.Provider value={groupName}>
+          {children}
+        </GroupContext.Provider>
+      </div>
+    )
+  },
+)
+AccordionRoot.displayName = 'Accordion'
+
+const AccordionItem = forwardRef<HTMLDetailsElement, AccordionItemProps>(
+  function AccordionItem(
+    {
+      defaultOpen = false,
+      open: controlledOpen,
+      onOpenChange,
+      className,
+      children,
+      ...rest
+    },
+    ref,
+  ) {
+    const groupName = useContext(GroupContext)
+    const isControlled = controlledOpen !== undefined
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen)
+    const open = isControlled ? controlledOpen : uncontrolledOpen
+
+    const handleToggle = (event: SyntheticEvent<HTMLDetailsElement>) => {
+      const next = event.currentTarget.open
+      if (!isControlled) setUncontrolledOpen(next)
+      onOpenChange?.(next)
+    }
+
+    return (
+      <details
+        ref={ref}
+        className={['eds-accordion__item', className].filter(Boolean).join(' ')}
+        name={groupName}
+        open={open}
+        onToggle={handleToggle}
+        {...rest}
+      >
+        {children}
+      </details>
+    )
+  },
+)
+AccordionItem.displayName = 'Accordion.Item'
+
+const AccordionHeader = forwardRef<HTMLElement, AccordionHeaderProps>(
+  function AccordionHeader({ className, children, ...rest }, ref) {
+    return (
+      <summary
+        ref={ref}
+        className={['eds-accordion__header', className]
+          .filter(Boolean)
+          .join(' ')}
+        data-selectable-space="md"
+        data-font-size="md"
+        {...rest}
+      >
+        <span
+          className="eds-accordion__chevron"
+          aria-hidden="true"
+          data-color-appearance="accent"
+        >
+          <Icon data={chevron_down} />
+        </span>
+        <span
+          className="eds-accordion__title"
+          data-font-family="ui"
+          data-font-size="md"
+          data-line-height="squished"
+          data-baseline="center"
+        >
+          {children}
+        </span>
+      </summary>
+    )
+  },
+)
+AccordionHeader.displayName = 'Accordion.Header'
+
+const AccordionPanel = forwardRef<HTMLDivElement, AccordionPanelProps>(
+  function AccordionPanel({ className, children, ...rest }, ref) {
+    return (
+      <div
+        className={['eds-accordion__panel', className]
+          .filter(Boolean)
+          .join(' ')}
+        ref={ref}
+        data-selectable-space="md"
+        {...rest}
+      >
+        <div
+          className="eds-accordion__panel-content"
+          data-font-family="ui"
+          data-font-size="md"
+          data-line-height="default"
+        >
+          {children}
+        </div>
+      </div>
+    )
+  },
+)
+AccordionPanel.displayName = 'Accordion.Panel'
+
+type CompoundAccordion = typeof AccordionRoot & {
+  Item: typeof AccordionItem
+  Header: typeof AccordionHeader
+  Panel: typeof AccordionPanel
+}
+
+export const Accordion = AccordionRoot as CompoundAccordion
+Accordion.Item = AccordionItem
+Accordion.Header = AccordionHeader
+Accordion.Panel = AccordionPanel

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
@@ -101,6 +101,7 @@ const AccordionHeader = forwardRef<HTMLElement, AccordionHeaderProps>(
         </span>
         <span
           className="title"
+          data-color-appearance="accent"
           data-font-family="ui"
           data-font-size="md"
           data-line-height="squished"

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.tsx
@@ -63,7 +63,7 @@ const AccordionItem = forwardRef<HTMLDetailsElement, AccordionItemProps>(
     return (
       <details
         ref={ref}
-        className={['eds-accordion__item', className].filter(Boolean).join(' ')}
+        className={className}
         name={groupName}
         open={open}
         onToggle={handleToggle}
@@ -81,22 +81,20 @@ const AccordionHeader = forwardRef<HTMLElement, AccordionHeaderProps>(
     return (
       <summary
         ref={ref}
-        className={['eds-accordion__header', className]
-          .filter(Boolean)
-          .join(' ')}
+        className={className}
         data-selectable-space="md"
         data-font-size="md"
         {...rest}
       >
         <span
-          className="eds-accordion__chevron"
+          className="chevron"
           aria-hidden="true"
           data-color-appearance="accent"
         >
           <Icon data={chevron_down} />
         </span>
         <span
-          className="eds-accordion__title"
+          className="title"
           data-font-family="ui"
           data-font-size="md"
           data-line-height="squished"
@@ -114,21 +112,15 @@ const AccordionPanel = forwardRef<HTMLDivElement, AccordionPanelProps>(
   function AccordionPanel({ className, children, ...rest }, ref) {
     return (
       <div
-        className={['eds-accordion__panel', className]
-          .filter(Boolean)
-          .join(' ')}
         ref={ref}
+        className={['panel', className].filter(Boolean).join(' ')}
         data-selectable-space="md"
+        data-font-family="ui"
+        data-font-size="md"
+        data-line-height="default"
         {...rest}
       >
-        <div
-          className="eds-accordion__panel-content"
-          data-font-family="ui"
-          data-font-size="md"
-          data-line-height="default"
-        >
-          {children}
-        </div>
+        {children}
       </div>
     )
   },

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.types.ts
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react'
+import type { DetailsHTMLAttributes, HTMLAttributes, ReactNode } from 'react'
 
 export type AccordionProps = {
   /**
@@ -13,9 +13,12 @@ export type AccordionItemProps = {
   defaultOpen?: boolean
   /** Controlled open state. When provided, the item is controlled. */
   open?: boolean
-  /** Called when the open state changes, from user interaction or controlled updates. */
+  /**
+   * Called when the open state changes from a user toggle. Not fired when the
+   * controlled `open` prop is updated from the parent.
+   */
   onOpenChange?: (open: boolean) => void
-} & Omit<HTMLAttributes<HTMLDetailsElement>, 'onToggle'>
+} & Omit<DetailsHTMLAttributes<HTMLDetailsElement>, 'onToggle' | 'open'>
 
 export type AccordionHeaderProps = {
   children: ReactNode

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.types.ts
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.types.ts
@@ -1,0 +1,24 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export type AccordionProps = {
+  /**
+   * When true, only one item can be open at a time within this group.
+   * Uses the native `name` attribute on `<details>` — no JS state machine.
+   */
+  exclusive?: boolean
+} & HTMLAttributes<HTMLDivElement>
+
+export type AccordionItemProps = {
+  /** Initial open state (uncontrolled). */
+  defaultOpen?: boolean
+  /** Controlled open state. When provided, the item is controlled. */
+  open?: boolean
+  /** Called when the open state changes, from user interaction or controlled updates. */
+  onOpenChange?: (open: boolean) => void
+} & Omit<HTMLAttributes<HTMLDetailsElement>, 'onToggle'>
+
+export type AccordionHeaderProps = {
+  children: ReactNode
+} & HTMLAttributes<HTMLElement>
+
+export type AccordionPanelProps = HTMLAttributes<HTMLDivElement>

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -68,6 +68,12 @@
       display: none;
     }
 
+    /* Open state — title picks up the accent appearance to signal expansion.
+     * Same specificity as :hover below, so hover/focus wins by source order. */
+    & > details[open] > summary {
+      --_title-color: var(--eds-color-text-accent-subtle);
+    }
+
     & > details > summary:hover,
     & > details > summary:focus-visible {
       --_summary-bg: var(--eds-color-bg-fill-muted-default);

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -4,6 +4,10 @@
     flex-direction: column;
     inline-size: 100%;
 
+    /* All inner selectors below are scoped with `>` so consumer content inside
+     * <Accordion.Panel> can't accidentally collide with our internal classes
+     * (.chevron, .title, .panel) or nested <details>/<summary> elements. */
+
     /* Item — each <details>. */
     & > details {
       border-block-start: var(--eds-sizing-stroke-thin) solid
@@ -26,7 +30,7 @@
     }
 
     /* Header (summary) */
-    & summary {
+    & > details > summary {
       cursor: pointer;
 
       display: flex;
@@ -44,12 +48,12 @@
     }
 
     /* Hide Safari's native marker */
-    & summary::-webkit-details-marker {
+    & > details > summary::-webkit-details-marker {
       display: none;
     }
 
-    & summary:hover,
-    & summary:focus-visible {
+    & > details > summary:hover,
+    & > details > summary:focus-visible {
       background-color: var(--eds-color-bg-fill-muted-default);
 
       & > .title {
@@ -57,14 +61,14 @@
       }
     }
 
-    & summary:focus-visible {
+    & > details > summary:focus-visible {
       outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
       outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
     }
 
     /* Chevron — the icon's built-in `margin-inline: -0.1em` (icon.css) shrinks
      * the column to its optical bounds, same pattern Chip uses. */
-    & .chevron {
+    & > details > summary > .chevron {
       display: inline-flex;
 
       /* Resolves against data-color-appearance="accent" on the span */
@@ -77,7 +81,7 @@
     }
 
     /* Title */
-    & .title {
+    & > details > summary > .title {
       flex: 1;
       color: var(--eds-color-text-strong);
     }
@@ -85,7 +89,7 @@
     /* Panel — Figma spec 16 28 24 46.4. Inline-start equals the title's
      * horizontal start (container pad + chevron optical column + gap) so content
      * aligns under the title text. */
-    & .panel {
+    & > details > .panel {
       padding-block: var(--eds-selectable-space-vertical)
         var(--eds-spacing-vertical-xl);
       padding-inline: calc(
@@ -100,7 +104,7 @@
   /* Reduced motion: skip height + chevron animation */
   @media (prefers-reduced-motion: reduce) {
     .eds-accordion > details::details-content,
-    .eds-accordion .chevron {
+    .eds-accordion > details > summary > .chevron {
       transition: none;
     }
   }

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -1,0 +1,109 @@
+@layer eds-components {
+  .eds-accordion {
+    display: flex;
+    flex-direction: column;
+    inline-size: 100%;
+  }
+
+  .eds-accordion__item {
+    border-block-start: var(--eds-sizing-stroke-thin) solid
+      var(--eds-color-border-subtle);
+  }
+
+  /* Native marker is replaced by the custom chevron span */
+  .eds-accordion__item::details-content {
+    /* Animate height open/close — calc-size(auto, size) lets us transition to auto.
+     * Older engines fall back to instant open/close. */
+    overflow: clip;
+    block-size: 0;
+    transition:
+      block-size 200ms ease,
+      content-visibility 200ms ease allow-discrete;
+  }
+
+  .eds-accordion__item[open]::details-content {
+    block-size: calc-size(auto, size);
+  }
+
+  /* Header (summary) */
+  .eds-accordion__header {
+    cursor: pointer;
+
+    display: flex;
+    gap: var(--eds-selectable-space-horizontal);
+    align-items: center;
+
+    padding-block: var(--eds-selectable-space-vertical);
+    padding-inline: var(--eds-selectable-space-horizontal);
+
+    list-style: none;
+
+    background-color: transparent;
+
+    transition: background-color 150ms ease;
+  }
+
+  /* Hide native marker (Safari) */
+  .eds-accordion__header::-webkit-details-marker {
+    display: none;
+  }
+
+  .eds-accordion__header:hover,
+  .eds-accordion__header:focus-visible {
+    background-color: var(--eds-color-bg-fill-muted-default);
+
+    & .eds-accordion__title {
+      color: var(--eds-color-text-accent-strong);
+    }
+  }
+
+  .eds-accordion__header:focus-visible {
+    outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
+    outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
+  }
+
+  /* Chevron — the icon's built-in `margin-inline: -0.1em` (icon.css) already shrinks
+   * the column to its optical bounds, same pattern as Chip uses for icon alignment. */
+  .eds-accordion__chevron {
+    display: inline-flex;
+
+    /* Dynamic token resolves against data-color-appearance="accent" on the span */
+    color: var(--eds-color-bg-fill-emphasis-default);
+    transition: rotate 200ms ease;
+  }
+
+  .eds-accordion__item[open] > .eds-accordion__header .eds-accordion__chevron {
+    rotate: 180deg;
+  }
+
+  /* Title */
+  .eds-accordion__title {
+    flex: 1;
+    color: var(--eds-color-text-strong);
+  }
+
+  /* Panel — content slot inside details.
+   * Figma spec: padding 16 28 24 46.4. The 46.4 is the title's horizontal start position
+   * in the header — container padding + chevron optical column + chevron-title gap.
+   * Chevron optical column = title line-height (icon.css's `-0.1em` inline margin
+   * collapses the chevron span's outer width to roughly the surrounding line-height,
+   * same pattern Chip uses for icon alignment). All three terms are EDS tokens. */
+  .eds-accordion__panel-content {
+    padding-block: var(--eds-selectable-space-vertical)
+      var(--eds-spacing-vertical-xl);
+    padding-inline: calc(
+        var(--eds-selectable-space-horizontal) * 2 +
+          var(--eds-typography-ui-body-md-line-height-squished)
+      )
+      var(--eds-spacing-horizontal-2xl);
+    color: var(--eds-color-text-subtle);
+  }
+
+  /* Reduced motion: opt out of height/rotation animations */
+  @media (prefers-reduced-motion: reduce) {
+    .eds-accordion__item::details-content,
+    .eds-accordion__chevron {
+      transition: none;
+    }
+  }
+}

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -2,6 +2,7 @@
   .eds-accordion {
     /* States override these vars; the consuming properties below stay stable. */
     --_summary-bg: transparent;
+    --_transition-duration: 200ms;
 
     /* Equals the summary's line-height so the chevron sits on the same
      * baseline grid as the title. The panel's inline-start references the
@@ -25,8 +26,8 @@
       overflow: clip;
       block-size: 0;
       transition:
-        block-size 200ms ease,
-        content-visibility 200ms ease allow-discrete;
+        block-size var(--_transition-duration) ease,
+        content-visibility var(--_transition-duration) ease allow-discrete;
     }
 
     & > details[open]::details-content {
@@ -43,11 +44,13 @@
       padding-block: var(--eds-selectable-space-vertical);
       padding-inline: var(--eds-selectable-space-horizontal);
 
+      font-size: var(--eds-typography-ui-body-md-font-size);
+
       list-style: none;
 
       background-color: var(--_summary-bg);
 
-      transition: background-color 150ms ease;
+      transition: background-color var(--_transition-duration) ease;
     }
 
     & > details > summary::-webkit-details-marker {
@@ -82,23 +85,24 @@
 
       color: var(--_chevron-color);
 
-      transition: rotate 200ms ease;
+      transition: rotate var(--_transition-duration) ease;
     }
 
     & > details[open] > summary > .chevron {
       rotate: 180deg;
     }
 
-    /* Title carries `data-color-appearance="accent"` so its `--eds-color-text-*`
-     * tokens resolve under the accent palette in *both* light and dark schemes.
-     * Static `--eds-color-text-accent-*` tokens are light-only — they were
-     * baked-in #1F6369 / #141F20 regardless of scheme. */
     & > details > summary > .title {
       --_title-color: var(--eds-color-text-strong);
 
       flex: 1;
+
+      font-family: var(--eds-typography-ui-body-font-family);
+      font-size: var(--eds-typography-ui-body-md-font-size);
+      line-height: var(--eds-typography-ui-body-md-line-height-squished);
       color: var(--_title-color);
-      transition: color 150ms ease;
+
+      transition: color var(--_transition-duration) ease;
     }
 
     & > details[open] > summary > .title {
@@ -114,15 +118,15 @@
           var(--eds-selectable-space-horizontal) * 2 + var(--_chevron-column)
         )
         var(--eds-spacing-horizontal-2xl);
+
+      font-family: var(--eds-typography-ui-body-font-family);
+      font-size: var(--eds-typography-ui-body-md-font-size);
+      line-height: var(--eds-typography-ui-body-md-line-height-default);
       color: var(--eds-color-text-subtle);
     }
-  }
 
-  @media (prefers-reduced-motion: reduce) {
-    .eds-accordion > details::details-content,
-    .eds-accordion > details > summary > .chevron,
-    .eds-accordion > details > summary > .title {
-      transition: none;
+    @media (prefers-reduced-motion: reduce) {
+      --_transition-duration: 0s;
     }
   }
 }

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -3,106 +3,104 @@
     display: flex;
     flex-direction: column;
     inline-size: 100%;
-  }
 
-  .eds-accordion__item {
-    border-block-start: var(--eds-sizing-stroke-thin) solid
-      var(--eds-color-border-subtle);
-  }
+    /* Item — each <details>. */
+    & > details {
+      border-block-start: var(--eds-sizing-stroke-thin) solid
+        var(--eds-color-border-subtle);
+    }
 
-  /* Native marker is replaced by the custom chevron span */
-  .eds-accordion__item::details-content {
-    /* Animate height open/close — calc-size(auto, size) lets us transition to auto.
-     * Older engines fall back to instant open/close. */
-    overflow: clip;
-    block-size: 0;
-    transition:
-      block-size 200ms ease,
-      content-visibility 200ms ease allow-discrete;
-  }
+    /* Animated content slot.
+     * calc-size(auto, size) lets the transition target an intrinsic size; older
+     * engines fall back to instant open/close. */
+    & > details::details-content {
+      overflow: clip;
+      block-size: 0;
+      transition:
+        block-size 200ms ease,
+        content-visibility 200ms ease allow-discrete;
+    }
 
-  .eds-accordion__item[open]::details-content {
-    block-size: calc-size(auto, size);
-  }
+    & > details[open]::details-content {
+      block-size: calc-size(auto, size);
+    }
 
-  /* Header (summary) */
-  .eds-accordion__header {
-    cursor: pointer;
+    /* Header (summary) */
+    & summary {
+      cursor: pointer;
 
-    display: flex;
-    gap: var(--eds-selectable-space-horizontal);
-    align-items: center;
+      display: flex;
+      gap: var(--eds-selectable-space-horizontal);
+      align-items: center;
 
-    padding-block: var(--eds-selectable-space-vertical);
-    padding-inline: var(--eds-selectable-space-horizontal);
+      padding-block: var(--eds-selectable-space-vertical);
+      padding-inline: var(--eds-selectable-space-horizontal);
 
-    list-style: none;
+      list-style: none;
 
-    background-color: transparent;
+      background-color: transparent;
 
-    transition: background-color 150ms ease;
-  }
+      transition: background-color 150ms ease;
+    }
 
-  /* Hide native marker (Safari) */
-  .eds-accordion__header::-webkit-details-marker {
-    display: none;
-  }
+    /* Hide Safari's native marker */
+    & summary::-webkit-details-marker {
+      display: none;
+    }
 
-  .eds-accordion__header:hover,
-  .eds-accordion__header:focus-visible {
-    background-color: var(--eds-color-bg-fill-muted-default);
+    & summary:hover,
+    & summary:focus-visible {
+      background-color: var(--eds-color-bg-fill-muted-default);
 
-    & .eds-accordion__title {
-      color: var(--eds-color-text-accent-strong);
+      & > .title {
+        color: var(--eds-color-text-accent-strong);
+      }
+    }
+
+    & summary:focus-visible {
+      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
+      outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
+    }
+
+    /* Chevron — the icon's built-in `margin-inline: -0.1em` (icon.css) shrinks
+     * the column to its optical bounds, same pattern Chip uses. */
+    & .chevron {
+      display: inline-flex;
+
+      /* Resolves against data-color-appearance="accent" on the span */
+      color: var(--eds-color-bg-fill-emphasis-default);
+      transition: rotate 200ms ease;
+    }
+
+    & > details[open] > summary > .chevron {
+      rotate: 180deg;
+    }
+
+    /* Title */
+    & .title {
+      flex: 1;
+      color: var(--eds-color-text-strong);
+    }
+
+    /* Panel — Figma spec 16 28 24 46.4. Inline-start equals the title's
+     * horizontal start (container pad + chevron optical column + gap) so content
+     * aligns under the title text. */
+    & .panel {
+      padding-block: var(--eds-selectable-space-vertical)
+        var(--eds-spacing-vertical-xl);
+      padding-inline: calc(
+          var(--eds-selectable-space-horizontal) * 2 +
+            var(--eds-typography-ui-body-md-line-height-squished)
+        )
+        var(--eds-spacing-horizontal-2xl);
+      color: var(--eds-color-text-subtle);
     }
   }
 
-  .eds-accordion__header:focus-visible {
-    outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
-    outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
-  }
-
-  /* Chevron — the icon's built-in `margin-inline: -0.1em` (icon.css) already shrinks
-   * the column to its optical bounds, same pattern as Chip uses for icon alignment. */
-  .eds-accordion__chevron {
-    display: inline-flex;
-
-    /* Dynamic token resolves against data-color-appearance="accent" on the span */
-    color: var(--eds-color-bg-fill-emphasis-default);
-    transition: rotate 200ms ease;
-  }
-
-  .eds-accordion__item[open] > .eds-accordion__header .eds-accordion__chevron {
-    rotate: 180deg;
-  }
-
-  /* Title */
-  .eds-accordion__title {
-    flex: 1;
-    color: var(--eds-color-text-strong);
-  }
-
-  /* Panel — content slot inside details.
-   * Figma spec: padding 16 28 24 46.4. The 46.4 is the title's horizontal start position
-   * in the header — container padding + chevron optical column + chevron-title gap.
-   * Chevron optical column = title line-height (icon.css's `-0.1em` inline margin
-   * collapses the chevron span's outer width to roughly the surrounding line-height,
-   * same pattern Chip uses for icon alignment). All three terms are EDS tokens. */
-  .eds-accordion__panel-content {
-    padding-block: var(--eds-selectable-space-vertical)
-      var(--eds-spacing-vertical-xl);
-    padding-inline: calc(
-        var(--eds-selectable-space-horizontal) * 2 +
-          var(--eds-typography-ui-body-md-line-height-squished)
-      )
-      var(--eds-spacing-horizontal-2xl);
-    color: var(--eds-color-text-subtle);
-  }
-
-  /* Reduced motion: opt out of height/rotation animations */
+  /* Reduced motion: skip height + chevron animation */
   @media (prefers-reduced-motion: reduce) {
-    .eds-accordion__item::details-content,
-    .eds-accordion__chevron {
+    .eds-accordion > details::details-content,
+    .eds-accordion .chevron {
       transition: none;
     }
   }

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -3,7 +3,12 @@
     /* Pseudo-private component vars. States/variants override these vars rather
      * than the consuming properties below. */
     --_summary-bg: transparent;
-    --_title-color: var(--eds-color-text-strong);
+
+    /* Title sits in accent appearance in every state. At rest (closed or open)
+     * it uses the subtle accent shade so chevron and title share the same
+     * family; hover/focus pull the title to the strong accent shade for
+     * interaction feedback. */
+    --_title-color: var(--eds-color-text-accent-subtle);
 
     /* TODO: the chevron is an icon foreground, but EDS tokens currently only
      * expose `accent-9` (#206F77) via bg-fill tokens. Replace with an
@@ -68,21 +73,20 @@
       display: none;
     }
 
-    /* Open state — title picks up the accent appearance to signal expansion.
-     * Same specificity as :hover below, so hover/focus wins by source order. */
-    & > details[open] > summary {
-      --_title-color: var(--eds-color-text-accent-subtle);
-    }
-
     & > details > summary:hover,
     & > details > summary:focus-visible {
       --_summary-bg: var(--eds-color-bg-fill-muted-default);
       --_title-color: var(--eds-color-text-accent-strong);
     }
 
+    /* Focus indicator on stacked items (accordion / menu): a single bottom
+     * edge line rather than a full outline, so adjacent items don't stack
+     * visually competing rings. Box-shadow keeps the summary's layout
+     * unchanged. */
     & > details > summary:focus-visible {
-      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
-      outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
+      outline: none;
+      box-shadow: inset 0 calc(-1 * var(--eds-sizing-stroke-thin)) 0
+        var(--eds-color-border-focus);
     }
 
     /* Chevron — explicit inline-size keeps the column predictable; the icon's

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -1,37 +1,26 @@
 @layer eds-components {
   .eds-accordion {
-    /* Pseudo-private component vars. States/variants override these vars rather
-     * than the consuming properties below. */
+    /* States override these vars; the consuming properties below stay stable. */
     --_summary-bg: transparent;
 
-    /* Title sits in accent appearance in every state. At rest (closed or open)
-     * it uses the subtle accent shade so chevron and title share the same
-     * family; hover/focus pull the title to the strong accent shade for
-     * interaction feedback. */
-    --_title-color: var(--eds-color-text-accent-subtle);
-
-    /* Visual width of the chevron column. Equals the summary's line-height so
-     * the chevron sits on the same baseline grid as the title. The panel
-     * references the same var so its inline-start aligns under the title. */
+    /* Equals the summary's line-height so the chevron sits on the same
+     * baseline grid as the title. The panel's inline-start references the
+     * same var so content aligns under the title. */
     --_chevron-column: var(--eds-typography-ui-body-md-line-height-squished);
 
     display: flex;
     flex-direction: column;
     inline-size: 100%;
 
-    /* All inner selectors below are scoped with `>` so consumer content inside
-     * <Accordion.Panel> can't collide with our internal classes (.chevron,
-     * .title, .panel) or nested <details>/<summary> elements. */
-
-    /* Item — each <details>. */
+    /* Inner selectors scoped with `>` so consumer content inside .panel can't
+     * collide with our internal class names. */
     & > details {
       border-block-start: var(--eds-sizing-stroke-thin) solid
         var(--eds-color-border-subtle);
     }
 
-    /* Animated content slot.
-     * calc-size(auto, size) lets the transition target an intrinsic size; older
-     * engines fall back to instant open/close. */
+    /* calc-size(auto, size) lets the height transition target intrinsic size;
+     * older engines fall back to instant open/close. */
     & > details::details-content {
       overflow: clip;
       block-size: 0;
@@ -44,7 +33,6 @@
       block-size: calc-size(auto, size);
     }
 
-    /* Header (summary) */
     & > details > summary {
       cursor: pointer;
 
@@ -62,7 +50,6 @@
       transition: background-color 150ms ease;
     }
 
-    /* Hide Safari's native marker */
     & > details > summary::-webkit-details-marker {
       display: none;
     }
@@ -70,33 +57,20 @@
     & > details > summary:hover,
     & > details > summary:focus-visible {
       --_summary-bg: var(--eds-color-bg-fill-muted-default);
-      --_title-color: var(--eds-color-text-accent-strong);
     }
 
-    /* Focus indicator on stacked items (accordion / menu): a single bottom
-     * edge line rather than a full outline, so adjacent items don't stack
-     * visually competing rings. Box-shadow keeps the summary's layout
-     * unchanged. */
     & > details > summary:focus-visible {
-      outline: none;
-      box-shadow: inset 0 calc(-1 * var(--eds-sizing-stroke-thin)) 0
-        var(--eds-color-border-focus);
+      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
+      outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
     }
 
-    /* Chevron — explicit inline-size keeps the column predictable; the icon's
-     * built-in `margin-inline: -0.1em` (icon.css) makes the glyph sit optically
-     * tight inside, same pattern Chip uses.
+    /* --_chevron-color is defined here (not on .eds-accordion) so the
+     * bg-fill-emphasis token resolves under the chevron span's own
+     * `data-color-appearance="accent"` — substitution happens at the
+     * property's defining cascade context, not the use site.
      *
-     * NOTE: --_chevron-color is defined here (not on .eds-accordion) so the
-     * `var(--eds-color-bg-fill-emphasis-default)` resolves under this element's
-     * `data-color-appearance="accent"` context. Defining it at the root would
-     * lock in the neutral-context value (an EDS token gotcha — substitution
-     * happens at the property's defining cascade context).
-     *
-     * TODO: the chevron is an icon foreground, but EDS tokens currently only
-     * expose `accent-9` (#206F77) via bg-fill tokens. Replace with an
-     * `--eds-color-icon-accent-*` or `--eds-color-text-accent-*` semantic token
-     * once those exist. Tracked in a follow-up issue. */
+     * TODO: drop in --eds-color-icon-accent-* once EDS tokens expose a
+     * foreground equivalent for accent-9. */
     & > details > summary > .chevron {
       --_chevron-color: var(--eds-color-bg-fill-emphasis-default);
 
@@ -115,16 +89,24 @@
       rotate: 180deg;
     }
 
-    /* Title */
+    /* Title carries `data-color-appearance="accent"` so its `--eds-color-text-*`
+     * tokens resolve under the accent palette in *both* light and dark schemes.
+     * Static `--eds-color-text-accent-*` tokens are light-only — they were
+     * baked-in #1F6369 / #141F20 regardless of scheme. */
     & > details > summary > .title {
+      --_title-color: var(--eds-color-text-strong);
+
       flex: 1;
       color: var(--_title-color);
       transition: color 150ms ease;
     }
 
-    /* Panel — inline-start equals the title's horizontal start in the header
-     * (container pad + chevron column + gap), so content aligns under the
-     * title. Block padding is taken from EDS spacing tokens. */
+    & > details[open] > summary > .title {
+      --_title-color: var(--eds-color-text-subtle);
+    }
+
+    /* inline-start matches the title's horizontal start in the header
+     * (container pad + chevron column + gap), aligning content under the title. */
     & > details > .panel {
       padding-block: var(--eds-selectable-space-vertical)
         var(--eds-spacing-vertical-xl);
@@ -136,7 +118,6 @@
     }
   }
 
-  /* Reduced motion: skip height + chevron + title animations */
   @media (prefers-reduced-motion: reduce) {
     .eds-accordion > details::details-content,
     .eds-accordion > details > summary > .chevron,

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -1,12 +1,28 @@
 @layer eds-components {
   .eds-accordion {
+    /* Pseudo-private component vars. States/variants override these vars rather
+     * than the consuming properties below. */
+    --_summary-bg: transparent;
+    --_title-color: var(--eds-color-text-strong);
+
+    /* TODO: the chevron is an icon foreground, but EDS tokens currently only
+     * expose `accent-9` (#206F77) via bg-fill tokens. Replace with an
+     * `--eds-color-icon-accent-*` or `--eds-color-text-accent-*` semantic token
+     * once those exist. Tracked in a follow-up issue. */
+    --_chevron-color: var(--eds-color-bg-fill-emphasis-default);
+
+    /* Visual width of the chevron column. Equals the summary's line-height so
+     * the chevron sits on the same baseline grid as the title. The panel
+     * references the same var so its inline-start aligns under the title. */
+    --_chevron-column: var(--eds-typography-ui-body-md-line-height-squished);
+
     display: flex;
     flex-direction: column;
     inline-size: 100%;
 
     /* All inner selectors below are scoped with `>` so consumer content inside
-     * <Accordion.Panel> can't accidentally collide with our internal classes
-     * (.chevron, .title, .panel) or nested <details>/<summary> elements. */
+     * <Accordion.Panel> can't collide with our internal classes (.chevron,
+     * .title, .panel) or nested <details>/<summary> elements. */
 
     /* Item — each <details>. */
     & > details {
@@ -42,7 +58,7 @@
 
       list-style: none;
 
-      background-color: transparent;
+      background-color: var(--_summary-bg);
 
       transition: background-color 150ms ease;
     }
@@ -54,11 +70,8 @@
 
     & > details > summary:hover,
     & > details > summary:focus-visible {
-      background-color: var(--eds-color-bg-fill-muted-default);
-
-      & > .title {
-        color: var(--eds-color-text-accent-strong);
-      }
+      --_summary-bg: var(--eds-color-bg-fill-muted-default);
+      --_title-color: var(--eds-color-text-accent-strong);
     }
 
     & > details > summary:focus-visible {
@@ -66,13 +79,18 @@
       outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
     }
 
-    /* Chevron — the icon's built-in `margin-inline: -0.1em` (icon.css) shrinks
-     * the column to its optical bounds, same pattern Chip uses. */
+    /* Chevron — explicit inline-size keeps the column predictable; the icon's
+     * built-in `margin-inline: -0.1em` (icon.css) makes the glyph sit optically
+     * tight inside, same pattern Chip uses. */
     & > details > summary > .chevron {
       display: inline-flex;
+      align-items: center;
+      justify-content: center;
 
-      /* Resolves against data-color-appearance="accent" on the span */
-      color: var(--eds-color-bg-fill-emphasis-default);
+      inline-size: var(--_chevron-column);
+
+      color: var(--_chevron-color);
+
       transition: rotate 200ms ease;
     }
 
@@ -83,28 +101,29 @@
     /* Title */
     & > details > summary > .title {
       flex: 1;
-      color: var(--eds-color-text-strong);
+      color: var(--_title-color);
+      transition: color 150ms ease;
     }
 
-    /* Panel — Figma spec 16 28 24 46.4. Inline-start equals the title's
-     * horizontal start (container pad + chevron optical column + gap) so content
-     * aligns under the title text. */
+    /* Panel — inline-start equals the title's horizontal start in the header
+     * (container pad + chevron column + gap), so content aligns under the
+     * title. Block padding is taken from EDS spacing tokens. */
     & > details > .panel {
       padding-block: var(--eds-selectable-space-vertical)
         var(--eds-spacing-vertical-xl);
       padding-inline: calc(
-          var(--eds-selectable-space-horizontal) * 2 +
-            var(--eds-typography-ui-body-md-line-height-squished)
+          var(--eds-selectable-space-horizontal) * 2 + var(--_chevron-column)
         )
         var(--eds-spacing-horizontal-2xl);
       color: var(--eds-color-text-subtle);
     }
   }
 
-  /* Reduced motion: skip height + chevron animation */
+  /* Reduced motion: skip height + chevron + title animations */
   @media (prefers-reduced-motion: reduce) {
     .eds-accordion > details::details-content,
-    .eds-accordion > details > summary > .chevron {
+    .eds-accordion > details > summary > .chevron,
+    .eds-accordion > details > summary > .title {
       transition: none;
     }
   }

--- a/packages/eds-core-react/src/components/next/Accordion/accordion.css
+++ b/packages/eds-core-react/src/components/next/Accordion/accordion.css
@@ -10,12 +10,6 @@
      * interaction feedback. */
     --_title-color: var(--eds-color-text-accent-subtle);
 
-    /* TODO: the chevron is an icon foreground, but EDS tokens currently only
-     * expose `accent-9` (#206F77) via bg-fill tokens. Replace with an
-     * `--eds-color-icon-accent-*` or `--eds-color-text-accent-*` semantic token
-     * once those exist. Tracked in a follow-up issue. */
-    --_chevron-color: var(--eds-color-bg-fill-emphasis-default);
-
     /* Visual width of the chevron column. Equals the summary's line-height so
      * the chevron sits on the same baseline grid as the title. The panel
      * references the same var so its inline-start aligns under the title. */
@@ -91,8 +85,21 @@
 
     /* Chevron — explicit inline-size keeps the column predictable; the icon's
      * built-in `margin-inline: -0.1em` (icon.css) makes the glyph sit optically
-     * tight inside, same pattern Chip uses. */
+     * tight inside, same pattern Chip uses.
+     *
+     * NOTE: --_chevron-color is defined here (not on .eds-accordion) so the
+     * `var(--eds-color-bg-fill-emphasis-default)` resolves under this element's
+     * `data-color-appearance="accent"` context. Defining it at the root would
+     * lock in the neutral-context value (an EDS token gotcha — substitution
+     * happens at the property's defining cascade context).
+     *
+     * TODO: the chevron is an icon foreground, but EDS tokens currently only
+     * expose `accent-9` (#206F77) via bg-fill tokens. Replace with an
+     * `--eds-color-icon-accent-*` or `--eds-color-text-accent-*` semantic token
+     * once those exist. Tracked in a follow-up issue. */
     & > details > summary > .chevron {
+      --_chevron-color: var(--eds-color-bg-fill-emphasis-default);
+
       display: inline-flex;
       align-items: center;
       justify-content: center;

--- a/packages/eds-core-react/src/components/next/Accordion/index.ts
+++ b/packages/eds-core-react/src/components/next/Accordion/index.ts
@@ -1,0 +1,7 @@
+export { Accordion } from './Accordion'
+export type {
+  AccordionProps,
+  AccordionItemProps,
+  AccordionHeaderProps,
+  AccordionPanelProps,
+} from './Accordion.types'

--- a/packages/eds-core-react/src/components/next/index.css
+++ b/packages/eds-core-react/src/components/next/index.css
@@ -34,4 +34,5 @@
 @import './Banner/banner.css';
 @import './Chip/chip.css';
 @import './Divider/divider.css';
+@import './Accordion/accordion.css';
 

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -60,3 +60,11 @@ export type { ChipProps, ChipTone, ChipVariant } from './Chip'
 
 export { Divider } from './Divider'
 export type { DividerProps } from './Divider'
+
+export { Accordion } from './Accordion'
+export type {
+  AccordionProps,
+  AccordionItemProps,
+  AccordionHeaderProps,
+  AccordionPanelProps,
+} from './Accordion'


### PR DESCRIPTION
## Summary

Adds the `Accordion` component to `@equinor/eds-core-react/next`, built on native `<details>`/`<summary>` for free accessibility, keyboard support, and CSS-only height animation.

## API

Compound component:

```tsx
<Accordion exclusive>
  <Accordion.Item defaultOpen>
    <Accordion.Header>Title</Accordion.Header>
    <Accordion.Panel>Content</Accordion.Panel>
  </Accordion.Item>
</Accordion>
```

- `exclusive` on the root: only one item open at a time via the native HTML `name` attribute on `<details>` — no JS state machine.
- `Accordion.Item` supports controlled (`open` + `onOpenChange`) and uncontrolled (`defaultOpen`) modes.
- `Accordion.Header` renders as `<summary>`; `Accordion.Panel` is the collapsible content.

## Notes

- All spacing and color values derived from EDS tokens — no magic numbers in CSS.
- Open/close animation uses `details::details-content` + `calc-size(auto, size)` (progressive enhancement; older engines fall back to instant toggle).
- Includes `prefers-reduced-motion` opt-out.

## Test plan

- [ ] Visual check in Storybook against Figma frame (Open/Closed × Default/Hover/Focus)
- [ ] Keyboard: Tab + Enter/Space toggles, focus ring visible
- [ ] Exclusive group: opening one closes the previously open item
- [ ] Controlled mode: parent `open` state stays in sync with user clicks
- [ ] Screen reader announces expand/collapse (native `<details>` behaviour)