### PR TITLE
fix(deps): revert brace-expansion@^1 override — breaks minimatch@3.x API

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
       "undici": ">=7.24.0",
       "yaml@^2": ">=2.8.3",
       "picomatch@^2": ">=2.3.2",
-      "brace-expansion@^1": ">=2.0.3",
       "brace-expansion@^2": ">=2.0.3",
       "@isaacs/brace-expansion": ">=5.0.1",
       "json5@^1": ">=1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,6 @@ overrides:
   undici: '>=7.24.0'
   yaml@^2: '>=2.8.3'
   picomatch@^2: '>=2.3.2'
-  brace-expansion@^1: '>=2.0.3'
   brace-expansion@^2: '>=2.0.3'
   '@isaacs/brace-expansion': '>=5.0.1'
   json5@^1: '>=1.0.3'
@@ -4981,6 +4980,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -5032,6 +5034,9 @@ packages:
   boxen@7.1.1:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -5360,6 +5365,9 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-with-sourcemaps@1.1.0:
     resolution: {integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==}
@@ -13144,7 +13152,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.2.5)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.15
       react: 19.2.5
 
   '@docusaurus/theme-classic@3.10.1(@types/react@19.2.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
@@ -16544,6 +16552,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -16620,6 +16630,11 @@ snapshots:
       type-fest: 2.19.0
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.5:
     dependencies:
@@ -16942,6 +16957,8 @@ snapshots:
       - supports-color
 
   compute-scroll-into-view@3.1.1: {}
+
+  concat-map@0.0.1: {}
 
   concat-with-sourcemaps@1.1.0:
     dependencies:
@@ -20538,7 +20555,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 1.1.14
 
   minimatch@9.0.9:
     dependencies:


### PR DESCRIPTION
## Summary

Reverts the `brace-expansion@^1` override added in #4923.

`brace-expansion@2.x` changed its export API — it exports an object, while `1.x` exports the function directly. `minimatch@3.x` expects the `1.x` API and throws `TypeError: expand is not a function` at runtime, breaking ESLint for everyone.

The `json5@^1 >= 1.0.3` override from #4923 is kept — that's a safe patch bump within 1.x with no API changes.

## Root cause

There is no patched version of `brace-expansion` within the 1.x series — the security fix was only released for 2.x and above. The only proper fix is to replace the packages that depend on `minimatch@3.x` (`copyfiles` in `eds-tokens` and `eslint-plugin-import`). That's tracked as a separate task.

Fixes CI failure on #4924.