### PR TITLE
ci: upgrade npm before publish to enable trusted publishing

### DIFF
--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -103,7 +103,7 @@ jobs:
       # Skip on beta runs — eds-utils has no beta channel
       - name: Upgrade npm for trusted publishing
         if: needs.setup.outputs.tag != 'beta'
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish to npm
         id: publish-to-npm
         if: needs.setup.outputs.tag != 'beta'
@@ -172,7 +172,7 @@ jobs:
           echo "Updated exports:"
           cat package.json | grep -A 15 '"exports"'
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-core-react

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -101,6 +101,9 @@ jobs:
         with:
           run_install: false
       # Skip on beta runs — eds-utils has no beta channel
+      - name: Upgrade npm for trusted publishing
+        if: needs.setup.outputs.tag != 'beta'
+        run: npm install -g npm@latest
       - name: Publish to npm
         id: publish-to-npm
         if: needs.setup.outputs.tag != 'beta'
@@ -168,6 +171,8 @@ jobs:
           "
           echo "Updated exports:"
           cat package.json | grep -A 15 '"exports"'
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-core-react

--- a/.github/workflows/publish_data_grid.yaml
+++ b/.github/workflows/publish_data_grid.yaml
@@ -101,7 +101,7 @@ jobs:
         with:
           run_install: false
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-data-grid-react

--- a/.github/workflows/publish_data_grid.yaml
+++ b/.github/workflows/publish_data_grid.yaml
@@ -100,6 +100,8 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           run_install: false
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-data-grid-react

--- a/.github/workflows/publish_icons.yaml
+++ b/.github/workflows/publish_icons.yaml
@@ -89,6 +89,8 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           run_install: false
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-icons

--- a/.github/workflows/publish_icons.yaml
+++ b/.github/workflows/publish_icons.yaml
@@ -90,7 +90,7 @@ jobs:
         with:
           run_install: false
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-icons

--- a/.github/workflows/publish_lab.yaml
+++ b/.github/workflows/publish_lab.yaml
@@ -101,7 +101,7 @@ jobs:
         with:
           run_install: false
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-utils
@@ -139,7 +139,7 @@ jobs:
         with:
           run_install: false
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-lab-react

--- a/.github/workflows/publish_lab.yaml
+++ b/.github/workflows/publish_lab.yaml
@@ -100,6 +100,8 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           run_install: false
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-utils
@@ -136,6 +138,8 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           run_install: false
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-lab-react

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -90,7 +90,7 @@ jobs:
         with:
           run_install: false
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-tokens

--- a/.github/workflows/publish_tokens.yaml
+++ b/.github/workflows/publish_tokens.yaml
@@ -89,6 +89,8 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           run_install: false
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Publish to npm
         id: publish-to-npm
         working-directory: packages/eds-tokens


### PR DESCRIPTION
## Summary

Today's manual `workflow_dispatch` releases for `eds-icons`, `eds-utils` and `eds-core-react` all failed with `E404 Not Found - PUT https://registry.npmjs.org/...` even though the Trusted Publisher is configured on npmjs.com for each package.

**Root cause:** Node 22.14.0 ships with npm 10.9.2. Trusted publishing (OIDC-based registry auth) requires **npm ≥ 11.5.1**. The failed runs show provenance signing succeeded (sigstore + OIDC), but the npm CLI then fell back to classic `_authToken` auth against the registry — and the placeholder `XXXXX-XXXXX-XXXXX-XXXXX` token set by `actions/setup-node` is naturally rejected (404).

PR #4841 (the OIDC migration) noted *"bump Node to 22.14.0 (required by npm CLI 11.5.1+ for trusted publishing)"*, but that Node version doesn't actually include npm 11.5.1+.

**Fix:** install `npm@latest` immediately before each `npm publish` step in all five migrated publish workflows, so the CLI is new enough to use the OIDC token for registry auth.

## Affected workflows

- `publish_icons.yaml` (1 publish step)
- `publish_tokens.yaml` (1)
- `publish_data_grid.yaml` (1)
- `publish_core_react.yaml` (2 — eds-utils + eds-core-react)
- `publish_lab.yaml` (2 — eds-utils + eds-lab-react)

## Test plan

- [ ] Merge, then re-run `Publish icons` via `workflow_dispatch` with `tag=next` and confirm publish succeeds
- [ ] Re-run `Publish core-react` (`tag=next` or `beta`) and confirm both utils and core-react publish
- [ ] Verify provenance is still attached on the published versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)