### PR TITLE
chore: auto-include AGENTS.md content in Claude Code sessions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,6 +5,8 @@
 >
 > This file holds only Claude-Code-specific configuration that doesn't belong in `AGENTS.md`.
 
+@../AGENTS.md
+
 ## Path-Scoped Rules
 
 Claude Code automatically loads rules in `.claude/rules/` when working on matching files:

--- a/.claude/commands/accessibility-audit.md
+++ b/.claude/commands/accessibility-audit.md
@@ -4,6 +4,8 @@ Conduct an accessibility audit of the URL provided in **$ARGUMENTS** against WCA
 
 > **Canonical reference:** [`documentation/agent-instructions/ACCESSIBILITY_AUDIT.md`](../../documentation/agent-instructions/ACCESSIBILITY_AUDIT.md) — the 13-section audit checklist, output format, severity rubric, and tips for the agent. Project-wide accessibility expectations live in [`AGENTS.md`](../../AGENTS.md) § Accessibility.
 
+@../../documentation/agent-instructions/ACCESSIBILITY_AUDIT.md
+
 ## Steps
 
 1. Open the URL with a browser-automation MCP server (Playwright or Chrome DevTools). MCP servers are configured in personal Claude Code settings.

--- a/.claude/commands/audit-harnesses.md
+++ b/.claude/commands/audit-harnesses.md
@@ -4,6 +4,8 @@ Run a read-only consistency audit across the AI agent configurations in this rep
 
 > **Canonical reference:** [`documentation/agent-instructions/HARNESS_AUDIT.md`](../../documentation/agent-instructions/HARNESS_AUDIT.md) — explicit scope (Claude Code, Copilot, OpenCode), the canonical-docs pattern, the eight audit steps, finding classification, severity rubric, and report format.
 
+@../../documentation/agent-instructions/HARNESS_AUDIT.md
+
 ## Workflow
 
 1. Read the canonical playbook above. The scope, the surfaces in play, and the report shape all live there.

--- a/.claude/commands/create-component-doc.md
+++ b/.claude/commands/create-component-doc.md
@@ -4,6 +4,8 @@ Restructure the raw content in **$ARGUMENTS** into a properly formatted componen
 
 > **Canonical reference:** [`documentation/agent-instructions/COMPONENT_DOC_STYLE.md`](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md) — tone of voice, formatting conventions (British English, no em-dashes, admonitions), section order, output template, Storybook iframes workflow, sidebar registration, and the verification checklist. Project-wide conventions live in [`AGENTS.md`](../../AGENTS.md).
 
+@../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md
+
 ## Input
 
 $ARGUMENTS

--- a/.claude/commands/new-component.md
+++ b/.claude/commands/new-component.md
@@ -4,6 +4,8 @@ Create a new EDS 2.0 component named **$ARGUMENTS** in `packages/eds-core-react/
 
 > **Canonical reference:** [`documentation/agent-instructions/BUILDING_EDS_2_COMPONENTS.md`](../../documentation/agent-instructions/BUILDING_EDS_2_COMPONENTS.md) — foundation data-attributes, critical patterns, file templates, common mistakes, advanced patterns, and the anti-patterns checklist. Project-wide conventions live in [`AGENTS.md`](../../AGENTS.md).
 
+@../../documentation/agent-instructions/BUILDING_EDS_2_COMPONENTS.md
+
 This command focuses on the per-component scaffolding flow. The patterns and code templates referenced below all live in the canonical doc above — read them there rather than inferring from memory.
 
 ## Workflow


### PR DESCRIPTION
## Summary

Adds an `@../AGENTS.md` directive to `.claude/CLAUDE.md` so Claude Code pulls the canonical conventions into context automatically on every session.

The existing markdown link (`[\`AGENTS.md\`](../AGENTS.md)`) is informational only — Claude Code does not follow it. As a result, conventions documented exclusively in `AGENTS.md` (e.g. AGENTS.md:430 "never attribute AI in commit messages") were not enforced when sessions defaulted to the built-in commit template. The `@` syntax pulls the referenced file into context directly.

## Test plan

- [ ] Open a new Claude Code session in this repo and confirm AGENTS.md content appears in the loaded context (e.g. ask the agent about a convention defined only in AGENTS.md)
- [ ] Verify no behavioural regression in existing path-scoped rules under `.claude/rules/`