### PR TITLE
chore: assert ESM dist of eds-tokens-sync has no require leaks

### DIFF
--- a/packages/eds-tokens-sync/package.json
+++ b/packages/eds-tokens-sync/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node ./scripts/assert-no-require.mjs",
     "preview": "vite preview",
     "prettier": "prettier . --write",
     "lint": "eslint"

--- a/packages/eds-tokens-sync/scripts/assert-no-require.mjs
+++ b/packages/eds-tokens-sync/scripts/assert-no-require.mjs
@@ -1,0 +1,29 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const distDir = './dist'
+
+const jsFiles = readdirSync(distDir, { recursive: true }).filter(
+  (f) => typeof f === 'string' && f.endsWith('.js'),
+)
+
+// `require` should never appear as a bare identifier in a pure ESM build.
+// When rolldown bundles a CJS dep it cannot statically convert, it emits a
+// `typeof require < "u" ? require : ...` shim that throws "Calling \`require\` for ..."
+// at runtime. The package is "type": "module", so the throw fires on first use.
+// Catching the bare identifier covers both that shim and any literal `require(...)` call.
+const requireIdentifier = /\brequire\b/
+
+const offenders = jsFiles.filter((f) =>
+  requireIdentifier.test(readFileSync(join(distDir, f), 'utf8')),
+)
+
+if (offenders.length > 0) {
+  throw new Error(
+    `ESM dist contains a \`require\` identifier in: ${offenders.join(', ')}. ` +
+      `A CJS dependency was bundled into the ESM output and will crash at runtime ` +
+      `("Calling \`require\` for ..." from rolldown's CJS shim). ` +
+      `Fix by adding the offending package to rolldownOptions.external in vite.config.ts ` +
+      `(see PR #4883 for the dotenv precedent).`,
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `packages/eds-tokens-sync/scripts/assert-no-require.mjs` — fails the build if any file under `dist/` contains a bare `require` identifier (the rolldown CJS-shim signature behind #4883's runtime crash).
- Wires it into `build` as a post-step, mirroring the existing `assert-no-light-dark.mjs` pattern in `eds-tokens`.

Closes #4887.

## Why a word-boundary `\brequire\b` instead of literal `require(`

The issue's plan suggested checking for the literal token `require(`. Reproducing #4883 locally (by removing `dotenv` from `rolldownOptions.external`) showed that rolldown's CJS shim emits `typeof require < "u"`, `require.apply(this, arguments)`, and a shimmed `r("fs")` call — none of which contain the literal `require(`. The bare `require` identifier is what should never appear in a pure ESM build, and it catches both the shim and any direct `require(...)` call.

## Verification

- Clean build passes: `pnpm --filter @equinor/eds-tokens-sync build` ✓
- Negative test — removed `dotenv` from `vite.config.ts` externals locally, rebuilt: assert fired with the expected error pointing at `rolldownOptions.external` and #4883. Restored config; build clean again. ✓

## Test plan

- [x] CI passes
- [x] Confirm Figma sync still works end-to-end after the wired-in assertion (`pnpm run update-tokens:foundations` from `eds-tokens`)

## Follow-up (optional, separate issue)

Lift the script to `eds-tokens-build` as a shared utility and wire into `eds-tokens-build` / `eds-tokens` (generate-variables) builds too.