### PR TITLE
chore: harden vite externals to prevent CJS-in-ESM bundling

### DIFF
--- a/apps/eds-color-palette-generator/vite.config.ts
+++ b/apps/eds-color-palette-generator/vite.config.ts
@@ -12,10 +12,12 @@ export default defineConfig({
     },
     rolldownOptions: {
       external: [
-        'node:fs',
-        'node:fs/promises',
-        'node:path',
-        'node:process',
+        /^node:/,
+        'fs',
+        'path',
+        'os',
+        'crypto',
+        'process',
         'colorjs.io',
         'colorjs.io/fn',
       ],

--- a/packages/eds-tokens-build/vite.config.ts
+++ b/packages/eds-tokens-build/vite.config.ts
@@ -48,11 +48,12 @@ export default defineConfig({
     },
     rolldownOptions: {
       external: [
-        'node:fs',
-        'node:fs/promises',
-        'node:path',
-        'node:process',
+        /^node:/,
+        'fs',
         'path',
+        'os',
+        'crypto',
+        'process',
         'style-dictionary',
         'style-dictionary/types',
         'style-dictionary/utils',

--- a/packages/eds-tokens-sync/vite.config.ts
+++ b/packages/eds-tokens-sync/vite.config.ts
@@ -19,7 +19,16 @@ export default defineConfig({
       formats: ['es'],
     },
     rolldownOptions: {
-      external: [/^node:/, 'fs', 'path', 'os', 'dotenv', 'dotenv/config'],
+      external: [
+        /^node:/,
+        'fs',
+        'path',
+        'os',
+        'crypto',
+        'process',
+        'dotenv',
+        'dotenv/config',
+      ],
     },
   },
   plugins: [dts({ bundleTypes: true })],

--- a/packages/eds-tokens/vite.generate-variables.config.ts
+++ b/packages/eds-tokens/vite.generate-variables.config.ts
@@ -12,10 +12,12 @@ export default defineConfig({
         dir: 'build-generate-variables',
       },
       external: [
+        /^node:/,
         'fs',
         'path',
         'os',
         'crypto',
+        'process',
         'style-dictionary',
         'style-dictionary-utils',
         '@equinor/eds-tokens-sync',


### PR DESCRIPTION
## Summary

Extend the `external` hardening from #4883 (eds-tokens-sync) to the remaining vite configs, so a transitive dep importing `node:*` built-ins (or bare-name built-ins) can't be silently bundled into ESM output the way `dotenv` was.

Canonical shape — same in all four configs now:

```ts
external: [
  /^node:/,
  'fs', 'path', 'os', 'crypto', 'process',
  // ...config-specific package externals
]
```

## Changes

- `packages/eds-tokens-build/vite.config.ts` — replaced explicit `node:fs|node:fs/promises|node:path|node:process` with `/^node:/`; added bare-name `fs`, `os`, `crypto`, `process` (kept `path`)
- `packages/eds-tokens/vite.generate-variables.config.ts` — added `/^node:/` and `process` (already had bare-name built-ins)
- `apps/eds-color-palette-generator/vite.config.ts` — replaced explicit `node:*` set with `/^node:/`; added bare-name `fs`, `path`, `os`, `crypto`, `process`

## Verification

- `pnpm --filter @equinor/eds-tokens-build build` — succeeds, `dist/` **byte-identical** to pre-change baseline
- `pnpm --filter @equinor/eds-color-palette-generator build:cli` — succeeds, `dist/` **byte-identical**
- `pnpm --filter @equinor/eds-tokens run build:variables:typography-and-spacing` — succeeds; vite output **byte-identical**, downstream `node generate-variables.js` consumer runs clean

Confirmed via `diff -rq` against snapshots taken on `main` before edits — zero behavioural drift.

Closes #4886