### PR TITLE
docs: reframe component doc audience as usage guide

### DIFF
--- a/.claude/commands/create-component-doc.md
+++ b/.claude/commands/create-component-doc.md
@@ -10,9 +10,13 @@ Restructure the raw content in **$ARGUMENTS** into a properly formatted componen
 
 $ARGUMENTS
 
+## Audience reminder
+
+These docs are the **usage guide** for the EDS component library. The audience is **anyone deciding whether and how to use a component** - designers, developers picking between components, product folks scoping a feature, accessibility reviewers, contributors new to EDS. They are not a designer-only reference, and they are not a Figma manual. Storybook owns implementation (props, code, callbacks, integration). Read the [Audience](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#audience) section of `COMPONENT_DOC_STYLE.md` before drafting anything.
+
 ## Workflow
 
-1. **Take the raw content above** (from Figma, design specs, meetings, scraped text, etc.) and identify the component name and category.
+1. **Identify the component name and category from the raw input.** The input may include Figma specs, meeting notes, scraped text, or pointers to source code. Treat source code (`*.tsx`, `*.types.ts`, `*.stories.tsx`) as a **fact-check source** for variant names, state names, and accessibility behaviour - not as content to paraphrase. The prose in the doc comes from Figma and design intent.
 
 2. **Decide the target path.** Component docs live at `apps/design-system-docs/docs/components/{category}/{component}.md` — e.g. `apps/design-system-docs/docs/components/inputs/button.md`.
 
@@ -22,6 +26,15 @@ $ARGUMENTS
 
 5. **Register in the sidebar.** Update `apps/design-system-docs/sidebars.ts` per [`COMPONENT_DOC_STYLE.md`](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#sidebar-registration).
 
+6. **Self-review pass before saving.** Re-read your draft against [`What NOT to Include`](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#what-not-to-include) and remove every red flag you find. Common ones to grep for in your own draft:
+   - Prop names with literal values: `prop={`, `prop="`
+   - JSDoc-style callback descriptions: "fires with", "receives the", "returns "
+   - Integration code in prose (RHF Controller wiring, debounce snippets)
+   - Enumerated ARIA roles or attributes beyond a one-sentence pattern reference
+   - The same redirect appearing in both `When to Use` and the `Don't` list
+   - Sentence-case headings if siblings in the same category folder use Title Case
+   - Then sanity-check against the [Reference Exemplars](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#reference-exemplars) - if your draft is noticeably more prop-heavy or callback-heavy than `autocomplete.md`, rewrite.
+
 ## Rules
 
 - Use only content provided in the input — do not generate or invent information
@@ -29,3 +42,5 @@ $ARGUMENTS
 - Always include the H1 title
 - Remove artefacts: caps-locked folder names, duplicate paragraphs, dates/timestamps, scrape noise
 - Follow the tone of voice and formatting (British English, no em-dashes, admonitions) per the canonical doc
+- Each Guidelines paragraph answers *when* and *why*; the iframe answers *how*
+- Do's and Don'ts are usage guidance only - never API rules, handler overrides, or framework-integration warnings

--- a/.claude/commands/create-component-doc.md
+++ b/.claude/commands/create-component-doc.md
@@ -26,14 +26,7 @@ These docs are the **usage guide** for the EDS component library. The audience i
 
 5. **Register in the sidebar.** Update `apps/design-system-docs/sidebars.ts` per [`COMPONENT_DOC_STYLE.md`](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#sidebar-registration).
 
-6. **Self-review pass before saving.** Re-read your draft against [`What NOT to Include`](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#what-not-to-include) and remove every red flag you find. Common ones to grep for in your own draft:
-   - Prop names with literal values: `prop={`, `prop="`
-   - JSDoc-style callback descriptions: "fires with", "receives the", "returns "
-   - Integration code in prose (RHF Controller wiring, debounce snippets)
-   - Enumerated ARIA roles or attributes beyond a one-sentence pattern reference
-   - The same redirect appearing in both `When to Use` and the `Don't` list
-   - Sentence-case headings if siblings in the same category folder use Title Case
-   - Then sanity-check against the [Reference Exemplars](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#reference-exemplars) - if your draft is noticeably more prop-heavy or callback-heavy than `autocomplete.md`, rewrite.
+6. **Self-review pass before saving.** Re-read your draft against [`What NOT to Include`](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#what-not-to-include) and remove every red flag you find. Then sanity-check against the [Reference Exemplars](../../documentation/agent-instructions/COMPONENT_DOC_STYLE.md#reference-exemplars).
 
 ## Rules
 

--- a/documentation/agent-instructions/COMPONENT_DOC_STYLE.md
+++ b/documentation/agent-instructions/COMPONENT_DOC_STYLE.md
@@ -97,7 +97,7 @@ Before saving the file, re-read your draft and remove anything matching the list
 - **A JSDoc-style callback or return description.** Examples: "fires with the selected option", "receives the full option `T` or `undefined`", "returns `true` to include the option". Replace with a user-facing reason to use the pattern.
 - **Integration code described in prose.** RHF Controller wiring, debounce snippets, controlled-vs-uncontrolled walkthroughs. One sentence naming the integration is enough; the iframe carries the wiring.
 - **Exact ARIA role or attribute names beyond a one-sentence pattern reference.** "Implements the ARIA 1.2 combobox pattern" is fine; enumerating `role="combobox"`, `aria-autocomplete="list"`, `aria-activedescendant`, `role="listbox"` is not.
-- **Live-region wording, screen-reader announcement copy, or aria-live mechanics.** Storybook owns this.
+- **Live-region wording, screen-reader announcement copy, or aria-live mechanics beyond one sentence stating what is announced** (e.g. "the number of results is announced when the list updates" is fine; the exact copy and timing belong in Storybook).
 - **The same redirect ("use TextField instead", "use Search instead") appearing in both `When to Use` and the `Don't` list.** Pick one - usually `When to Use`, since that is where readers decide.
 - **The same guidance appearing in a section body and the Do's / Don'ts list.** If `Disabled and Read Only` already says "prefer read-only over disabled", the Do's list should not repeat it.
 - **Headings in sentence case** if siblings in the same category folder use Title Case. Check `apps/design-system-docs/docs/components/{category}/*.md` for the local convention before writing headings.
@@ -298,12 +298,11 @@ After writing the doc, update `apps/design-system-docs/sidebars.ts` so the compo
 
 ## Reference Exemplars
 
-When in doubt about prose style or section weight, imitate these existing docs rather than the raw template:
+When in doubt about prose style or section weight, imitate an existing doc rather than the raw template:
 
-- [`apps/design-system-docs/docs/components/inputs/autocomplete.md`](../../apps/design-system-docs/docs/components/inputs/autocomplete.md) - Guidelines paragraphs that answer *when* and *why*, a two-sentence Accessibility section, and usage-only Do's and Don'ts. Use this as the primary exemplar for the usage-guide voice.
-- [`apps/design-system-docs/docs/components/inputs/search.md`](../../apps/design-system-docs/docs/components/inputs/search.md) - Short Accessibility paragraph in the lighter style.
+- [`apps/design-system-docs/docs/components/inputs/search.md`](../../apps/design-system-docs/docs/components/inputs/search.md) - Use this as the primary exemplar for the usage-guide voice. Guidelines paragraphs that answer *when* and *why*, a short Accessibility paragraph in the lighter style, and usage-only Do's and Don'ts.
 
-If your draft is noticeably more prop-heavy or callback-heavy than these, rewrite before saving.
+If your draft is noticeably more prop-heavy or callback-heavy than this, rewrite before saving.
 
 ## Verification Checklist
 

--- a/documentation/agent-instructions/COMPONENT_DOC_STYLE.md
+++ b/documentation/agent-instructions/COMPONENT_DOC_STYLE.md
@@ -6,13 +6,32 @@ Component docs live in `apps/design-system-docs/docs/components/{category}/{comp
 
 ## Table of Contents
 
+- [Audience](#audience)
 - [Tone of Voice](#tone-of-voice)
 - [Formatting Conventions](#formatting-conventions)
+- [What NOT to Include](#what-not-to-include)
 - [Section Order](#section-order)
 - [Output Template](#output-template)
 - [Storybook Iframes](#storybook-iframes)
 - [Sidebar Registration](#sidebar-registration)
+- [Reference Exemplars](#reference-exemplars)
 - [Verification Checklist](#verification-checklist)
+
+## Audience
+
+These docs are the **usage guide** for the EDS component library. The audience is **anyone deciding whether and how to use a component** - designers building screens, developers picking between components, product folks scoping a feature, accessibility reviewers, contributors new to EDS.
+
+This is not a designer-only reference, and it is not a Figma manual. It is the place a reader lands when they need to answer questions like: *Is this the right component for my problem? What is it for? When should I reach for a sibling instead? What does it look like in the Figma library? What should I avoid when I use it?*
+
+Scope contract:
+
+- **Storybook = implementation reference.** Owns props with literal values, code snippets, callback signatures, integration patterns (react-hook-form, debounce, controlled vs uncontrolled wiring), and the precise list of ARIA roles and attributes.
+- **Docusaurus component doc (this guide) = usage reference.** Owns *when* a component is the right choice, *why*, what to avoid, the component's anatomy, and what it looks like in the Figma library.
+
+Concretely, when writing prose:
+
+- Each Guidelines paragraph answers **when** to use the pattern and **why**. The iframe + "View in Storybook" link below answers **how**.
+- Prose comes from design intent, product context, and Figma - not from `*.types.ts` or `*.stories.tsx`. Use source code as a *fact-check source* for variant names, state names, and accessibility behaviour - not as content to paraphrase.
 
 ## Tone of Voice
 
@@ -55,18 +74,33 @@ Component docs render via Docusaurus, which supports the `:::type` admonition sy
 ```markdown
 :::info **Do**
 
-- Good practice from input
+- Provide a clear, visible label so users know what they are selecting
 
 :::
 
 :::danger **Don't**
 
-- Anti-pattern or thing to avoid
+- Hide or omit the label - placeholder text is not a substitute
 
 :::
 ```
 
-Use `:::info` for Do's (positive guidance) and `:::danger` for Don'ts (things to avoid). Close every admonition with `:::`.
+Use `:::info` for Do's (positive UX guidance) and `:::danger` for Don'ts (things to avoid). Close every admonition with `:::`.
+
+**Do's and Don'ts are usage decisions** made before implementation - label clarity, when to choose this component over a sibling, content pitfalls, accessibility hygiene visible to the user, expected list length, readOnly vs disabled. Do **not** list API rules, handler overrides, framework-integration warnings, or callback-ordering caveats - those belong in Storybook story descriptions.
+
+## What NOT to Include
+
+Before saving the file, re-read your draft and remove anything matching the list below. These are the red flags that mean the prose has drifted into developer-reference territory.
+
+- **A prop name with a literal value** in prose. Examples: `prop={value}`, `prop="..."`, `optionsFilter={() => true}`. The Storybook iframe demonstrates it - the doc does not need to spell it out.
+- **A JSDoc-style callback or return description.** Examples: "fires with the selected option", "receives the full option `T` or `undefined`", "returns `true` to include the option". Replace with a user-facing reason to use the pattern.
+- **Integration code described in prose.** RHF Controller wiring, debounce snippets, controlled-vs-uncontrolled walkthroughs. One sentence naming the integration is enough; the iframe carries the wiring.
+- **Exact ARIA role or attribute names beyond a one-sentence pattern reference.** "Implements the ARIA 1.2 combobox pattern" is fine; enumerating `role="combobox"`, `aria-autocomplete="list"`, `aria-activedescendant`, `role="listbox"` is not.
+- **Live-region wording, screen-reader announcement copy, or aria-live mechanics.** Storybook owns this.
+- **The same redirect ("use TextField instead", "use Search instead") appearing in both `When to Use` and the `Don't` list.** Pick one - usually `When to Use`, since that is where readers decide.
+- **The same guidance appearing in a section body and the Do's / Don'ts list.** If `Disabled and Read Only` already says "prefer read-only over disabled", the Do's list should not repeat it.
+- **Headings in sentence case** if siblings in the same category folder use Title Case. Check `apps/design-system-docs/docs/components/{category}/*.md` for the local convention before writing headings.
 
 ## Section Order
 
@@ -126,9 +160,11 @@ All [component] variants support:
 
 ## Guidelines
 
+[Each subsection answers *when* to use a pattern and *why*. The iframe + "View in Storybook" link answers *how*. Use Title Case for headings (e.g. "Validation States", "Disabled and Read Only") and match the convention of sibling docs in the same category folder.]
+
 ### Variants
 
-[Descriptive text explaining variants.]
+[Descriptive text explaining when each variant is appropriate. Do not include prop names with literal values - the iframe carries that.]
 
 | Variant   | Emphasis | Use Case           |
 | --------- | -------- | ------------------ |
@@ -178,16 +214,13 @@ All [component] variants support:
 
 ## Accessibility
 
-[Document accessibility considerations and requirements.]
+[One short paragraph naming the WAI-ARIA pattern the component implements (e.g. "implements the ARIA 1.2 combobox pattern") and confirming that labels, descriptions, and helper messages are wired up automatically. Do NOT enumerate role names or ARIA attribute names beyond that one-sentence pattern reference - Storybook owns the exact contract.]
 
-**Standard [Component]**
+**Keyboard support:**
 
-- **Keyboard**: Tab focus, Enter/Space activation
-- **Disabled state**: Guidelines
-
-**Icon-Only Variant** (if applicable)
-
-- Accessible name requirements
+- **Tab**: Move focus to and from the field
+- **Enter / Space**: Activate
+- [Other keys relevant to this component, in plain language]
 
 ## Figma
 
@@ -263,34 +296,55 @@ After writing the doc, update `apps/design-system-docs/sidebars.ts` so the compo
 - Add the component doc ID (e.g. `'components/navigation/link'`) to the appropriate category's `items` array.
 - If the category doesn't exist, create a new category entry following the existing pattern.
 
+## Reference Exemplars
+
+When in doubt about prose style or section weight, imitate these existing docs rather than the raw template:
+
+- [`apps/design-system-docs/docs/components/inputs/autocomplete.md`](../../apps/design-system-docs/docs/components/inputs/autocomplete.md) - Guidelines paragraphs that answer *when* and *why*, a two-sentence Accessibility section, and usage-only Do's and Don'ts. Use this as the primary exemplar for the usage-guide voice.
+- [`apps/design-system-docs/docs/components/inputs/search.md`](../../apps/design-system-docs/docs/components/inputs/search.md) - Short Accessibility paragraph in the lighter style.
+
+If your draft is noticeably more prop-heavy or callback-heavy than these, rewrite before saving.
+
 ## Verification Checklist
 
 When reviewing an existing component doc, walk through these criteria. List findings as bullets — do not output tables.
 
-1. **Clarity and understandability**
+1. **Usage-focused** (highest priority)
+   - Could someone deciding whether to use this component read it without dropping into the source code or Storybook for each decision?
+   - Does each Guidelines paragraph answer *when* and *why*, leaving *how* to the iframe?
+   - Are any of the [What NOT to Include](#what-not-to-include) red flags present? Specifically:
+     - Prop names with literal values in prose (`prop={value}`, `prop="..."`)
+     - JSDoc-style callback/return descriptions ("fires with...", "receives the full...")
+     - Integration code (RHF wiring, debounce, etc.) described in prose
+     - ARIA role/attribute names enumerated beyond a one-sentence pattern reference
+     - Duplicate redirects between `When to Use` and the `Don't` list
+     - Same guidance repeated in a section body and the Do's / Don'ts list
+
+2. **Clarity and understandability**
    - Is the component description clear and easy to understand?
    - Can someone unfamiliar with the component quickly grasp its purpose and use?
 
-2. **Completeness**
+3. **Completeness**
    - Are the key sections present? (Title + intro, When to Use, Structure, Guidelines, Accessibility, Figma, Do's and Don'ts, hero iframe.)
    - Does each section contain useful information? Note what is missing.
 
-3. **Tone of voice**
+4. **Tone of voice**
    - Is the tone friendly, approachable, and professional?
    - Does it reflect the brand values: inspiring, inclusive, practical, supportive?
 
-4. **Consistency**
-   - Is the structure consistent with other components?
-   - Are terms and formatting applied consistently (headings, lists, admonitions, British English)?
+5. **Consistency**
+   - Is the structure consistent with other components in the same category folder?
+   - Headings in Title Case if siblings use Title Case?
+   - Are terms and formatting applied consistently (lists, admonitions, British English)?
    - Are em-dashes avoided?
 
-5. **Redundancy or noise**
+6. **Redundancy or noise**
    - Are there duplicated or unnecessary paragraphs?
    - Is there leftover scrape artefact (notes, system labels, caps-locked folder names, dates/timestamps)?
 
-6. **Practical usability**
-   - Would a designer or developer be able to use this documentation to work with the component in Figma and code?
-   - Is there enough detail to take action?
+7. **Practical usability**
+   - Would the reader be able to use this documentation to choose the component and work with it in Figma?
+   - Is there enough detail to take action without dropping into the source code or Storybook for every decision?
 
 ### Output format
 


### PR DESCRIPTION
## Summary

- Reframe component docs as the **usage guide** for anyone deciding whether and how to use a component (designers, devs picking components, PMs, a11y reviewers) - not a designer-only reference. Storybook keeps ownership of props, code, callbacks, and integration patterns; the Docusaurus doc owns the *when*, *why*, and *what to avoid*.
- Add a self-review pass with concrete red flags (prop literals in prose, JSDoc-style callback descriptions, integration code, enumerated ARIA roles, duplicate redirects, sentence-case headings) and point to \`autocomplete.md\` / \`search.md\` as exemplars.
- Add the audience reminder to the \`/create-component-doc\` slash command so future runs read it before drafting.

## Test plan

- [ ] Run \`/create-component-doc\` on a sample component and confirm the audience reminder surfaces in the prompt
- [ ] Verify the self-review red-flag list catches prop-literal prose, JSDoc-style callback wording, and integration snippets