### PR TITLE
feat: Dialog EDS 2.0

### DIFF
--- a/packages/eds-core-react/.storybook/preview-head.html
+++ b/packages/eds-core-react/.storybook/preview-head.html
@@ -16,8 +16,13 @@
     }
   }
 
-  :where(h1, h2, h3, h4, h5, h6) {
-    font-family: Equinor, sans-serif;
+  /* Wrapped in @layer so component CSS in @layer eds-components wins
+     naturally (unlayered styles outrank any layer). The layer name is
+     declared here first, so it is the lowest-priority layer in the cascade. */
+  @layer storybook {
+    :where(h1, h2, h3, h4, h5, h6) {
+      font-family: Equinor, sans-serif;
+    }
   }
 
   .sbdocs.sbdocs-a {

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
@@ -10,13 +10,12 @@ figma.connect(
       title: figma.string('Dialog Title'),
       // Trailing space matches the Figma layer name verbatim.
       content: figma.string('Content '),
-      hasClose: figma.boolean('Has Close Icon'),
       showPrimary: figma.boolean('Show Primary Button'),
       showSecondary: figma.boolean('Show Secondary Button'),
     },
-    example: ({ title, content, hasClose, showPrimary, showSecondary }) => (
+    example: ({ title, content, showPrimary, showSecondary }) => (
       <Dialog open onOpenChange={() => {}}>
-        <Dialog.Header closable={hasClose}>
+        <Dialog.Header>
           <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>{content}</Dialog.Content>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
@@ -1,0 +1,29 @@
+import figma from '@figma/code-connect'
+import { Dialog } from '.'
+import { Button } from '../Button'
+
+figma.connect(
+  Dialog,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/EDS-Core-Components?node-id=6458-254&m=dev',
+  {
+    props: {
+      title: figma.string('Dialog Title'),
+      content: figma.string('Content '),
+      hasClose: figma.boolean('Has Close Icon'),
+      showPrimary: figma.boolean('Show Primary Button'),
+      showSecondary: figma.boolean('Show Secondary Button'),
+    },
+    example: ({ title, content, hasClose, showPrimary, showSecondary }) => (
+      <Dialog open onOpenChange={() => {}} aria-labelledby="dialog-title">
+        <Dialog.Header onClose={hasClose ? () => {} : undefined}>
+          <Dialog.Title id="dialog-title">{title}</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>{content}</Dialog.Content>
+        <Dialog.Actions>
+          {showSecondary && <Button variant="secondary">Label</Button>}
+          {showPrimary && <Button>Label</Button>}
+        </Dialog.Actions>
+      </Dialog>
+    ),
+  },
+)

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
@@ -15,7 +15,7 @@ figma.connect(
     },
     example: ({ title, content, hasClose, showPrimary, showSecondary }) => (
       <Dialog open onOpenChange={() => {}}>
-        <Dialog.Header onClose={hasClose ? () => {} : undefined}>
+        <Dialog.Header closable={hasClose}>
           <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>{content}</Dialog.Content>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
@@ -14,9 +14,9 @@ figma.connect(
       showSecondary: figma.boolean('Show Secondary Button'),
     },
     example: ({ title, content, hasClose, showPrimary, showSecondary }) => (
-      <Dialog open onOpenChange={() => {}} aria-labelledby="dialog-title">
+      <Dialog open onOpenChange={() => {}}>
         <Dialog.Header onClose={hasClose ? () => {} : undefined}>
-          <Dialog.Title id="dialog-title">{title}</Dialog.Title>
+          <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>{content}</Dialog.Content>
         <Dialog.Actions>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.figma.tsx
@@ -8,6 +8,7 @@ figma.connect(
   {
     props: {
       title: figma.string('Dialog Title'),
+      // Trailing space matches the Figma layer name verbatim.
       content: figma.string('Content '),
       hasClose: figma.boolean('Has Close Icon'),
       showPrimary: figma.boolean('Show Primary Button'),

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -17,22 +17,13 @@ Built on the native \`<dialog>\` element with \`showModal()\` for free focus
 trapping, Escape-key handling and inert background. Backdrop clicks close
 the dialog.
 
+### Import
+
 \`\`\`tsx
-import { Dialog, Button } from '@equinor/eds-core-react/next'
-
-const [open, setOpen] = useState(false)
-
-<Dialog open={open} onOpenChange={setOpen}>
-  <Dialog.Header onClose={() => setOpen(false)}>
-    <Dialog.Title>Confirm action</Dialog.Title>
-  </Dialog.Header>
-  <Dialog.Content>Are you sure you want to continue?</Dialog.Content>
-  <Dialog.Actions>
-    <Button variant="secondary" onClick={() => setOpen(false)}>Cancel</Button>
-    <Button onClick={() => setOpen(false)}>Confirm</Button>
-  </Dialog.Actions>
-</Dialog>
+import { Dialog } from '@equinor/eds-core-react/next'
 \`\`\`
+
+See the stories below for usage patterns.
         `,
       },
     },

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import type { Meta, StoryFn } from '@storybook/react-vite'
+import { Dialog } from '.'
+import { Button } from '../Button'
+
+const meta: Meta<typeof Dialog> = {
+  title: 'EDS 2.0 (beta)/Surface/Dialog',
+  component: Dialog,
+  tags: ['beta'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+⚠️ **Beta Component** - This component is under active development.
+
+Built on the native \`<dialog>\` element with \`showModal()\` for free focus
+trapping, Escape-key handling and inert background. Backdrop clicks close
+the dialog.
+
+\`\`\`tsx
+import { Dialog, Button } from '@equinor/eds-core-react/next'
+
+const [open, setOpen] = useState(false)
+
+<Dialog open={open} onOpenChange={setOpen} aria-labelledby="dialog-title">
+  <Dialog.Header onClose={() => setOpen(false)}>
+    <Dialog.Title id="dialog-title">Confirm action</Dialog.Title>
+  </Dialog.Header>
+  <Dialog.Content>Are you sure you want to continue?</Dialog.Content>
+  <Dialog.Actions>
+    <Button variant="secondary" onClick={() => setOpen(false)}>Cancel</Button>
+    <Button onClick={() => setOpen(false)}>Confirm</Button>
+  </Dialog.Actions>
+</Dialog>
+\`\`\`
+        `,
+      },
+    },
+  },
+}
+
+export default meta
+
+export const Introduction: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Dialog open={open} onOpenChange={setOpen} aria-labelledby="dialog-title">
+        <Dialog.Header onClose={() => setOpen(false)}>
+          <Dialog.Title id="dialog-title">Dialog title</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>
+          This is a short description of the action the user is about to take.
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => setOpen(false)}>Confirm</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </>
+  )
+}
+
+export const WithoutCloseButton: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Dialog
+        open={open}
+        onOpenChange={setOpen}
+        aria-labelledby="dialog-title-no-close"
+      >
+        <Dialog.Header>
+          <Dialog.Title id="dialog-title-no-close">
+            Decision required
+          </Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>
+          The user must pick one of the actions below — no close affordance in
+          the header.
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Discard
+          </Button>
+          <Button onClick={() => setOpen(false)}>Keep</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </>
+  )
+}
+
+export const WithoutScrim: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Dialog
+        open={open}
+        onOpenChange={setOpen}
+        scrim={false}
+        aria-labelledby="dialog-title-no-scrim"
+      >
+        <Dialog.Header onClose={() => setOpen(false)}>
+          <Dialog.Title id="dialog-title-no-scrim">Dialog title</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>
+          With <code>scrim={'{false}'}</code> the backdrop stays transparent —
+          useful when the dialog is part of a flow that already dims the
+          background, or when a standalone Scrim component is composed
+          externally.
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => setOpen(false)}>Confirm</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </>
+  )
+}

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -38,7 +38,7 @@ export const Introduction: StoryFn = () => {
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header closable>
+        <Dialog.Header>
           <Dialog.Title>Dialog title</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -61,7 +61,7 @@ export const WithoutCloseButton: StoryFn = () => {
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header>
+        <Dialog.Header closable={false}>
           <Dialog.Title>Decision required</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -87,7 +87,7 @@ export const DangerAction: StoryFn = () => {
         Delete project
       </Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header closable>
+        <Dialog.Header>
           <Dialog.Title>Delete this project?</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -113,7 +113,7 @@ export const SingleAction: StoryFn = () => {
     <>
       <Button onClick={() => setOpen(true)}>Show details</Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header closable>
+        <Dialog.Header>
           <Dialog.Title>You are now offline</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -133,7 +133,7 @@ export const WithoutScrim: StoryFn = () => {
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
       <Dialog open={open} onOpenChange={setOpen} scrim={false}>
-        <Dialog.Header closable>
+        <Dialog.Header>
           <Dialog.Title>Dialog title</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -165,7 +165,7 @@ export const SpecificWidth: StoryFn = () => {
         onOpenChange={setOpen}
         style={{ inlineSize: '32rem' }}
       >
-        <Dialog.Header closable>
+        <Dialog.Header>
           <Dialog.Title>Dialog with a specific width</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -124,3 +124,42 @@ export const WithoutScrim: StoryFn = () => {
     </>
   )
 }
+
+export const SpecificWidth: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Dialog
+        open={open}
+        onOpenChange={setOpen}
+        aria-labelledby="dialog-title-specific-width"
+        style={{ inlineSize: '32rem' }}
+      >
+        <Dialog.Header onClose={() => setOpen(false)}>
+          <Dialog.Title id="dialog-title-specific-width">
+            Dialog with a specific width
+          </Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>
+          <p style={{ margin: 0 }}>
+            By default the dialog is at least 300px wide and grows with its
+            content (capped to the viewport by the browser). For dialogs holding
+            forms, tables, or longer body copy, set a wider{' '}
+            <code>inlineSize</code> via <code>style</code> or a custom{' '}
+            <code>className</code>.
+          </p>
+          <pre style={{ margin: 0 }}>
+            {`<Dialog style={{ inlineSize: '32rem' }}>...</Dialog>`}
+          </pre>
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => setOpen(false)}>Confirm</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </>
+  )
+}

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -4,7 +4,7 @@ import { Dialog } from '.'
 import { Button } from '../Button'
 
 const meta: Meta<typeof Dialog> = {
-  title: 'EDS 2.0 (beta)/Surface/Dialog',
+  title: 'EDS 2.0 (beta)/Feedback/Dialog',
   component: Dialog,
   tags: ['beta'],
   parameters: {
@@ -22,9 +22,9 @@ import { Dialog, Button } from '@equinor/eds-core-react/next'
 
 const [open, setOpen] = useState(false)
 
-<Dialog open={open} onOpenChange={setOpen} aria-labelledby="dialog-title">
+<Dialog open={open} onOpenChange={setOpen}>
   <Dialog.Header onClose={() => setOpen(false)}>
-    <Dialog.Title id="dialog-title">Confirm action</Dialog.Title>
+    <Dialog.Title>Confirm action</Dialog.Title>
   </Dialog.Header>
   <Dialog.Content>Are you sure you want to continue?</Dialog.Content>
   <Dialog.Actions>
@@ -46,9 +46,9 @@ export const Introduction: StoryFn = () => {
   return (
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
-      <Dialog open={open} onOpenChange={setOpen} aria-labelledby="dialog-title">
+      <Dialog open={open} onOpenChange={setOpen}>
         <Dialog.Header onClose={() => setOpen(false)}>
-          <Dialog.Title id="dialog-title">Dialog title</Dialog.Title>
+          <Dialog.Title>Dialog title</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
           This is a short description of the action the user is about to take.
@@ -69,15 +69,9 @@ export const WithoutCloseButton: StoryFn = () => {
   return (
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
-      <Dialog
-        open={open}
-        onOpenChange={setOpen}
-        aria-labelledby="dialog-title-no-close"
-      >
+      <Dialog open={open} onOpenChange={setOpen}>
         <Dialog.Header>
-          <Dialog.Title id="dialog-title-no-close">
-            Decision required
-          </Dialog.Title>
+          <Dialog.Title>Decision required</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
           The user must pick one of the actions below — no close affordance in
@@ -94,25 +88,70 @@ export const WithoutCloseButton: StoryFn = () => {
   )
 }
 
+export const DangerAction: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button tone="danger" onClick={() => setOpen(true)}>
+        Delete project
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog.Header onClose={() => setOpen(false)}>
+          <Dialog.Title>Delete this project?</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>
+          This permanently removes the project and all of its data. This action
+          cannot be undone.
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button tone="danger" onClick={() => setOpen(false)}>
+            Delete
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
+    </>
+  )
+}
+
+export const SingleAction: StoryFn = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Show details</Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog.Header onClose={() => setOpen(false)}>
+          <Dialog.Title>You are now offline</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>
+          Changes will sync automatically when your connection is restored.
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button onClick={() => setOpen(false)}>Got it</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </>
+  )
+}
+
 export const WithoutScrim: StoryFn = () => {
   const [open, setOpen] = useState(false)
   return (
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
-      <Dialog
-        open={open}
-        onOpenChange={setOpen}
-        scrim={false}
-        aria-labelledby="dialog-title-no-scrim"
-      >
+      <Dialog open={open} onOpenChange={setOpen} scrim={false}>
         <Dialog.Header onClose={() => setOpen(false)}>
-          <Dialog.Title id="dialog-title-no-scrim">Dialog title</Dialog.Title>
+          <Dialog.Title>Dialog title</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
-          With <code>scrim={'{false}'}</code> the backdrop stays transparent —
-          useful when the dialog is part of a flow that already dims the
-          background, or when a standalone Scrim component is composed
-          externally.
+          <p style={{ margin: 0 }}>
+            With <code>scrim={'{false}'}</code> the backdrop is fully
+            transparent — useful when the dialog is part of a flow that already
+            dims the background, or when a standalone Scrim component is
+            composed externally.
+          </p>
         </Dialog.Content>
         <Dialog.Actions>
           <Button variant="secondary" onClick={() => setOpen(false)}>
@@ -133,13 +172,10 @@ export const SpecificWidth: StoryFn = () => {
       <Dialog
         open={open}
         onOpenChange={setOpen}
-        aria-labelledby="dialog-title-specific-width"
         style={{ inlineSize: '32rem' }}
       >
         <Dialog.Header onClose={() => setOpen(false)}>
-          <Dialog.Title id="dialog-title-specific-width">
-            Dialog with a specific width
-          </Dialog.Title>
+          <Dialog.Title>Dialog with a specific width</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
           <p style={{ margin: 0 }}>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -38,7 +38,7 @@ export const Introduction: StoryFn = () => {
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header onClose={() => setOpen(false)}>
+        <Dialog.Header closable>
           <Dialog.Title>Dialog title</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -87,7 +87,7 @@ export const DangerAction: StoryFn = () => {
         Delete project
       </Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header onClose={() => setOpen(false)}>
+        <Dialog.Header closable>
           <Dialog.Title>Delete this project?</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -113,7 +113,7 @@ export const SingleAction: StoryFn = () => {
     <>
       <Button onClick={() => setOpen(true)}>Show details</Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header onClose={() => setOpen(false)}>
+        <Dialog.Header closable>
           <Dialog.Title>You are now offline</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -133,7 +133,7 @@ export const WithoutScrim: StoryFn = () => {
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
       <Dialog open={open} onOpenChange={setOpen} scrim={false}>
-        <Dialog.Header onClose={() => setOpen(false)}>
+        <Dialog.Header closable>
           <Dialog.Title>Dialog title</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
@@ -165,7 +165,7 @@ export const SpecificWidth: StoryFn = () => {
         onOpenChange={setOpen}
         style={{ inlineSize: '32rem' }}
       >
-        <Dialog.Header onClose={() => setOpen(false)}>
+        <Dialog.Header closable>
           <Dialog.Title>Dialog with a specific width</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -55,25 +55,19 @@ export const Introduction: StoryFn = () => {
   )
 }
 
-export const WithoutCloseButton: StoryFn = () => {
+export const Passive: StoryFn = () => {
   const [open, setOpen] = useState(false)
   return (
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <Dialog.Header closable={false}>
-          <Dialog.Title>Decision required</Dialog.Title>
+        <Dialog.Header>
+          <Dialog.Title>You are now offline</Dialog.Title>
         </Dialog.Header>
         <Dialog.Content>
-          The user must pick one of the actions below — no close affordance in
-          the header.
+          A passive dialog — no action row. Dismiss via the close icon, Escape,
+          or backdrop click.
         </Dialog.Content>
-        <Dialog.Actions>
-          <Button variant="secondary" onClick={() => setOpen(false)}>
-            Discard
-          </Button>
-          <Button onClick={() => setOpen(false)}>Keep</Button>
-        </Dialog.Actions>
       </Dialog>
     </>
   )

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
@@ -24,7 +24,7 @@ beforeAll(() => {
 const renderOpen = (onOpenChange: (open: boolean) => void = () => {}) =>
   render(
     <Dialog open onOpenChange={onOpenChange}>
-      <Dialog.Header closable>
+      <Dialog.Header>
         <Dialog.Title>Title</Dialog.Title>
       </Dialog.Header>
       <Dialog.Content>Content</Dialog.Content>
@@ -96,10 +96,21 @@ describe('Dialog (next)', () => {
       expect(screen.getByRole('dialog')).not.toHaveAttribute('data-scrim')
     })
 
-    it('omits the close button when closable is not set', () => {
+    it('renders a close button by default', () => {
       render(
         <Dialog open aria-label="d">
           <Dialog.Header>
+            <Dialog.Title>Title</Dialog.Title>
+          </Dialog.Header>
+        </Dialog>,
+      )
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+    })
+
+    it('omits the close button when closable is false', () => {
+      render(
+        <Dialog open aria-label="d">
+          <Dialog.Header closable={false}>
             <Dialog.Title>Title</Dialog.Title>
           </Dialog.Header>
         </Dialog>,
@@ -234,7 +245,7 @@ describe('Dialog (next)', () => {
               setOpen(next)
             }}
           >
-            <Dialog.Header closable>
+            <Dialog.Header>
               <Dialog.Title>Title</Dialog.Title>
             </Dialog.Header>
           </Dialog>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
@@ -24,7 +24,7 @@ beforeAll(() => {
 const renderOpen = (onOpenChange: (open: boolean) => void = () => {}) =>
   render(
     <Dialog open onOpenChange={onOpenChange}>
-      <Dialog.Header onClose={() => onOpenChange(false)}>
+      <Dialog.Header closable>
         <Dialog.Title>Title</Dialog.Title>
       </Dialog.Header>
       <Dialog.Content>Content</Dialog.Content>
@@ -96,7 +96,7 @@ describe('Dialog (next)', () => {
       expect(screen.getByRole('dialog')).not.toHaveAttribute('data-scrim')
     })
 
-    it('omits the close button when onClose is not provided', () => {
+    it('omits the close button when closable is not set', () => {
       render(
         <Dialog open aria-label="d">
           <Dialog.Header>
@@ -169,10 +169,24 @@ describe('Dialog (next)', () => {
     it('invokes onOpenChange(false) on backdrop click', () => {
       const onOpenChange = jest.fn()
       renderOpen(onOpenChange)
-      // A click whose target IS the dialog element comes from the backdrop —
-      // children stop event.target from being the dialog itself.
-      fireEvent.click(screen.getByRole('dialog'))
+      // A click whose target IS the dialog element comes from the backdrop.
+      // Both mousedown and click must land on the dialog itself — guards
+      // against drag-out from a text selection.
+      const dialog = screen.getByRole('dialog')
+      fireEvent.mouseDown(dialog)
+      fireEvent.click(dialog)
       expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('does not close when mousedown started on a child and ended on the dialog', () => {
+      const onOpenChange = jest.fn()
+      renderOpen(onOpenChange)
+      const dialog = screen.getByRole('dialog')
+      // mousedown on a child (text-selection drag start), released over the
+      // dialog itself. Without the mousedown-target guard this would close.
+      fireEvent.mouseDown(screen.getByText('Content'))
+      fireEvent.click(dialog)
+      expect(onOpenChange).not.toHaveBeenCalled()
     })
 
     it('does not invoke onOpenChange when clicking dialog children', async () => {
@@ -180,6 +194,71 @@ describe('Dialog (next)', () => {
       const onOpenChange = jest.fn()
       renderOpen(onOpenChange)
       await user.click(screen.getByText('Content'))
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
+    it('fires onOpenChange exactly once on backdrop click', () => {
+      const onOpenChange = jest.fn()
+      const Controlled = () => {
+        const [open, setOpen] = useState(true)
+        return (
+          <Dialog
+            open={open}
+            onOpenChange={(next) => {
+              onOpenChange(next)
+              setOpen(next)
+            }}
+            aria-label="d"
+          >
+            <Dialog.Content>x</Dialog.Content>
+          </Dialog>
+        )
+      }
+      render(<Controlled />)
+      const dialog = screen.getByRole('dialog', { hidden: true })
+      fireEvent.mouseDown(dialog)
+      fireEvent.click(dialog)
+      expect(onOpenChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('fires onOpenChange exactly once on close-button click', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = jest.fn()
+      const Controlled = () => {
+        const [open, setOpen] = useState(true)
+        return (
+          <Dialog
+            open={open}
+            onOpenChange={(next) => {
+              onOpenChange(next)
+              setOpen(next)
+            }}
+          >
+            <Dialog.Header closable>
+              <Dialog.Title>Title</Dialog.Title>
+            </Dialog.Header>
+          </Dialog>
+        )
+      }
+      render(<Controlled />)
+      await user.click(screen.getByRole('button', { name: 'Close' }))
+      expect(onOpenChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('fires onOpenChange exactly once when consumer flips open to false', () => {
+      const onOpenChange = jest.fn()
+      const { rerender } = render(
+        <Dialog open onOpenChange={onOpenChange} aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      rerender(
+        <Dialog open={false} onOpenChange={onOpenChange} aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      // The effect-driven close should suppress the close-event callback so
+      // a state-driven close doesn't loop back into onOpenChange.
       expect(onOpenChange).not.toHaveBeenCalled()
     })
 
@@ -253,6 +332,18 @@ describe('Dialog (next)', () => {
       const dialog = screen.getByRole('dialog')
       expect(dialog).toHaveAttribute('aria-label', 'Confirmation')
       expect(dialog).not.toHaveAttribute('aria-labelledby')
+    })
+
+    it('omits aria-labelledby when no title and no aria-label is given', () => {
+      render(
+        <Dialog open>
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      // Without a Dialog.Title or aria-label, defaulting aria-labelledby to
+      // an unregistered id would dangle. The title id is only used if a
+      // Dialog.Title has actually registered.
+      expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-labelledby')
     })
   })
 })

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
@@ -21,6 +21,11 @@ beforeAll(() => {
   }
 })
 
+afterAll(() => {
+  Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal')
+  Reflect.deleteProperty(HTMLDialogElement.prototype, 'close')
+})
+
 const renderOpen = (onOpenChange: (open: boolean) => void = () => {}) =>
   render(
     <Dialog open onOpenChange={onOpenChange}>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
@@ -53,7 +53,7 @@ describe('Dialog (next)', () => {
     it('forwards ref to the dialog element', () => {
       const ref = { current: null as HTMLDialogElement | null }
       render(
-        <Dialog open ref={ref} aria-label="d">
+        <Dialog open onOpenChange={() => {}} ref={ref} aria-label="d">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
@@ -62,7 +62,7 @@ describe('Dialog (next)', () => {
 
     it('renders Dialog.Actions children inside an action row', () => {
       render(
-        <Dialog open aria-label="d">
+        <Dialog open onOpenChange={() => {}} aria-label="d">
           <Dialog.Actions>
             <Button>Confirm</Button>
           </Dialog.Actions>
@@ -75,7 +75,12 @@ describe('Dialog (next)', () => {
 
     it('applies an inline width override via style', () => {
       render(
-        <Dialog open style={{ inlineSize: '32rem' }} aria-label="d">
+        <Dialog
+          open
+          onOpenChange={() => {}}
+          style={{ inlineSize: '32rem' }}
+          aria-label="d"
+        >
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
@@ -89,16 +94,16 @@ describe('Dialog (next)', () => {
 
     it('omits data-scrim when scrim is false', () => {
       render(
-        <Dialog open scrim={false} aria-label="d">
+        <Dialog open onOpenChange={() => {}} scrim={false} aria-label="d">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
       expect(screen.getByRole('dialog')).not.toHaveAttribute('data-scrim')
     })
 
-    it('renders a close button by default', () => {
+    it('renders a close button inside Dialog.Header', () => {
       render(
-        <Dialog open aria-label="d">
+        <Dialog open onOpenChange={() => {}} aria-label="d">
           <Dialog.Header>
             <Dialog.Title>Title</Dialog.Title>
           </Dialog.Header>
@@ -106,25 +111,12 @@ describe('Dialog (next)', () => {
       )
       expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
     })
-
-    it('omits the close button when closable is false', () => {
-      render(
-        <Dialog open aria-label="d">
-          <Dialog.Header closable={false}>
-            <Dialog.Title>Title</Dialog.Title>
-          </Dialog.Header>
-        </Dialog>,
-      )
-      expect(
-        screen.queryByRole('button', { name: 'Close' }),
-      ).not.toBeInTheDocument()
-    })
   })
 
   describe('Open state', () => {
     it('opens via showModal when initial open is true', () => {
       render(
-        <Dialog open aria-label="d">
+        <Dialog open onOpenChange={() => {}} aria-label="d">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
@@ -133,7 +125,7 @@ describe('Dialog (next)', () => {
 
     it('opens when the open prop becomes true', () => {
       const { rerender } = render(
-        <Dialog open={false} aria-label="d">
+        <Dialog open={false} onOpenChange={() => {}} aria-label="d">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
@@ -142,7 +134,7 @@ describe('Dialog (next)', () => {
       )
 
       rerender(
-        <Dialog open aria-label="d">
+        <Dialog open onOpenChange={() => {}} aria-label="d">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
@@ -151,14 +143,14 @@ describe('Dialog (next)', () => {
 
     it('closes when the open prop becomes false', () => {
       const { rerender } = render(
-        <Dialog open aria-label="d">
+        <Dialog open onOpenChange={() => {}} aria-label="d">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
       expect(screen.getByRole('dialog')).toHaveAttribute('open')
 
       rerender(
-        <Dialog open={false} aria-label="d">
+        <Dialog open={false} onOpenChange={() => {}} aria-label="d">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
@@ -322,7 +314,7 @@ describe('Dialog (next)', () => {
 
     it('respects an explicit aria-labelledby on Dialog', () => {
       render(
-        <Dialog open aria-labelledby="explicit-id">
+        <Dialog open onOpenChange={() => {}} aria-labelledby="explicit-id">
           <Dialog.Header>
             <Dialog.Title id="explicit-id">Title</Dialog.Title>
           </Dialog.Header>
@@ -336,7 +328,7 @@ describe('Dialog (next)', () => {
 
     it('uses aria-label without setting aria-labelledby', () => {
       render(
-        <Dialog open aria-label="Confirmation">
+        <Dialog open onOpenChange={() => {}} aria-label="Confirmation">
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )
@@ -347,7 +339,7 @@ describe('Dialog (next)', () => {
 
     it('omits aria-labelledby when no title and no aria-label is given', () => {
       render(
-        <Dialog open>
+        <Dialog open onOpenChange={() => {}}>
           <Dialog.Content>x</Dialog.Content>
         </Dialog>,
       )

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
@@ -23,9 +23,9 @@ beforeAll(() => {
 
 const renderOpen = (onOpenChange: (open: boolean) => void = () => {}) =>
   render(
-    <Dialog open onOpenChange={onOpenChange} aria-labelledby="t">
+    <Dialog open onOpenChange={onOpenChange}>
       <Dialog.Header onClose={() => onOpenChange(false)}>
-        <Dialog.Title id="t">Title</Dialog.Title>
+        <Dialog.Title>Title</Dialog.Title>
       </Dialog.Header>
       <Dialog.Content>Content</Dialog.Content>
       <Dialog.Actions>
@@ -60,6 +60,28 @@ describe('Dialog (next)', () => {
       expect(ref.current).toBeInstanceOf(HTMLDialogElement)
     })
 
+    it('renders Dialog.Actions children inside an action row', () => {
+      render(
+        <Dialog open aria-label="d">
+          <Dialog.Actions>
+            <Button>Confirm</Button>
+          </Dialog.Actions>
+        </Dialog>,
+      )
+      expect(
+        screen.getByRole('button', { name: 'Confirm' }),
+      ).toBeInTheDocument()
+    })
+
+    it('applies an inline width override via style', () => {
+      render(
+        <Dialog open style={{ inlineSize: '32rem' }} aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog')).toHaveStyle({ inlineSize: '32rem' })
+    })
+
     it('sets data-scrim by default', () => {
       renderOpen()
       expect(screen.getByRole('dialog')).toHaveAttribute('data-scrim')
@@ -89,6 +111,15 @@ describe('Dialog (next)', () => {
   })
 
   describe('Open state', () => {
+    it('opens via showModal when initial open is true', () => {
+      render(
+        <Dialog open aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog')).toHaveAttribute('open')
+    })
+
     it('opens when the open prop becomes true', () => {
       const { rerender } = render(
         <Dialog open={false} aria-label="d">
@@ -189,6 +220,39 @@ describe('Dialog (next)', () => {
       expect(
         screen.getByRole('heading', { level: 2, name: 'Title' }),
       ).toBeInTheDocument()
+    })
+
+    it('auto-wires aria-labelledby to Dialog.Title', () => {
+      renderOpen()
+      const dialog = screen.getByRole('dialog')
+      const heading = screen.getByRole('heading', { name: 'Title' })
+      expect(dialog).toHaveAttribute('aria-labelledby', heading.id)
+      expect(heading.id).toBeTruthy()
+    })
+
+    it('respects an explicit aria-labelledby on Dialog', () => {
+      render(
+        <Dialog open aria-labelledby="explicit-id">
+          <Dialog.Header>
+            <Dialog.Title id="explicit-id">Title</Dialog.Title>
+          </Dialog.Header>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog')).toHaveAttribute(
+        'aria-labelledby',
+        'explicit-id',
+      )
+    })
+
+    it('uses aria-label without setting aria-labelledby', () => {
+      render(
+        <Dialog open aria-label="Confirmation">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveAttribute('aria-label', 'Confirmation')
+      expect(dialog).not.toHaveAttribute('aria-labelledby')
     })
   })
 })

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.test.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+import { Dialog } from '.'
+import { Button } from '../Button'
+
+// JSDOM doesn't implement HTMLDialogElement.showModal / .close — patch them
+// onto the prototype so the useEffect open/close sync can be observed via the
+// DOM. Safe to overwrite unconditionally in the test environment.
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal(
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '')
+  }
+  HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+    this.removeAttribute('open')
+    this.dispatchEvent(new Event('close'))
+  }
+})
+
+const renderOpen = (onOpenChange: (open: boolean) => void = () => {}) =>
+  render(
+    <Dialog open onOpenChange={onOpenChange} aria-labelledby="t">
+      <Dialog.Header onClose={() => onOpenChange(false)}>
+        <Dialog.Title id="t">Title</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Content>Content</Dialog.Content>
+      <Dialog.Actions>
+        <Button>OK</Button>
+      </Dialog.Actions>
+    </Dialog>,
+  )
+
+describe('Dialog (next)', () => {
+  describe('Rendering', () => {
+    it('renders title, content and actions', () => {
+      renderOpen()
+      expect(screen.getByRole('heading', { name: 'Title' })).toBeInTheDocument()
+      expect(screen.getByText('Content')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'OK' })).toBeInTheDocument()
+    })
+
+    it('renders a <dialog> element with the eds-dialog class', () => {
+      renderOpen()
+      const dialog = screen.getByRole('dialog')
+      expect(dialog.tagName).toBe('DIALOG')
+      expect(dialog).toHaveClass('eds-dialog')
+    })
+
+    it('forwards ref to the dialog element', () => {
+      const ref = { current: null as HTMLDialogElement | null }
+      render(
+        <Dialog open ref={ref} aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(ref.current).toBeInstanceOf(HTMLDialogElement)
+    })
+
+    it('sets data-scrim by default', () => {
+      renderOpen()
+      expect(screen.getByRole('dialog')).toHaveAttribute('data-scrim')
+    })
+
+    it('omits data-scrim when scrim is false', () => {
+      render(
+        <Dialog open scrim={false} aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog')).not.toHaveAttribute('data-scrim')
+    })
+
+    it('omits the close button when onClose is not provided', () => {
+      render(
+        <Dialog open aria-label="d">
+          <Dialog.Header>
+            <Dialog.Title>Title</Dialog.Title>
+          </Dialog.Header>
+        </Dialog>,
+      )
+      expect(
+        screen.queryByRole('button', { name: 'Close' }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Open state', () => {
+    it('opens when the open prop becomes true', () => {
+      const { rerender } = render(
+        <Dialog open={false} aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog', { hidden: true })).not.toHaveAttribute(
+        'open',
+      )
+
+      rerender(
+        <Dialog open aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog')).toHaveAttribute('open')
+    })
+
+    it('closes when the open prop becomes false', () => {
+      const { rerender } = render(
+        <Dialog open aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog')).toHaveAttribute('open')
+
+      rerender(
+        <Dialog open={false} aria-label="d">
+          <Dialog.Content>x</Dialog.Content>
+        </Dialog>,
+      )
+      expect(screen.getByRole('dialog', { hidden: true })).not.toHaveAttribute(
+        'open',
+      )
+    })
+  })
+
+  describe('Closing', () => {
+    it('invokes onOpenChange(false) when the close button is clicked', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = jest.fn()
+      renderOpen(onOpenChange)
+      await user.click(screen.getByRole('button', { name: 'Close' }))
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('invokes onOpenChange(false) on backdrop click', () => {
+      const onOpenChange = jest.fn()
+      renderOpen(onOpenChange)
+      // A click whose target IS the dialog element comes from the backdrop —
+      // children stop event.target from being the dialog itself.
+      fireEvent.click(screen.getByRole('dialog'))
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('does not invoke onOpenChange when clicking dialog children', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = jest.fn()
+      renderOpen(onOpenChange)
+      await user.click(screen.getByText('Content'))
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
+    it('invokes onOpenChange(false) on the native close event', () => {
+      const onOpenChange = jest.fn()
+      const Controlled = () => {
+        const [open, setOpen] = useState(true)
+        return (
+          <Dialog
+            open={open}
+            onOpenChange={(next) => {
+              onOpenChange(next)
+              setOpen(next)
+            }}
+            aria-label="d"
+          >
+            <Dialog.Content>x</Dialog.Content>
+          </Dialog>
+        )
+      }
+      render(<Controlled />)
+      const dialog = screen.getByRole('dialog')
+      // ESC triggers the dialog's close() in browsers; simulate by firing
+      // the close event directly (our patched close() does the same).
+      fireEvent(dialog, new Event('close'))
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has no violations when open with aria-labelledby', async () => {
+      const { container } = renderOpen()
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('exposes the title as an h2 heading', () => {
+      renderOpen()
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'Title' }),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
@@ -66,11 +66,14 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
     }
   }, [open])
 
-  const setRef = (node: HTMLDialogElement | null) => {
-    dialogRef.current = node
-    if (typeof ref === 'function') ref(node)
-    else if (ref) ref.current = node
-  }
+  const setRef = useCallback(
+    (node: HTMLDialogElement | null) => {
+      dialogRef.current = node
+      if (typeof ref === 'function') ref(node)
+      else if (ref) ref.current = node
+    },
+    [ref],
+  )
 
   const handleClose = () => {
     if (expectedCloseRef.current) {
@@ -137,10 +140,7 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
 DialogRoot.displayName = 'Dialog'
 
 const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
-  function DialogHeader(
-    { closable = true, children, className, ...rest },
-    ref,
-  ) {
+  function DialogHeader({ children, className, ...rest }, ref) {
     const ctx = useContext(DialogContext)
     return (
       <div
@@ -149,19 +149,17 @@ const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
         {...rest}
       >
         <div className="title-container">{children}</div>
-        {closable && (
-          <Button
-            type="button"
-            variant="ghost"
-            tone="accent"
-            icon
-            round
-            onClick={() => ctx?.close()}
-            aria-label="Close"
-          >
-            <Icon data={closeIcon} />
-          </Button>
-        )}
+        <Button
+          type="button"
+          variant="ghost"
+          tone="accent"
+          icon
+          round
+          onClick={() => ctx?.close()}
+          aria-label="Close"
+        >
+          <Icon data={closeIcon} />
+        </Button>
       </div>
     )
   },

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
@@ -1,0 +1,145 @@
+import { forwardRef, useEffect, useRef, type MouseEvent } from 'react'
+import { close as closeIcon } from '@equinor/eds-icons'
+import { Button } from '../Button'
+import { Icon } from '../Icon'
+import type {
+  DialogActionsProps,
+  DialogContentProps,
+  DialogHeaderProps,
+  DialogProps,
+  DialogTitleProps,
+} from './Dialog.types'
+
+const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
+  { open, onOpenChange, scrim = true, className, children, ...rest },
+  ref,
+) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (open && !dialog.open) dialog.showModal()
+    else if (!open && dialog.open) dialog.close()
+  }, [open])
+
+  const setRef = (node: HTMLDialogElement | null) => {
+    dialogRef.current = node
+    if (typeof ref === 'function') ref(node)
+    else if (ref) ref.current = node
+  }
+
+  const handleClose = () => onOpenChange?.(false)
+
+  // The native <dialog> reports the dialog itself as the click target when the
+  // backdrop (the ::backdrop pseudo) is clicked. Children dispatch from their
+  // own elements, so checking target === dialog isolates backdrop clicks.
+  const handleClick = (event: MouseEvent<HTMLDialogElement>) => {
+    if (event.target === dialogRef.current) onOpenChange?.(false)
+  }
+
+  return (
+    // Native <dialog> doesn't expose ::backdrop as a separately clickable
+    // element; a click whose target is the dialog itself comes from the
+    // backdrop. Keyboard dismissal (Escape) is handled by the native dialog
+    // and emits the `close` event we already wire up — no extra key handler.
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+    <dialog
+      ref={setRef}
+      className={['eds-dialog', className].filter(Boolean).join(' ')}
+      data-scrim={scrim ? '' : undefined}
+      onClose={handleClose}
+      onClick={handleClick}
+      {...rest}
+    >
+      {children}
+    </dialog>
+  )
+})
+DialogRoot.displayName = 'Dialog'
+
+const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
+  function DialogHeader({ onClose, children, className, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={['header', className].filter(Boolean).join(' ')}
+        {...rest}
+      >
+        <div className="title-container">{children}</div>
+        {onClose && (
+          <Button
+            type="button"
+            variant="ghost"
+            tone="accent"
+            icon
+            round
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <Icon data={closeIcon} />
+          </Button>
+        )}
+      </div>
+    )
+  },
+)
+DialogHeader.displayName = 'Dialog.Header'
+
+const DialogTitle = forwardRef<HTMLHeadingElement, DialogTitleProps>(
+  function DialogTitle({ className, children, ...rest }, ref) {
+    return (
+      <h2
+        ref={ref}
+        className={['title', className].filter(Boolean).join(' ')}
+        {...rest}
+      >
+        {children}
+      </h2>
+    )
+  },
+)
+DialogTitle.displayName = 'Dialog.Title'
+
+const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
+  function DialogContent({ className, children, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={['content', className].filter(Boolean).join(' ')}
+        {...rest}
+      >
+        {children}
+      </div>
+    )
+  },
+)
+DialogContent.displayName = 'Dialog.Content'
+
+const DialogActions = forwardRef<HTMLDivElement, DialogActionsProps>(
+  function DialogActions({ className, children, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={['actions', className].filter(Boolean).join(' ')}
+        {...rest}
+      >
+        {children}
+      </div>
+    )
+  },
+)
+DialogActions.displayName = 'Dialog.Actions'
+
+type CompoundDialog = typeof DialogRoot & {
+  Header: typeof DialogHeader
+  Title: typeof DialogTitle
+  Content: typeof DialogContent
+  Actions: typeof DialogActions
+}
+
+export const Dialog = DialogRoot as CompoundDialog
+Dialog.Header = DialogHeader
+Dialog.Title = DialogTitle
+Dialog.Content = DialogContent
+Dialog.Actions = DialogActions

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
@@ -1,10 +1,13 @@
 import {
   createContext,
   forwardRef,
+  useCallback,
   useContext,
   useEffect,
   useId,
+  useMemo,
   useRef,
+  useState,
   type MouseEvent,
 } from 'react'
 import { close as closeIcon } from '@equinor/eds-icons'
@@ -18,7 +21,13 @@ import type {
   DialogTitleProps,
 } from './Dialog.types'
 
-const DialogContext = createContext<{ titleId: string } | null>(null)
+type DialogContextValue = {
+  titleId: string | undefined
+  registerTitle: (id: string) => () => void
+  close: () => void
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null)
 
 const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
   {
@@ -34,13 +43,27 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
   ref,
 ) {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  const titleId = useId()
+  // Suppresses the onOpenChange call fired by the native `close` event when
+  // we close the dialog in response to a consumer flipping `open` to false.
+  // Without this, the consumer's setter would be called once externally and
+  // once from handleClose — see review thread on PR #4956.
+  const expectedCloseRef = useRef(false)
+  // Records whether the mousedown that started a click landed on the dialog
+  // element itself. Click fires on the common ancestor of mousedown/up, so a
+  // text-selection drag that overshoots into the backdrop would otherwise be
+  // mistaken for a backdrop click and close the dialog.
+  const mouseDownOnDialogRef = useRef(false)
+  const [titleId, setTitleId] = useState<string | undefined>(undefined)
 
   useEffect(() => {
     const dialog = dialogRef.current
     if (!dialog) return
-    if (open && !dialog.open) dialog.showModal()
-    else if (!open && dialog.open) dialog.close()
+    if (open && !dialog.open) {
+      dialog.showModal()
+    } else if (!open && dialog.open) {
+      expectedCloseRef.current = true
+      dialog.close()
+    }
   }, [open])
 
   const setRef = (node: HTMLDialogElement | null) => {
@@ -49,23 +72,46 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
     else if (ref) ref.current = node
   }
 
-  const handleClose = () => onOpenChange?.(false)
-
-  // The native <dialog> reports the dialog itself as the click target when the
-  // backdrop (the ::backdrop pseudo) is clicked. Children dispatch from their
-  // own elements, so checking target === dialog isolates backdrop clicks.
-  const handleClick = (event: MouseEvent<HTMLDialogElement>) => {
-    if (event.target === dialogRef.current) onOpenChange?.(false)
+  const handleClose = () => {
+    if (expectedCloseRef.current) {
+      expectedCloseRef.current = false
+      return
+    }
+    onOpenChange?.(false)
   }
 
-  // Default aria-labelledby to the auto-generated title id so Dialog.Title is
-  // wired up without consumer boilerplate. Consumer can override with an
-  // explicit aria-labelledby or aria-label.
+  const handleMouseDown = (event: MouseEvent<HTMLDialogElement>) => {
+    mouseDownOnDialogRef.current = event.target === dialogRef.current
+  }
+
+  // Native <dialog> reports the dialog itself as the click target when the
+  // backdrop is clicked; children dispatch from their own elements. The
+  // additional mousedown check guards against drag-out from a selection.
+  const handleClick = (event: MouseEvent<HTMLDialogElement>) => {
+    const wasOnBackdrop =
+      event.target === dialogRef.current && mouseDownOnDialogRef.current
+    mouseDownOnDialogRef.current = false
+    if (wasOnBackdrop) dialogRef.current?.close()
+  }
+
+  const close = useCallback(() => dialogRef.current?.close(), [])
+  const registerTitle = useCallback((id: string) => {
+    setTitleId(id)
+    return () => setTitleId((current) => (current === id ? undefined : current))
+  }, [])
+
+  const ctxValue = useMemo<DialogContextValue>(
+    () => ({ titleId, registerTitle, close }),
+    [titleId, registerTitle, close],
+  )
+
+  // aria-labelledby resolves to the registered title id when a Dialog.Title is
+  // present. Explicit aria-labelledby or aria-label on Dialog still wins.
   const resolvedAriaLabelledBy =
     ariaLabelledBy ?? (ariaLabel ? undefined : titleId)
 
   return (
-    <DialogContext.Provider value={{ titleId }}>
+    <DialogContext.Provider value={ctxValue}>
       {/* Native <dialog> doesn't expose ::backdrop as a separately clickable
           element; a click whose target is the dialog itself comes from the
           backdrop. Keyboard dismissal (Escape) is handled by the native
@@ -79,6 +125,7 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
         aria-labelledby={resolvedAriaLabelledBy}
         aria-label={ariaLabel}
         onClose={handleClose}
+        onMouseDown={handleMouseDown}
         onClick={handleClick}
         {...rest}
       >
@@ -90,7 +137,8 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
 DialogRoot.displayName = 'Dialog'
 
 const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
-  function DialogHeader({ onClose, children, className, ...rest }, ref) {
+  function DialogHeader({ closable, children, className, ...rest }, ref) {
+    const ctx = useContext(DialogContext)
     return (
       <div
         ref={ref}
@@ -98,14 +146,14 @@ const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
         {...rest}
       >
         <div className="title-container">{children}</div>
-        {onClose && (
+        {closable && (
           <Button
             type="button"
             variant="ghost"
             tone="accent"
             icon
             round
-            onClick={onClose}
+            onClick={() => ctx?.close()}
             aria-label="Close"
           >
             <Icon data={closeIcon} />
@@ -120,10 +168,18 @@ DialogHeader.displayName = 'Dialog.Header'
 const DialogTitle = forwardRef<HTMLHeadingElement, DialogTitleProps>(
   function DialogTitle({ id, className, children, ...rest }, ref) {
     const ctx = useContext(DialogContext)
+    const generatedId = useId()
+    const resolvedId = id ?? generatedId
+
+    useEffect(() => {
+      if (!ctx) return
+      return ctx.registerTitle(resolvedId)
+    }, [ctx, resolvedId])
+
     return (
       <h2
         ref={ref}
-        id={id ?? ctx?.titleId}
+        id={resolvedId}
         className={['title', className].filter(Boolean).join(' ')}
         {...rest}
       >

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
@@ -137,7 +137,10 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
 DialogRoot.displayName = 'Dialog'
 
 const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
-  function DialogHeader({ closable, children, className, ...rest }, ref) {
+  function DialogHeader(
+    { closable = true, children, className, ...rest },
+    ref,
+  ) {
     const ctx = useContext(DialogContext)
     return (
       <div

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useEffect, useRef, type MouseEvent } from 'react'
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  type MouseEvent,
+} from 'react'
 import { close as closeIcon } from '@equinor/eds-icons'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
@@ -10,11 +18,23 @@ import type {
   DialogTitleProps,
 } from './Dialog.types'
 
+const DialogContext = createContext<{ titleId: string } | null>(null)
+
 const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
-  { open, onOpenChange, scrim = true, className, children, ...rest },
+  {
+    open,
+    onOpenChange,
+    scrim = true,
+    className,
+    children,
+    'aria-labelledby': ariaLabelledBy,
+    'aria-label': ariaLabel,
+    ...rest
+  },
   ref,
 ) {
   const dialogRef = useRef<HTMLDialogElement | null>(null)
+  const titleId = useId()
 
   useEffect(() => {
     const dialog = dialogRef.current
@@ -38,22 +58,33 @@ const DialogRoot = forwardRef<HTMLDialogElement, DialogProps>(function Dialog(
     if (event.target === dialogRef.current) onOpenChange?.(false)
   }
 
+  // Default aria-labelledby to the auto-generated title id so Dialog.Title is
+  // wired up without consumer boilerplate. Consumer can override with an
+  // explicit aria-labelledby or aria-label.
+  const resolvedAriaLabelledBy =
+    ariaLabelledBy ?? (ariaLabel ? undefined : titleId)
+
   return (
-    // Native <dialog> doesn't expose ::backdrop as a separately clickable
-    // element; a click whose target is the dialog itself comes from the
-    // backdrop. Keyboard dismissal (Escape) is handled by the native dialog
-    // and emits the `close` event we already wire up — no extra key handler.
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-    <dialog
-      ref={setRef}
-      className={['eds-dialog', className].filter(Boolean).join(' ')}
-      data-scrim={scrim ? '' : undefined}
-      onClose={handleClose}
-      onClick={handleClick}
-      {...rest}
-    >
-      {children}
-    </dialog>
+    <DialogContext.Provider value={{ titleId }}>
+      {/* Native <dialog> doesn't expose ::backdrop as a separately clickable
+          element; a click whose target is the dialog itself comes from the
+          backdrop. Keyboard dismissal (Escape) is handled by the native
+          dialog and emits the `close` event we already wire up — no extra
+          key handler. */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+      <dialog
+        ref={setRef}
+        className={['eds-dialog', className].filter(Boolean).join(' ')}
+        data-scrim={scrim || undefined}
+        aria-labelledby={resolvedAriaLabelledBy}
+        aria-label={ariaLabel}
+        onClose={handleClose}
+        onClick={handleClick}
+        {...rest}
+      >
+        {children}
+      </dialog>
+    </DialogContext.Provider>
   )
 })
 DialogRoot.displayName = 'Dialog'
@@ -87,10 +118,12 @@ const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
 DialogHeader.displayName = 'Dialog.Header'
 
 const DialogTitle = forwardRef<HTMLHeadingElement, DialogTitleProps>(
-  function DialogTitle({ className, children, ...rest }, ref) {
+  function DialogTitle({ id, className, children, ...rest }, ref) {
+    const ctx = useContext(DialogContext)
     return (
       <h2
         ref={ref}
+        id={id ?? ctx?.titleId}
         className={['title', className].filter(Boolean).join(' ')}
         {...rest}
       >

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
@@ -21,10 +21,12 @@ export type DialogProps = {
 
 export type DialogHeaderProps = {
   /**
-   * When provided, renders a close icon button at the end of the header
-   * that invokes this handler. Omit to render the header without a close button.
+   * When true, renders a close icon button at the end of the header that
+   * closes the dialog (firing the parent `Dialog`'s `onOpenChange(false)`
+   * exactly once). Defaults to `false` — omit the prop to render a header
+   * without a close affordance.
    */
-  onClose?: () => void
+  closable?: boolean
   children?: ReactNode
 } & HTMLAttributes<HTMLDivElement>
 

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
@@ -8,9 +8,10 @@ export type DialogProps = {
   open: boolean
   /**
    * Called when the dialog requests to close — via Escape key, backdrop click,
-   * or any consumer-rendered close trigger. Update your `open` state in response.
+   * or the header close button. Update your `open` state in response; the
+   * component is fully controlled.
    */
-  onOpenChange?: (open: boolean) => void
+  onOpenChange: (open: boolean) => void
   /**
    * Whether to render a visible backdrop (scrim) behind the dialog.
    * Defaults to true. Set to false for transparent backdrops.
@@ -20,14 +21,6 @@ export type DialogProps = {
 } & Omit<DialogHTMLAttributes<HTMLDialogElement>, 'open' | 'onClose'>
 
 export type DialogHeaderProps = {
-  /**
-   * Renders a close icon button at the end of the header that closes the
-   * dialog (firing the parent `Dialog`'s `onOpenChange(false)` exactly once).
-   * Set to `false` for decision-forcing dialogs where the user must pick an
-   * action.
-   * @default true
-   */
-  closable?: boolean
   children?: ReactNode
 } & HTMLAttributes<HTMLDivElement>
 

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
@@ -28,8 +28,19 @@ export type DialogHeaderProps = {
   children?: ReactNode
 } & HTMLAttributes<HTMLDivElement>
 
+/**
+ * The dialog title. Defaults to an `<h2>`. If `id` is omitted, an id is
+ * auto-generated and wired up to the parent `Dialog`'s `aria-labelledby`,
+ * so the dialog is correctly labelled without consumer boilerplate.
+ */
 export type DialogTitleProps = HTMLAttributes<HTMLHeadingElement>
 
+/**
+ * The dialog's main content region. Children are laid out in a vertical
+ * stack with consistent spacing — wrap mixed inline/block content in a
+ * block-level element (e.g. `<p>`) to avoid each inline becoming its own row.
+ */
 export type DialogContentProps = HTMLAttributes<HTMLDivElement>
 
+/** The dialog's action row, right-aligned, intended for Button children. */
 export type DialogActionsProps = HTMLAttributes<HTMLDivElement>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
@@ -1,0 +1,35 @@
+import type { DialogHTMLAttributes, HTMLAttributes, ReactNode } from 'react'
+
+export type DialogProps = {
+  /**
+   * Controlled open state. When true, the dialog is shown via the native
+   * `HTMLDialogElement.showModal()` (modal mode: focus trap + inert background).
+   */
+  open: boolean
+  /**
+   * Called when the dialog requests to close — via Escape key, backdrop click,
+   * or any consumer-rendered close trigger. Update your `open` state in response.
+   */
+  onOpenChange?: (open: boolean) => void
+  /**
+   * Whether to render a visible backdrop (scrim) behind the dialog.
+   * Defaults to true. Set to false for transparent backdrops.
+   * @default true
+   */
+  scrim?: boolean
+} & Omit<DialogHTMLAttributes<HTMLDialogElement>, 'open' | 'onClose'>
+
+export type DialogHeaderProps = {
+  /**
+   * When provided, renders a close icon button at the end of the header
+   * that invokes this handler. Omit to render the header without a close button.
+   */
+  onClose?: () => void
+  children?: ReactNode
+} & HTMLAttributes<HTMLDivElement>
+
+export type DialogTitleProps = HTMLAttributes<HTMLHeadingElement>
+
+export type DialogContentProps = HTMLAttributes<HTMLDivElement>
+
+export type DialogActionsProps = HTMLAttributes<HTMLDivElement>

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.types.ts
@@ -21,10 +21,11 @@ export type DialogProps = {
 
 export type DialogHeaderProps = {
   /**
-   * When true, renders a close icon button at the end of the header that
-   * closes the dialog (firing the parent `Dialog`'s `onOpenChange(false)`
-   * exactly once). Defaults to `false` — omit the prop to render a header
-   * without a close affordance.
+   * Renders a close icon button at the end of the header that closes the
+   * dialog (firing the parent `Dialog`'s `onOpenChange(false)` exactly once).
+   * Set to `false` for decision-forcing dialogs where the user must pick an
+   * action.
+   * @default true
    */
   closable?: boolean
   children?: ReactNode

--- a/packages/eds-core-react/src/components/next/Dialog/dialog.css
+++ b/packages/eds-core-react/src/components/next/Dialog/dialog.css
@@ -1,0 +1,78 @@
+@layer eds-components {
+  .eds-dialog {
+    --_text-color: var(--eds-color-text-strong);
+    --_section-padding: var(--eds-spacing-vertical-md);
+
+    inline-size: max-content;
+    max-inline-size: min(calc(100vw - 2rem), 32rem);
+    padding: 0;
+    border: none;
+    border-radius: var(--eds-spacing-border-radius-rounded);
+
+    color: var(--_text-color);
+
+    background: var(--eds-color-bg-floating);
+    box-shadow: var(--eds-elevation-low);
+
+    /* TODO: replace the rgba placeholder with `--eds-color-scrim` (or
+       equivalent) once the scrim is specified in Figma. The longer-term plan
+       is a standalone `Scrim` component; until then, the dialog renders its
+       own backdrop via the native `::backdrop` pseudo when `scrim` is true. */
+    &[data-scrim]::backdrop {
+      background: rgb(0 0 0 / 40%);
+    }
+
+    & > .header {
+      display: flex;
+      gap: var(--eds-spacing-horizontal-sm);
+      align-items: center;
+      padding: var(--_section-padding);
+    }
+
+    & > .header > .title-container {
+      display: flex;
+      flex: 1;
+      align-items: center;
+      align-self: stretch;
+    }
+
+    & > .content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--eds-spacing-vertical-md);
+
+      padding: var(--_section-padding);
+
+      font-family: var(--eds-typography-ui-body-font-family);
+      font-size: var(--eds-typography-ui-body-md-font-size);
+      line-height: var(--eds-typography-ui-body-md-line-height-default);
+      color: var(--_text-color);
+    }
+
+    & > .actions {
+      display: flex;
+      gap: var(--eds-spacing-horizontal-sm);
+      align-items: center;
+      justify-content: flex-end;
+
+      padding: var(--_section-padding);
+    }
+
+    & .title {
+      margin: 0;
+
+      font-size: var(--eds-typography-ui-body-lg-font-size);
+      font-weight: var(--eds-typography-ui-body-lg-font-weight);
+      line-height: var(--eds-typography-ui-body-lg-line-height-default);
+      color: var(--_text-color);
+    }
+  }
+}
+
+/* Storybook's preview-head.html applies a `:where(h1-h6) { font-family: Equinor }`
+   reset *outside* any @layer. Layered styles always lose to unlayered styles
+   regardless of specificity, so we set the title font-family outside the layer
+   to win the cascade. Inter is what the Figma design specifies for this size. */
+.eds-dialog .title {
+  font-family: var(--eds-typography-ui-body-font-family);
+}

--- a/packages/eds-core-react/src/components/next/Dialog/dialog.css
+++ b/packages/eds-core-react/src/components/next/Dialog/dialog.css
@@ -76,7 +76,7 @@
 
       font-family: var(--eds-typography-ui-body-font-family);
       font-size: var(--eds-typography-ui-body-lg-font-size);
-      font-weight: var(--eds-typography-ui-body-lg-font-weight);
+      font-weight: var(--eds-typography-ui-body-lg-font-weight-bolder);
       line-height: var(--eds-typography-ui-body-lg-line-height-default);
       color: var(--_text-color);
     }

--- a/packages/eds-core-react/src/components/next/Dialog/dialog.css
+++ b/packages/eds-core-react/src/components/next/Dialog/dialog.css
@@ -3,8 +3,12 @@
     --_text-color: var(--eds-color-text-strong);
     --_section-padding: var(--eds-spacing-vertical-md);
 
-    inline-size: max-content;
-    max-inline-size: min(calc(100vw - 2rem), 32rem);
+    /* TODO: replace 300px with a dialog-min-width token once one exists in
+       @equinor/eds-tokens. Width is otherwise content-driven (native
+       `<dialog>` defaults to fit-content with a UA-stylesheet viewport cap);
+       consumers needing a wider layout — forms, prompts with longer copy —
+       override via `style` or `className`. See the SpecificWidth story. */
+    min-inline-size: 300px;
     padding: 0;
     border: none;
     border-radius: var(--eds-spacing-border-radius-rounded);

--- a/packages/eds-core-react/src/components/next/Dialog/dialog.css
+++ b/packages/eds-core-react/src/components/next/Dialog/dialog.css
@@ -37,7 +37,7 @@
 
     & > .header {
       display: flex;
-      gap: var(--eds-spacing-horizontal-sm);
+      gap: var(--eds-spacing-horizontal-xs);
       align-items: center;
       padding: var(--_section-padding);
     }
@@ -64,7 +64,7 @@
 
     & > .actions {
       display: flex;
-      gap: var(--eds-spacing-horizontal-sm);
+      gap: var(--eds-spacing-horizontal-xs);
       align-items: center;
       justify-content: flex-end;
 

--- a/packages/eds-core-react/src/components/next/Dialog/dialog.css
+++ b/packages/eds-core-react/src/components/next/Dialog/dialog.css
@@ -74,18 +74,11 @@
     & .title {
       margin: 0;
 
+      font-family: var(--eds-typography-ui-body-font-family);
       font-size: var(--eds-typography-ui-body-lg-font-size);
       font-weight: var(--eds-typography-ui-body-lg-font-weight);
       line-height: var(--eds-typography-ui-body-lg-line-height-default);
       color: var(--_text-color);
     }
   }
-}
-
-/* Storybook's preview-head.html applies a `:where(h1-h6) { font-family: Equinor }`
-   reset *outside* any @layer. Layered styles always lose to unlayered styles
-   regardless of specificity, so we set the title font-family outside the layer
-   to win the cascade. Inter is what the Figma design specifies for this size. */
-.eds-dialog .title {
-  font-family: var(--eds-typography-ui-body-font-family);
 }

--- a/packages/eds-core-react/src/components/next/Dialog/dialog.css
+++ b/packages/eds-core-react/src/components/next/Dialog/dialog.css
@@ -18,6 +18,15 @@
     background: var(--eds-color-bg-floating);
     box-shadow: var(--eds-elevation-low);
 
+    /* Chrome's UA stylesheet sets `::backdrop` to `rgba(0 0 0 / 0.1)` by
+       default — explicitly force transparency so `scrim={false}` truly hides
+       the backdrop, letting consumers compose their own (e.g. a standalone
+       Scrim component) without a faint browser-default overlay leaking
+       through. */
+    &::backdrop {
+      background: transparent;
+    }
+
     /* TODO: replace the rgba placeholder with `--eds-color-scrim` (or
        equivalent) once the scrim is specified in Figma. The longer-term plan
        is a standalone `Scrim` component; until then, the dialog renders its

--- a/packages/eds-core-react/src/components/next/Dialog/index.ts
+++ b/packages/eds-core-react/src/components/next/Dialog/index.ts
@@ -1,0 +1,8 @@
+export { Dialog } from './Dialog'
+export type {
+  DialogActionsProps,
+  DialogContentProps,
+  DialogHeaderProps,
+  DialogProps,
+  DialogTitleProps,
+} from './Dialog.types'

--- a/packages/eds-core-react/src/components/next/index.css
+++ b/packages/eds-core-react/src/components/next/index.css
@@ -39,4 +39,5 @@
 @import './Autocomplete/autocomplete.css';
 @import './Select/select.css';
 @import './Badge/badge.css';
+@import './Dialog/dialog.css';
 

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -85,3 +85,12 @@ export type {
   BadgeEmphasis,
   BadgeVariant,
 } from './Badge'
+
+export { Dialog } from './Dialog'
+export type {
+  DialogActionsProps,
+  DialogContentProps,
+  DialogHeaderProps,
+  DialogProps,
+  DialogTitleProps,
+} from './Dialog'


### PR DESCRIPTION
## Summary

- Native `<dialog>`-based modal with compound API: `Dialog.Header`, `Dialog.Title`, `Dialog.Content`, `Dialog.Actions`.
- Fully controlled via `open` + `onOpenChange` (both required). Closes on Escape (native), backdrop click, and the header's close button (always rendered).
- **Single close path:** all close interactions (close button, backdrop, Escape, consumer flipping `open`) converge on the native `close` event, so `onOpenChange(false)` fires exactly once per close.
- **Auto-wired accessibility:** `Dialog.Title` registers its id with `Dialog` via context, and `aria-labelledby` defaults to it — no manual id boilerplate. When no title is rendered (and no `aria-label` is set), `aria-labelledby` is omitted to avoid dangling references.
- **Safer backdrop:** click only closes when both the `mousedown` and `click` target the dialog itself, so a text-selection drag that overshoots into the backdrop doesn't dismiss the dialog.
- **Width:** content-driven with a 300px minimum (per designer); consumers can set a larger `inlineSize` via `style` or `className` for forms or longer copy.
- **Scrim:** `scrim` prop (default `true`) toggles backdrop visibility via `data-scrim`. The `::backdrop` pseudo is forced transparent when `scrim={false}` so Chrome's UA-default 10% overlay doesn't bleed through. Backdrop colour is a placeholder pending Figma spec and a future standalone Scrim component — see TODO in `dialog.css`.
- Built on `--eds-color-bg-floating`, `--eds-elevation-low`, `--eds-spacing-border-radius-rounded`, `--eds-color-text-strong`, and the `ui-body-lg` / `ui-body-md` typography tokens.

Implemented from [Figma — Dialog](https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/%F0%9F%94%B9-EDS-Core-Components?node-id=6458-14664&m=dev). The Figma component set has three variants — Dialog (standard), Danger, and Passive — plus a "Has Close Icon" property. Danger is achieved via Button `tone="danger"` (see DangerAction story). Passive (no action row) is achieved by omitting `Dialog.Actions`. The close icon is always rendered in `Dialog.Header`; the Escape key, backdrop click, and close button all close the dialog per WAI-ARIA APG.

Two hardcoded values remain in `dialog.css`, both flagged with TODOs and bound to designer-confirmed specs:
- `300px` min-width — pending dialog-sizing token
- `rgba(0 0 0 / 40%)` backdrop — pending scrim token and standalone Scrim component

## Stories (under `EDS 2.0 (beta) / Feedback / Dialog`)

- **Introduction** — Standard variant with Cancel + Confirm
- **Passive** — No `Dialog.Actions`; dismiss via close icon, Escape, or backdrop (matches Figma's Passive variant)
- **DangerAction** — Destructive action with `tone="danger"` on the primary button
- **SingleAction** — Single acknowledge button (info dialog)
- **WithoutScrim** — `scrim={false}` for transparent backdrop
- **SpecificWidth** — How to override the default width via `style`

## Test plan

- [ ] `pnpm test --testPathPatterns="next/Dialog"` — 25/25 green locally
- [ ] `pnpm run lint ./packages/eds-core-react/src/components/next/Dialog/` — clean
- [ ] Storybook: verify each story above renders against Figma
- [ ] Keyboard: Escape closes the dialog; focus traps inside while open; focus returns to opener on close
- [ ] Backdrop click closes the dialog (only when both mousedown and click target the dialog itself, not its children)
- [ ] Visual comparison against Figma standard variant — title in Inter 16/24, close button 36×36, accent buttons, low elevation shadow

## Follow-ups (not in this PR)

- Bind 300px min-width to a dialog-sizing token once one lands in `@equinor/eds-tokens`
- Bind backdrop colour to a scrim token once the design lands
- Extract a standalone `Scrim` component for non-dialog use cases
- Route component-internal background / box-shadow through \`--_\` pseudo-private vars once a Danger / Passive surface lands (current set covers only \`--_text-color\` and \`--_section-padding\`)