### PR TITLE
fix(eds-core-react): use --eds-elevation-low token in Switch handle

### DIFF
--- a/packages/eds-core-react/src/components/next/Switch/switch.css
+++ b/packages/eds-core-react/src/components/next/Switch/switch.css
@@ -3,12 +3,15 @@
   .eds-switch {
     --_switch-hover-color: var(--eds-color-bg-fill-muted-default);
     --_icon-size: var(--eds-sizing-icon-lg);
+
     /* Track: 22x8px, Handle: 12px (spacious density with 24px icon size) */
     --_handle-size: calc(var(--_icon-size) / 2);
     --_track-width: calc(var(--_icon-size) * 11 / 12);
     --_track-height: calc(var(--_icon-size) / 3);
+
     /* TODO: Replace with semantic token when available */
     --_track-hover-bg: var(--eds-color-neutral-2);
+
     /*
      * Gap compensation for label alignment with Checkbox and Radio.
      * Checkbox/Radio icons have ~3px internal SVG padding, but the Switch
@@ -17,15 +20,19 @@
      */
     --_switch-gap-compensation: 0.1rem;
 
+    cursor: pointer;
+
     position: relative;
+
     gap: calc(
       var(--eds-generic-gap-horizontal) + var(--_switch-gap-compensation)
     );
-    padding-inline: var(--eds-selectable-space-horizontal);
-    padding-block: var(--eds-selectable-space-vertical);
+
     width: auto;
+    padding-block: var(--eds-selectable-space-vertical);
+    padding-inline: var(--eds-selectable-space-horizontal);
     border-radius: var(--eds-spacing-border-radius-rounded);
-    cursor: pointer;
+
     transition: background-color 150ms;
   }
 
@@ -39,28 +46,30 @@
       cursor: not-allowed;
     }
 
-    @media (hover: hover) and (pointer: fine) {
-      &:hover:not([data-disabled='true']) {
-        background-color: var(--_switch-hover-color);
-      }
-    }
-
     & .eds-field__label {
       cursor: pointer;
     }
 
     &[data-disabled='true'] .eds-field__label {
-      color: var(--eds-color-text-disabled);
       cursor: not-allowed;
+      color: var(--eds-color-text-disabled);
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover:not([data-disabled='true']) {
+        background-color: var(--_switch-hover-color);
+      }
     }
   }
 
   .eds-switch__control {
     display: inline-flex;
+    flex-shrink: 0;
     align-items: center;
     justify-content: center;
-    flex-shrink: 0;
+
     min-block-size: var(--_icon-size);
+
     /* Negative margin for alignment with Checkbox/Radio icons */
     margin-block: -6px;
     margin-inline: -1.9px;
@@ -71,12 +80,15 @@
   }
 
   .eds-switch__input {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    margin: 0;
-    appearance: none;
     cursor: pointer;
+
+    position: absolute;
+    z-index: 1;
+    inset: 0;
+
+    margin: 0;
+
+    appearance: none;
 
     &:focus {
       outline: none;
@@ -88,14 +100,19 @@
   }
 
   .eds-switch__track {
+    pointer-events: none;
+
     position: relative;
+
     display: inline-block;
+
     inline-size: var(--_track-width);
     block-size: var(--_track-height);
     border-radius: var(--eds-spacing-border-radius-pill);
+
     background-color: var(--eds-color-bg-fill-muted-default);
+
     transition: background-color 150ms;
-    pointer-events: none;
 
     @media (hover: hover) and (pointer: fine) {
       .eds-switch:hover:not([data-disabled='true']) & {
@@ -105,19 +122,22 @@
   }
 
   .eds-switch__handle {
+    pointer-events: none;
+
     position: absolute;
     inset-block-start: 50%;
     inset-inline-start: 0;
     translate: 0 -50%;
+
     inline-size: var(--_handle-size);
     block-size: var(--_handle-size);
     border-radius: var(--eds-spacing-border-radius-pill);
+
     background-color: var(--eds-color-bg-fill-emphasis-default);
-    box-shadow: var(--eds-elevation-raised);
+
     transition:
       inset-inline-start 150ms,
       background-color 150ms;
-    pointer-events: none;
 
     .eds-switch:has(.eds-switch__input:checked) & {
       inset-inline-start: calc(100% - var(--_handle-size));
@@ -125,7 +145,6 @@
 
     .eds-switch:has(.eds-switch__input:disabled) & {
       background-color: var(--eds-color-bg-disabled);
-      box-shadow: none;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the non-existent `--eds-elevation-raised` token with `--eds-elevation-low` on the Switch handle's `box-shadow`
- The token was never defined in `@equinor/eds-tokens`, so the Switch handle has had no box-shadow since it was introduced in #4387
- Only two elevation tokens exist (`--eds-elevation-low` and `--eds-elevation-high`); `low` is the correct choice for a small thumb/handle element

## Test plan

- [x] Existing Switch tests pass (15/15)
- [ ] Visually verify Switch handle shadow appears in Storybook

Closes #4838