### PR TITLE
fix: replace styled-components Tooltip with next/Tooltip in TextField and TextArea

### DIFF
--- a/packages/eds-core-react/src/components/next/TextArea/TextArea.tsx
+++ b/packages/eds-core-react/src/components/next/TextArea/TextArea.tsx
@@ -5,8 +5,7 @@ import type { TextAreaProps } from './TextArea.types'
 import { Field, useFieldIds } from '../Field'
 import { Input } from '../Input'
 import { Button } from '../Button'
-// TODO: swap to next/Tooltip when available
-import { Tooltip } from '../../Tooltip'
+import { Tooltip } from '../Tooltip'
 import { Icon } from '../Icon'
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(

--- a/packages/eds-core-react/src/components/next/TextArea/textarea.css
+++ b/packages/eds-core-react/src/components/next/TextArea/textarea.css
@@ -2,30 +2,35 @@
   .eds-text-area {
     & .label-row {
       display: flex;
+      gap: var(--eds-typography-gap-horizontal);
       align-items: center;
       justify-content: space-between;
-      gap: var(--eds-typography-gap-horizontal);
+
       inline-size: 100%;
 
-      & > button {
+      & > button,
+      & > .eds-tooltip-anchor {
         flex-shrink: 0;
         margin-block: calc(var(--eds-sizing-icon-xs) / -2);
       }
     }
 
     & .eds-input-container {
+      overflow: hidden;
       align-items: flex-start;
       padding-block: var(--eds-container-space-vertical);
-      overflow: hidden;
 
       & textarea.eds-input {
-        box-sizing: border-box;
-        overflow: auto;
-        white-space: pre-wrap;
-        text-overflow: clip;
         resize: vertical;
+
+        overflow: auto;
+
+        box-sizing: border-box;
         padding-block-end: var(--eds-container-space-vertical);
         padding-inline-end: var(--eds-selectable-space-horizontal);
+
+        text-overflow: clip;
+        white-space: pre-wrap;
       }
 
       &:has(+ .helper-row) {
@@ -37,8 +42,8 @@
 
     & .helper-row {
       display: flex;
-      align-items: baseline;
       gap: var(--eds-typography-gap-horizontal);
+      align-items: baseline;
       inline-size: 100%;
     }
 

--- a/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe'
 import { TextField } from './TextField'
 
 // jsdom does not implement the Popover API (used by next/Tooltip)
+const originalMatches = Element.prototype.matches
 beforeAll(() => {
   HTMLElement.prototype.showPopover = function (this: HTMLElement) {
     this.setAttribute('data-popover-open', '')
@@ -19,6 +20,9 @@ beforeAll(() => {
       return this.hasAttribute('data-popover-open')
     return Element.prototype.matches.call(this, selector)
   }
+})
+afterAll(() => {
+  Element.prototype.matches = originalMatches
 })
 
 describe('TextField (Next EDS 2.0)', () => {

--- a/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
@@ -3,6 +3,20 @@ import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import { TextField } from './TextField'
 
+// jsdom does not implement the Popover API (used by next/Tooltip)
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = function (this: HTMLElement) {
+    this.setAttribute('data-popover-open', '')
+  }
+  HTMLElement.prototype.hidePopover = function (this: HTMLElement) {
+    this.removeAttribute('data-popover-open')
+  }
+  HTMLElement.prototype.matches = function (this: HTMLElement, selector: string) {
+    if (selector === ':popover-open') return this.hasAttribute('data-popover-open')
+    return Element.prototype.matches.call(this, selector)
+  }
+})
+
 describe('TextField (Next EDS 2.0)', () => {
   it('Matches snapshot', () => {
     const { container } = render(

--- a/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
@@ -4,7 +4,6 @@ import { axe } from 'jest-axe'
 import { TextField } from './TextField'
 
 // jsdom does not implement the Popover API (used by next/Tooltip)
-const originalMatches = Element.prototype.matches
 beforeAll(() => {
   HTMLElement.prototype.showPopover = function (this: HTMLElement) {
     this.setAttribute('data-popover-open', '')
@@ -22,7 +21,8 @@ beforeAll(() => {
   }
 })
 afterAll(() => {
-  Element.prototype.matches = originalMatches
+  // Remove the own-property override — prototype chain falls back to Element.prototype.matches
+  Reflect.deleteProperty(HTMLElement.prototype, 'matches')
 })
 
 describe('TextField (Next EDS 2.0)', () => {

--- a/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.test.tsx
@@ -11,8 +11,12 @@ beforeAll(() => {
   HTMLElement.prototype.hidePopover = function (this: HTMLElement) {
     this.removeAttribute('data-popover-open')
   }
-  HTMLElement.prototype.matches = function (this: HTMLElement, selector: string) {
-    if (selector === ':popover-open') return this.hasAttribute('data-popover-open')
+  HTMLElement.prototype.matches = function (
+    this: HTMLElement,
+    selector: string,
+  ) {
+    if (selector === ':popover-open')
+      return this.hasAttribute('data-popover-open')
     return Element.prototype.matches.call(this, selector)
   }
 })

--- a/packages/eds-core-react/src/components/next/TextField/TextField.tsx
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.tsx
@@ -4,7 +4,7 @@ import type { TextFieldProps } from './TextField.types'
 import { Field, useFieldIds } from '../Field'
 import { Input } from '../Input'
 import { Button } from '../Button'
-import { Tooltip } from '../../Tooltip'
+import { Tooltip } from '../Tooltip'
 import { Icon } from '../Icon'
 import './text-field.css'
 

--- a/packages/eds-core-react/src/components/next/TextField/TextField.types.ts
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.types.ts
@@ -5,7 +5,7 @@ export type TextFieldProps = {
   /** Label for the field */
   label?: ReactNode
   /** Info tooltip content shown next to the label */
-  labelInfo?: ReactNode
+  labelInfo?: string
   /** Indicator text shown after label, e.g. "(Required)" or "(Optional)" */
   indicator?: string
   /** Descriptive text that provides additional context for the field */

--- a/packages/eds-core-react/src/components/next/TextField/text-field.css
+++ b/packages/eds-core-react/src/components/next/TextField/text-field.css
@@ -1,14 +1,17 @@
 @layer eds-components {
   .eds-text-field__header {
     display: flex;
+    gap: var(--eds-typography-gap-horizontal);
     align-items: center;
     justify-content: space-between;
-    gap: var(--eds-typography-gap-horizontal);
+
     inline-size: 100%;
   }
 
-  .eds-text-field__info {
+  .eds-text-field__info,
+  .eds-text-field__header > .eds-tooltip-anchor {
     flex-shrink: 0;
+
     /* Negative margin collapses the button's 24px layout contribution to ~8px,
        matching Figma's 8px icon container. Label text-box height determines row height. */
     margin-block: calc(var(--eds-sizing-icon-xs) / -2);

--- a/packages/eds-core-react/src/components/next/TextField/text-field.css
+++ b/packages/eds-core-react/src/components/next/TextField/text-field.css
@@ -8,7 +8,7 @@
     inline-size: 100%;
   }
 
-  .eds-text-field__info,
+  .eds-text-field__header > .eds-text-field__info,
   .eds-text-field__header > .eds-tooltip-anchor {
     flex-shrink: 0;
 


### PR DESCRIPTION
## Summary

- Replaces the `../../Tooltip` (styled-components) import in `TextField` and `TextArea` with `../Tooltip` (next/Tooltip) to remove the styled-components leak
- The next/Tooltip wraps its child in a `<span class="eds-tooltip-anchor">` which becomes the flex item in the label row, bypassing the existing negative-margin fix that kept the row height tight. Updated the CSS in both components to also target the anchor span.

Part of #4978 — the Autocomplete/Progress leak is addressed in #4982.

## Stories to check

- **EDS 2.0 (beta) / Inputs / TextField — With label info**: tooltip should appear on hover/focus of the info button, label row height should match the version without a tooltip
- **EDS 2.0 (beta) / Inputs / TextArea — Full field**: same as above

## Test plan

- [ ] TextField with `labelInfo` shows tooltip on hover/focus with correct label row spacing
- [ ] TextArea with `labelInfo` shows tooltip on hover/focus with correct label row spacing
- [ ] No styled-components import in the next bundle for TextField or TextArea