### PR TITLE
fix(eds-core-react): replace styled-components Progress with spinning icon in Autocomplete

### DIFF
--- a/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.tsx
@@ -12,7 +12,12 @@ import {
   type ReactElement,
   type RefAttributes,
 } from 'react'
-import { search as searchIcon, close, add_box, refresh } from '@equinor/eds-icons'
+import {
+  search as searchIcon,
+  close,
+  add_box,
+  refresh,
+} from '@equinor/eds-icons'
 import type { AutocompleteProps } from './Autocomplete.types'
 import {
   defaultOptionsFilter,

--- a/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.tsx
+++ b/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.tsx
@@ -12,7 +12,7 @@ import {
   type ReactElement,
   type RefAttributes,
 } from 'react'
-import { search as searchIcon, close, add_box } from '@equinor/eds-icons'
+import { search as searchIcon, close, add_box, refresh } from '@equinor/eds-icons'
 import type { AutocompleteProps } from './Autocomplete.types'
 import {
   defaultOptionsFilter,
@@ -25,8 +25,6 @@ import { Input } from '../Input'
 import { Icon } from '../Icon'
 import { Button } from '../Button'
 import { Menu, MenuItem } from '../Menu'
-// TODO: replace with next/Progress when available
-import { Progress } from '../../Progress'
 
 type OptionItem<T> =
   | { type: 'list'; value: T }
@@ -486,7 +484,13 @@ function AutocompleteInner<T = string>(
             startAdornment={<Icon data={searchIcon} className="search-icon" />}
             endAdornment={
               loading ? (
-                <Progress.Circular size={16} />
+                // TODO: replace with next/Progress when available
+                <Icon
+                  data={refresh}
+                  size="xs"
+                  className="loading-icon"
+                  aria-label="Loading"
+                />
               ) : (
                 <Button
                   variant="ghost"

--- a/packages/eds-core-react/src/components/next/Autocomplete/autocomplete.css
+++ b/packages/eds-core-react/src/components/next/Autocomplete/autocomplete.css
@@ -1,5 +1,15 @@
+@keyframes eds-autocomplete-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @layer eds-components {
   .eds-autocomplete {
+    & .loading-icon {
+      animation: eds-autocomplete-spin 1s linear infinite;
+    }
+
     & .anchor {
       anchor-name: var(--menu-anchor);
     }


### PR DESCRIPTION
## Summary

- Removes the `../../Progress` (styled-components) import from `Autocomplete`
- Replaces `<Progress.Circular size={16} />` with a spinning `next/Icon` using the `refresh` icon and a CSS `@keyframes` animation
- A `// TODO` comment marks the spot to swap in a proper `next/Progress` when that component is available

Part of #4978 — the Tooltip leak in TextField/TextArea is addressed in #4981.

## Stories to check

- **EDS 2.0 (beta) / Inputs / Autocomplete — Loading**: spinner icon should appear in the right end of the input and animate
- **EDS 2.0 (beta) / Inputs / Autocomplete — Introduction** (or any non-loading story): clear button and normal behaviour unaffected

> Note: the Async story fetches from `restcountries.com` which blocks requests from `localhost` due to CORS — this is a pre-existing issue unrelated to this PR.

## Test plan

- [ ] Loading story shows a spinning `refresh` icon in the input end adornment
- [ ] Spinner is absent on all non-loading stories
- [ ] No styled-components import in the next bundle for Autocomplete