### PR TITLE
refactor(eds-core-react): migrate Banner.Message and Chip label off TypographyNext

### DIFF
--- a/packages/eds-core-react/src/components/next/Banner/Banner.tsx
+++ b/packages/eds-core-react/src/components/next/Banner/Banner.tsx
@@ -1,6 +1,5 @@
 import { forwardRef } from 'react'
 import { close } from '@equinor/eds-icons'
-import { TypographyNext } from '../../Typography'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
 import type {
@@ -27,19 +26,13 @@ const BannerIcon = forwardRef<HTMLSpanElement, BannerIconProps>(
 const BannerMessage = forwardRef<HTMLParagraphElement, BannerMessageProps>(
   function BannerMessage({ className, children, ...rest }, ref) {
     return (
-      <TypographyNext
+      <p
         ref={ref}
-        as="p"
-        family="ui"
-        size="md"
-        baseline="center"
-        lineHeight="default"
-        tracking="normal"
         className={['eds-banner__message', className].filter(Boolean).join(' ')}
         {...rest}
       >
         {children}
-      </TypographyNext>
+      </p>
     )
   },
 )

--- a/packages/eds-core-react/src/components/next/Banner/banner.css
+++ b/packages/eds-core-react/src/components/next/Banner/banner.css
@@ -36,9 +36,18 @@
 
   .eds-banner__message {
     flex: 1;
+
     min-width: 0;
     margin: 0;
+
+    font-family: var(--eds-typography-ui-body-font-family);
+    font-size: var(--eds-typography-ui-body-md-font-size);
+    line-height: var(--eds-typography-ui-body-md-line-height-default);
     color: var(--eds-color-text-strong);
+
+    @supports (text-box: trim-both cap alphabetic) {
+      text-box: trim-both cap alphabetic;
+    }
   }
 
   .eds-banner__actions {

--- a/packages/eds-core-react/src/components/next/Chip/Chip.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.tsx
@@ -7,7 +7,6 @@ import {
 } from '@equinor/eds-icons'
 import type { ChipProps } from './Chip.types'
 import { Icon } from '../Icon'
-import { TypographyNext } from '../../Typography'
 
 export const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
   {
@@ -51,10 +50,7 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
       className={classes}
       data-variant={variant}
       data-color-appearance={tone}
-      data-font-family="ui"
-      data-font-size="md"
       data-selectable-space="sm"
-      data-space-proportions="squished"
       data-selected={selected || undefined}
       aria-pressed={toggleable ? selected : undefined}
       aria-expanded={dropdown ? selected : undefined}
@@ -65,16 +61,7 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
       {selected && !dropdown && !deletable && (
         <Icon data={check} aria-hidden className="icon" />
       )}
-      <TypographyNext
-        as="span"
-        className="label"
-        family="ui"
-        size="md"
-        lineHeight="squished"
-        baseline="center"
-      >
-        {children}
-      </TypographyNext>
+      <span className="label">{children}</span>
       {deletable && <Icon data={close} title="Remove" className="icon" />}
       {!deletable && dropdown && (
         <Icon

--- a/packages/eds-core-react/src/components/next/Chip/chip.css
+++ b/packages/eds-core-react/src/components/next/Chip/chip.css
@@ -1,9 +1,21 @@
 @layer eds-components {
   .eds-chip {
+    /* Replaces data-space-proportions="squished" — squished vertical spacing for sm selectable space */
+    --eds-spacing-proportions-sm-vertical: var(
+      --eds-spacing-inset-sm-vertical-squished
+    );
+
+    /* Replaces data-font-size="md" — sets icon size and gap tokens for md context */
+    --eds-typography-icon-size: var(--eds-sizing-icon-md);
+    --eds-typography-gap-horizontal: var(--eds-spacing-icon-md-gap-horizontal);
+
     /* Typography metrics — same compensation pattern as Button */
+    --_label-font-size: var(--eds-typography-ui-body-md-font-size);
     --_label-line-height: var(--eds-typography-ui-body-md-line-height-squished);
     --_label-height: round(1cap, 4px); /* Figma has a cap-rounded value but it is not exposed as a CSS token; 1cap gives the same result (Inter metrics + 4px grid) */
+    --_font-family: var(--eds-typography-ui-body-font-family);
     --_padding-block: var(--eds-selectable-space-vertical);
+
     /*
      * Reduce block padding by half the line-height overflow so the visual
      * height equals (padding × 2 + cap-height) instead of (padding × 2 + line-height).
@@ -28,7 +40,9 @@
     border: none;
     border-radius: var(--eds-spacing-border-radius-pill, 100vmax);
 
-    font: inherit;
+    font-family: var(--_font-family);
+    font-size: var(--_label-font-size);
+    line-height: var(--_label-line-height);
     color: inherit;
 
     transition:
@@ -103,15 +117,6 @@
       margin-inline: calc(-1 * var(--_padding-adjusted) / 2);
     }
   }
-}
-
-/*
- * Outside @layer to override typography.css [data-font-family] { display: block }.
- * data-font-family/data-font-size on the chip container establishes the typography
- * context for gap and icon sizing tokens.
- */
-.eds-chip {
-  display: inline-flex;
 }
 
 /*


### PR DESCRIPTION
## Summary

- Removes `TypographyNext` wrapper from `Banner.Message` and `Chip` label, replacing it with direct CSS typography using `--eds-typography-*` tokens
- Part of #4655, follows the pattern established by Button in #4660

### Banner.Message (#4835)
- Renders a plain `<p>` instead of `<TypographyNext as="p">`
- `font-family`, `font-size`, and `line-height` set directly in `banner.css`
- `text-box: trim-both cap alphabetic` applied under `@supports` — matches Figma spec; replaces the old `baseline="center"` which was using the single-line centering formula (`ex alphabetic` + padding) unintentionally on a wrapping paragraph

### Chip (#4836)
- Replaces `<TypographyNext as="span">` with `<span className="label">`
- Removes `data-font-family`, `data-font-size`, and `data-space-proportions` attributes from the button element
- Replaces all three with explicit token overrides in `chip.css`:
  - `--eds-spacing-proportions-sm-vertical` → squished vertical spacing
  - `--eds-typography-icon-size` → md icon size
  - `--eds-typography-gap-horizontal` → md gap
- All tokens are density-aware — no hardcoded values

## Test plan

- [x] Banner and Chip tests pass (72/72)
- [x] Chip visually verified in Storybook — all variants/states match previous
- [x] Chip selected state icon size back to 20×20, gap pixel-perfect
- [x] Banner visually verified across all tones in Storybook — height change (~8px taller) is correct; old `baseline="center"` was applying single-line centering trimming to a wrapping paragraph, Figma confirms `trim-both cap alphabetic` with no extra padding

Closes #4835
Closes #4836