### PR TITLE
chore(eds-core-react): center Button story layout for embedded previews

### DIFF
--- a/packages/eds-core-react/src/components/next/Button/Button.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Button/Button.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<StoryArgs> = {
   title: 'EDS 2.0 (beta)/Inputs/Button',
   component: Button,
   parameters: {
+    layout: 'centered',
     docs: {
       page,
       source: {


### PR DESCRIPTION
## What

Sets `layout: 'centered'` on the `next/Button` Storybook meta so the component sits centred in the canvas.

## Why

The 2.0.0-beta docs site (#4989) embeds these stories as fixed-height iframes; centring makes the single-component previews sit neatly instead of hugging the top-left corner. Purely a Storybook-canvas presentation tweak.

## Scope

- `packages/eds-core-react/src/components/next/Button/Button.stories.tsx` (one line)

No runtime, bundle, or `package.json` changes. Independent of #4989 — can merge in any order.

> Note: this PR previously also added `/next` subpath exports to `package.json`. That was dropped — see #4989, which resolves `/next` via a docs-side webpack alias so #4395's beta-only export behaviour is preserved.