### PR TITLE
chore(deps): bump shell-quote to >=1.8.4 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
       "js-yaml": ">=4.1.1",
       "gray-matter>js-yaml": "^3.14.1",
       "lodash": ">=4.18.0",
-      "webpackbar": "^7.0.0"
+      "webpackbar": "^7.0.0",
+      "shell-quote": ">=1.8.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   gray-matter>js-yaml: ^3.14.1
   lodash: '>=4.18.0'
   webpackbar: ^7.0.0
+  shell-quote: '>=1.8.4'
 
 importers:
 
@@ -11375,10 +11376,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
 
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
@@ -23307,7 +23304,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   leven@3.1.0: {}
 
@@ -26710,8 +26707,6 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shell-quote@1.8.3: {}
 
   shell-quote@1.8.4: {}
 


### PR DESCRIPTION
## Summary

- Adds a `pnpm.overrides` entry to force `shell-quote` to `>=1.8.4`
- Resolves Dependabot alert [#474](https://github.com/equinor/design-system/security/dependabot/474) (critical severity)

**Vulnerability:** `shell-quote`'s `quote()` did not escape newlines in object `.op` values, allowing shell command injection. Fixed in `1.8.4`.

**Affected path:** `@docusaurus/core` → `webpack-dev-server` → `launch-editor@2.13.2` → `shell-quote@1.8.3` (dev-only dependency)

## Test plan

- [ ] `pnpm install` completes without errors
- [ ] `grep "shell-quote" pnpm-lock.yaml` shows `1.8.4`