### PR TITLE
feat: Badge EDS 2.0

### DIFF
--- a/packages/eds-core-react/src/components/next/Badge/Badge.figma.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.figma.tsx
@@ -1,0 +1,33 @@
+import figma from '@figma/code-connect'
+import { Badge } from '.'
+
+figma.connect(
+  Badge,
+  'https://www.figma.com/design/dz0XQdc5j7AAtjXr1gTfVR/%F0%9F%94%B9-EDS-Core-Components?node-id=4120-931',
+  {
+    props: {
+      tone: figma.enum('Tone', {
+        Neutral: 'neutral',
+        Accent: 'accent',
+        Success: 'success',
+        Info: 'info',
+        Warning: 'warning',
+        Error: 'danger',
+      }),
+      emphasis: figma.enum('Emphasis', {
+        Low: 'low',
+        Medium: 'medium',
+      }),
+      variant: figma.enum('Style', {
+        Solid: 'solid',
+        Outlined: 'outlined',
+      }),
+      children: figma.string('Text'),
+    },
+    example: ({ tone, emphasis, variant, children }) => (
+      <Badge tone={tone} emphasis={emphasis} variant={variant}>
+        {children}
+      </Badge>
+    ),
+  },
+)

--- a/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryFn } from '@storybook/react-vite'
+import { Badge, type BadgeProps } from '.'
+
+const meta: Meta<typeof Badge> = {
+  title: 'EDS 2.0 (beta)/Data Display/Badge',
+  component: Badge,
+  tags: ['beta'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+⚠️ **Beta Component** — this component is under active development.
+
+\`\`\`tsx
+import { Badge } from '@equinor/eds-core-react/next'
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    tone: {
+      control: 'select',
+      options: ['neutral', 'accent', 'success', 'info', 'warning', 'danger'],
+    },
+    emphasis: {
+      control: 'select',
+      options: ['low', 'medium'],
+    },
+    variant: {
+      control: 'select',
+      options: ['solid', 'outlined'],
+    },
+  },
+}
+
+export default meta
+
+export const Introduction: StoryFn<BadgeProps> = (args) => {
+  return <Badge {...args}>Label</Badge>
+}
+
+Introduction.args = {
+  tone: 'neutral',
+  emphasis: 'low',
+  variant: 'solid',
+}
+
+export const Tones: StoryFn<BadgeProps> = () => (
+  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+    <Badge tone="neutral">Neutral</Badge>
+    <Badge tone="accent">Accent</Badge>
+    <Badge tone="success">Success</Badge>
+    <Badge tone="info">Info</Badge>
+    <Badge tone="warning">Warning</Badge>
+    <Badge tone="danger">Danger</Badge>
+  </div>
+)
+
+export const Emphasis: StoryFn<BadgeProps> = () => (
+  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+    <Badge tone="accent" emphasis="low">
+      Low
+    </Badge>
+    <Badge tone="accent" emphasis="medium">
+      Medium
+    </Badge>
+  </div>
+)
+
+export const Variants: StoryFn<BadgeProps> = () => (
+  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+    <Badge tone="accent" variant="solid">
+      Solid
+    </Badge>
+    <Badge tone="accent" variant="outlined">
+      Outlined
+    </Badge>
+  </div>
+)
+
+export const AllCombinations: StoryFn<BadgeProps> = () => {
+  const tones = [
+    'neutral',
+    'accent',
+    'success',
+    'info',
+    'warning',
+    'danger',
+  ] as const
+  const emphases = ['low', 'medium'] as const
+  const variants = ['solid', 'outlined'] as const
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      {emphases.map((emphasis) =>
+        variants.map((variant) => (
+          <div
+            key={`${emphasis}-${variant}`}
+            style={{ display: 'flex', gap: '8px', alignItems: 'center' }}
+          >
+            <span style={{ fontSize: '12px', width: '120px', flexShrink: 0 }}>
+              {emphasis} / {variant}
+            </span>
+            {tones.map((tone) => (
+              <Badge
+                key={tone}
+                tone={tone}
+                emphasis={emphasis}
+                variant={variant}
+              >
+                Label
+              </Badge>
+            ))}
+          </div>
+        )),
+      )}
+    </div>
+  )
+}

--- a/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
@@ -351,6 +351,55 @@ MultipleLabels.parameters = {
   },
 }
 
+export const Density: StoryFn<BadgeProps> = () => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '24px',
+      fontFamily: 'var(--eds-typography-ui-body-font-family)',
+    }}
+  >
+    <div data-density="spacious">
+      <p style={{ margin: '0 0 8px', fontWeight: 600, fontSize: '14px' }}>
+        Spacious (default)
+      </p>
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+        <Badge tone="neutral">Draft</Badge>
+        <Badge tone="success">Active</Badge>
+        <Badge tone="warning">Pending</Badge>
+        <Badge tone="danger" emphasis="medium">
+          Critical
+        </Badge>
+        <Badge tone="info">Beta</Badge>
+      </div>
+    </div>
+    <div data-density="comfortable">
+      <p style={{ margin: '0 0 8px', fontWeight: 600, fontSize: '14px' }}>
+        Comfortable
+      </p>
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+        <Badge tone="neutral">Draft</Badge>
+        <Badge tone="success">Active</Badge>
+        <Badge tone="warning">Pending</Badge>
+        <Badge tone="danger" emphasis="medium">
+          Critical
+        </Badge>
+        <Badge tone="info">Beta</Badge>
+      </div>
+    </div>
+  </div>
+)
+
+Density.parameters = {
+  docs: {
+    description: {
+      story:
+        'Badge respects the `data-density` attribute on a parent element. Comfortable reduces padding for denser UIs.',
+    },
+  },
+}
+
 export const AllCombinations: StoryFn<BadgeProps> = () => {
   const tones = [
     'neutral',

--- a/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
@@ -264,7 +264,13 @@ InTable.parameters = {
   },
 }
 
-const assets = [
+type Asset = {
+  name: string
+  description: string
+  tags: { label: string; tone: BadgeProps['tone'] }[]
+}
+
+const assets: Asset[] = [
   {
     name: 'Oseberg A',
     description: 'Fixed steel jacket platform, North Sea',
@@ -290,7 +296,7 @@ const assets = [
       { label: 'Operational', tone: 'success' },
     ],
   },
-] as const
+]
 
 export const MultipleLabels: StoryFn<BadgeProps> = () => (
   <ul
@@ -395,7 +401,7 @@ Density.parameters = {
   docs: {
     description: {
       story:
-        'Badge respects the `data-density` attribute on a parent element. Comfortable reduces padding for denser UIs.',
+        'Badge responds to `data-density` on a parent element. Comfortable reduces block and inline padding from 6px to 4px.',
     },
   },
 }

--- a/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
@@ -14,6 +14,8 @@ const meta: Meta<typeof Badge> = {
 \`\`\`tsx
 import { Badge } from '@equinor/eds-core-react/next'
 \`\`\`
+
+Compact, non-interactive labels for conveying status, category, or metadata. For selectable labels, use [Chip](?path=/docs/eds-2-0-beta-data-display-chip--docs) instead.
         `,
       },
     },
@@ -57,6 +59,15 @@ export const Tones: StoryFn<BadgeProps> = () => (
   </div>
 )
 
+Tones.parameters = {
+  docs: {
+    description: {
+      story:
+        'Six semantic tones cover the full status spectrum. Use `success`, `warning`, and `danger` for operational states; `info` for informational labels; `accent` for categorisation; `neutral` as the default when no semantic meaning is needed.',
+    },
+  },
+}
+
 export const Emphasis: StoryFn<BadgeProps> = () => (
   <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
     <Badge tone="accent" emphasis="low">
@@ -68,6 +79,15 @@ export const Emphasis: StoryFn<BadgeProps> = () => (
   </div>
 )
 
+Emphasis.parameters = {
+  docs: {
+    description: {
+      story:
+        '`low` (default) uses a subtle background fill — appropriate for most inline use. `medium` increases the fill density for stronger contrast, useful when the badge needs to stand out on its own.',
+    },
+  },
+}
+
 export const Variants: StoryFn<BadgeProps> = () => (
   <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
     <Badge tone="accent" variant="solid">
@@ -78,6 +98,258 @@ export const Variants: StoryFn<BadgeProps> = () => (
     </Badge>
   </div>
 )
+
+Variants.parameters = {
+  docs: {
+    description: {
+      story:
+        'Solid (default) suits most contexts. Outlined uses a border instead of a fill — useful when the background is already coloured or when a lighter visual weight is preferable.',
+    },
+  },
+}
+
+export const InlineWithText: StoryFn<BadgeProps> = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+    <h3
+      style={{
+        margin: 0,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        fontSize: '16px',
+        fontFamily: 'var(--eds-typography-header-font-family)',
+        fontWeight: 700,
+      }}
+    >
+      Well integrity report{' '}
+      <Badge tone="danger" emphasis="medium">
+        Critical
+      </Badge>
+    </h3>
+    <p
+      style={{
+        margin: 0,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        fontSize: '14px',
+        fontFamily: 'var(--eds-typography-ui-body-font-family)',
+      }}
+    >
+      Pressure test <Badge tone="success">Passed</Badge>
+    </p>
+    <p
+      style={{
+        margin: 0,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        fontSize: '14px',
+        fontFamily: 'var(--eds-typography-ui-body-font-family)',
+      }}
+    >
+      API documentation <Badge tone="info">Beta</Badge>
+    </p>
+  </div>
+)
+
+InlineWithText.parameters = {
+  docs: {
+    description: {
+      story:
+        'Badges sit inline with headings and body text. Use `align-items: center` on the flex container to align the badge baseline with the surrounding text.',
+    },
+  },
+}
+
+export const InTable: StoryFn<BadgeProps> = () => (
+  <table
+    style={{
+      borderCollapse: 'collapse',
+      fontSize: '14px',
+      width: '100%',
+      fontFamily: 'var(--eds-typography-ui-body-font-family)',
+    }}
+  >
+    <thead>
+      <tr>
+        {['Work order', 'Location', 'Status', 'Priority'].map((h) => (
+          <th
+            key={h}
+            style={{
+              textAlign: 'left',
+              padding: '8px 12px',
+              borderBottom: '1px solid #e0e0e0',
+              fontWeight: 600,
+            }}
+          >
+            {h}
+          </th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {[
+        {
+          id: 'WO-1042',
+          location: 'Oseberg A',
+          status: 'Active',
+          tone: 'success',
+          priority: 'Normal',
+          priorityTone: 'neutral',
+        },
+        {
+          id: 'WO-1043',
+          location: 'Gullfaks C',
+          status: 'Pending',
+          tone: 'warning',
+          priority: 'High',
+          priorityTone: 'warning',
+        },
+        {
+          id: 'WO-1044',
+          location: 'Troll B',
+          status: 'Critical',
+          tone: 'danger',
+          priority: 'Critical',
+          priorityTone: 'danger',
+        },
+        {
+          id: 'WO-1045',
+          location: 'Snorre A',
+          status: 'Draft',
+          tone: 'neutral',
+          priority: 'Normal',
+          priorityTone: 'neutral',
+        },
+      ].map((row) => (
+        <tr key={row.id}>
+          <td
+            style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}
+          >
+            {row.id}
+          </td>
+          <td
+            style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}
+          >
+            {row.location}
+          </td>
+          <td
+            style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}
+          >
+            <Badge tone={row.tone as BadgeProps['tone']}>{row.status}</Badge>
+          </td>
+          <td
+            style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}
+          >
+            <Badge
+              tone={row.priorityTone as BadgeProps['tone']}
+              emphasis="medium"
+            >
+              {row.priority}
+            </Badge>
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+)
+
+InTable.parameters = {
+  docs: {
+    description: {
+      story:
+        'Badges in table columns let users scan status and priority at a glance. Use `emphasis="medium"` for the more prominent priority column.',
+    },
+  },
+}
+
+const assets = [
+  {
+    name: 'Oseberg A',
+    description: 'Fixed steel jacket platform, North Sea',
+    tags: [
+      { label: 'Offshore', tone: 'accent' },
+      { label: 'Operational', tone: 'success' },
+      { label: 'HPHT', tone: 'info' },
+    ],
+  },
+  {
+    name: 'Troll B',
+    description: 'Semi-submersible floating production platform',
+    tags: [
+      { label: 'Offshore', tone: 'accent' },
+      { label: 'Maintenance', tone: 'warning' },
+    ],
+  },
+  {
+    name: 'Mongstad',
+    description: 'Refinery and oil terminal, western Norway',
+    tags: [
+      { label: 'Onshore', tone: 'neutral' },
+      { label: 'Operational', tone: 'success' },
+    ],
+  },
+] as const
+
+export const MultipleLabels: StoryFn<BadgeProps> = () => (
+  <ul
+    style={{
+      listStyle: 'none',
+      margin: 0,
+      padding: 0,
+      fontFamily: 'var(--eds-typography-ui-body-font-family)',
+      width: '360px',
+    }}
+  >
+    {assets.map((asset, i) => (
+      <li
+        key={asset.name}
+        style={{
+          padding: '12px 0',
+          borderBottom: i < assets.length - 1 ? '1px solid #e0e0e0' : undefined,
+        }}
+      >
+        <span
+          style={{
+            display: 'block',
+            fontSize: '14px',
+            fontWeight: 600,
+            marginBottom: '4px',
+          }}
+        >
+          {asset.name}
+        </span>
+        <span
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            color: '#6f6f6f',
+            marginBottom: '8px',
+          }}
+        >
+          {asset.description}
+        </span>
+        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+          {asset.tags.map((tag) => (
+            <Badge key={tag.label} tone={tag.tone}>
+              {tag.label}
+            </Badge>
+          ))}
+        </div>
+      </li>
+    ))}
+  </ul>
+)
+
+MultipleLabels.parameters = {
+  docs: {
+    description: {
+      story:
+        'Multiple badges per item communicate orthogonal properties — location type, operational status, and technical classification — without cluttering the layout.',
+    },
+  },
+}
 
 export const AllCombinations: StoryFn<BadgeProps> = () => {
   const tones = [
@@ -117,4 +389,12 @@ export const AllCombinations: StoryFn<BadgeProps> = () => {
       )}
     </div>
   )
+}
+
+AllCombinations.parameters = {
+  docs: {
+    description: {
+      story: 'All combinations of tone × emphasis × variant for visual QA.',
+    },
+  },
 }

--- a/packages/eds-core-react/src/components/next/Badge/Badge.test.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.test.tsx
@@ -6,8 +6,8 @@ import { Badge } from '.'
 describe('Badge (next)', () => {
   describe('Rendering', () => {
     it('renders with default props', () => {
-      render(<Badge data-testid="eds-badge">Label</Badge>)
-      expect(screen.getByTestId('eds-badge')).toBeInTheDocument()
+      render(<Badge>Label</Badge>)
+      expect(screen.getByText('Label')).toBeInTheDocument()
     })
 
     it('renders children', () => {
@@ -16,12 +16,8 @@ describe('Badge (next)', () => {
     })
 
     it('applies custom className', () => {
-      render(
-        <Badge data-testid="eds-badge" className="custom">
-          Label
-        </Badge>,
-      )
-      expect(screen.getByTestId('eds-badge')).toHaveClass('eds-badge', 'custom')
+      render(<Badge className="custom">Label</Badge>)
+      expect(screen.getByText('Label')).toHaveClass('eds-badge', 'custom')
     })
 
     it('forwards ref', () => {
@@ -31,55 +27,39 @@ describe('Badge (next)', () => {
     })
 
     it('spreads additional props', () => {
-      render(
-        <Badge data-testid="test" data-custom="value">
-          Label
-        </Badge>,
-      )
-      expect(screen.getByTestId('test')).toHaveAttribute('data-custom', 'value')
+      render(<Badge data-custom="value">Label</Badge>)
+      expect(screen.getByText('Label')).toHaveAttribute('data-custom', 'value')
     })
   })
 
   describe('Variants', () => {
     it('sets default data attributes', () => {
-      render(<Badge data-testid="eds-badge">Label</Badge>)
-      const badge = screen.getByTestId('eds-badge')
+      render(<Badge>Label</Badge>)
+      const badge = screen.getByText('Label')
       expect(badge).toHaveAttribute('data-color-appearance', 'neutral')
       expect(badge).toHaveAttribute('data-emphasis', 'low')
       expect(badge).toHaveAttribute('data-variant', 'solid')
     })
 
     it('sets tone data attribute', () => {
-      render(
-        <Badge data-testid="eds-badge" tone="accent">
-          Label
-        </Badge>,
-      )
-      expect(screen.getByTestId('eds-badge')).toHaveAttribute(
+      render(<Badge tone="accent">Label</Badge>)
+      expect(screen.getByText('Label')).toHaveAttribute(
         'data-color-appearance',
         'accent',
       )
     })
 
     it('sets emphasis data attribute', () => {
-      render(
-        <Badge data-testid="eds-badge" emphasis="medium">
-          Label
-        </Badge>,
-      )
-      expect(screen.getByTestId('eds-badge')).toHaveAttribute(
+      render(<Badge emphasis="medium">Label</Badge>)
+      expect(screen.getByText('Label')).toHaveAttribute(
         'data-emphasis',
         'medium',
       )
     })
 
     it('sets variant data attribute', () => {
-      render(
-        <Badge data-testid="eds-badge" variant="outlined">
-          Label
-        </Badge>,
-      )
-      expect(screen.getByTestId('eds-badge')).toHaveAttribute(
+      render(<Badge variant="outlined">Label</Badge>)
+      expect(screen.getByText('Label')).toHaveAttribute(
         'data-variant',
         'outlined',
       )

--- a/packages/eds-core-react/src/components/next/Badge/Badge.test.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { axe } from 'jest-axe'
+import { Badge } from '.'
+
+describe('Badge (next)', () => {
+  describe('Rendering', () => {
+    it('renders with default props', () => {
+      render(<Badge data-testid="eds-badge">Label</Badge>)
+      expect(screen.getByTestId('eds-badge')).toBeInTheDocument()
+    })
+
+    it('renders children', () => {
+      render(<Badge>Status</Badge>)
+      expect(screen.getByText('Status')).toBeInTheDocument()
+    })
+
+    it('applies custom className', () => {
+      render(
+        <Badge data-testid="eds-badge" className="custom">
+          Label
+        </Badge>,
+      )
+      expect(screen.getByTestId('eds-badge')).toHaveClass('eds-badge', 'custom')
+    })
+
+    it('forwards ref', () => {
+      const ref = { current: null as HTMLSpanElement | null }
+      render(<Badge ref={ref}>Label</Badge>)
+      expect(ref.current).toBeInstanceOf(HTMLSpanElement)
+    })
+
+    it('spreads additional props', () => {
+      render(
+        <Badge data-testid="test" data-custom="value">
+          Label
+        </Badge>,
+      )
+      expect(screen.getByTestId('test')).toHaveAttribute('data-custom', 'value')
+    })
+  })
+
+  describe('Variants', () => {
+    it('sets default data attributes', () => {
+      render(<Badge data-testid="eds-badge">Label</Badge>)
+      const badge = screen.getByTestId('eds-badge')
+      expect(badge).toHaveAttribute('data-color-appearance', 'neutral')
+      expect(badge).toHaveAttribute('data-emphasis', 'low')
+      expect(badge).toHaveAttribute('data-variant', 'solid')
+    })
+
+    it('sets tone data attribute', () => {
+      render(
+        <Badge data-testid="eds-badge" tone="accent">
+          Label
+        </Badge>,
+      )
+      expect(screen.getByTestId('eds-badge')).toHaveAttribute(
+        'data-color-appearance',
+        'accent',
+      )
+    })
+
+    it('sets emphasis data attribute', () => {
+      render(
+        <Badge data-testid="eds-badge" emphasis="medium">
+          Label
+        </Badge>,
+      )
+      expect(screen.getByTestId('eds-badge')).toHaveAttribute(
+        'data-emphasis',
+        'medium',
+      )
+    })
+
+    it('sets variant data attribute', () => {
+      render(
+        <Badge data-testid="eds-badge" variant="outlined">
+          Label
+        </Badge>,
+      )
+      expect(screen.getByTestId('eds-badge')).toHaveAttribute(
+        'data-variant',
+        'outlined',
+      )
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(<Badge>Label</Badge>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations with all tone variants', async () => {
+      const { container } = render(
+        <div>
+          <Badge tone="neutral">Neutral</Badge>
+          <Badge tone="accent">Accent</Badge>
+          <Badge tone="success">Success</Badge>
+          <Badge tone="info">Info</Badge>
+          <Badge tone="warning">Warning</Badge>
+          <Badge tone="danger">Danger</Badge>
+        </div>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/eds-core-react/src/components/next/Badge/Badge.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.tsx
@@ -1,0 +1,31 @@
+import { forwardRef } from 'react'
+import type { BadgeProps } from './Badge.types'
+
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
+  {
+    tone = 'neutral',
+    emphasis = 'low',
+    variant = 'solid',
+    children,
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const classes = ['eds-badge', className].filter(Boolean).join(' ')
+
+  return (
+    <span
+      ref={ref}
+      className={classes}
+      data-color-appearance={tone}
+      data-emphasis={emphasis}
+      data-variant={variant}
+      {...rest}
+    >
+      {children}
+    </span>
+  )
+})
+
+Badge.displayName = 'Badge'

--- a/packages/eds-core-react/src/components/next/Badge/Badge.types.ts
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.types.ts
@@ -1,0 +1,52 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+/**
+ * Color tone for theming — maps to `data-color-appearance`.
+ * - `neutral`: Neutral gray tones (default)
+ * - `accent`: Brand/action color
+ * - `success`: Positive/confirmation
+ * - `info`: Informational
+ * - `warning`: Caution/alerts
+ * - `danger`: Destructive/error
+ */
+export type BadgeTone =
+  | 'neutral'
+  | 'accent'
+  | 'success'
+  | 'info'
+  | 'warning'
+  | 'danger'
+
+/**
+ * Visual emphasis level.
+ * - `low`: Subtle background (canvas) or light border
+ * - `medium`: More prominent fill or medium border
+ */
+export type BadgeEmphasis = 'low' | 'medium'
+
+/**
+ * Visual style variant.
+ * - `solid`: Filled background, no border
+ * - `outlined`: Border, transparent or canvas background
+ */
+export type BadgeVariant = 'solid' | 'outlined'
+
+export type BadgeProps = {
+  /**
+   * Color tone for theming.
+   * @default 'neutral'
+   */
+  tone?: BadgeTone
+  /**
+   * Visual emphasis level.
+   * @default 'low'
+   */
+  emphasis?: BadgeEmphasis
+  /**
+   * Visual style variant.
+   * @default 'solid'
+   */
+  variant?: BadgeVariant
+  /** Badge label text */
+  children?: ReactNode
+} & HTMLAttributes<HTMLSpanElement>

--- a/packages/eds-core-react/src/components/next/Badge/badge.css
+++ b/packages/eds-core-react/src/components/next/Badge/badge.css
@@ -27,11 +27,6 @@
       text-box: trim-both cap alphabetic;
     }
 
-    /* Neutral: wider horizontal padding (8px vs 6px for tonal variants) */
-    &[data-color-appearance='neutral'] {
-      --_padding-inline: var(--eds-spacing-vertical-xs);
-    }
-
     /* ===== LOW EMPHASIS ===== */
 
     &[data-emphasis='low'][data-variant='solid'] {

--- a/packages/eds-core-react/src/components/next/Badge/badge.css
+++ b/packages/eds-core-react/src/components/next/Badge/badge.css
@@ -52,9 +52,4 @@
       outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
     }
   }
-
-  [data-density='comfortable'] .eds-badge {
-    --_padding-block: var(--eds-spacing-vertical-3xs);
-    --_padding-inline: var(--eds-spacing-horizontal-3xs);
-  }
 }

--- a/packages/eds-core-react/src/components/next/Badge/badge.css
+++ b/packages/eds-core-react/src/components/next/Badge/badge.css
@@ -4,7 +4,7 @@
     --_color: var(--eds-color-text-subtle);
     --_bg: transparent;
     --_padding-block: var(--eds-spacing-vertical-2xs);
-    --_padding-inline: var(--eds-spacing-vertical-2xs);
+    --_padding-inline: var(--eds-spacing-horizontal-2xs);
 
     display: inline-block;
 
@@ -12,10 +12,11 @@
     padding-inline: var(--_padding-inline);
     border-radius: var(--eds-spacing-border-radius-rounded);
 
-    /* EDS Typography Mono Num: 12px / 500 / lining tabular numbers */
     font-family: var(--eds-typography-ui-body-font-family);
     font-size: var(--eds-typography-ui-body-sm-font-size);
     font-feature-settings: 'lnum', 'tnum';
+
+    /* 500 = medium weight; no --eds-typography-ui-body-sm-font-weight-* token exists */
     font-weight: 500;
     line-height: var(--eds-typography-ui-body-sm-line-height-default);
     color: var(--_color);
@@ -50,5 +51,10 @@
       outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-medium);
       outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
     }
+  }
+
+  [data-density='comfortable'] .eds-badge {
+    --_padding-block: var(--eds-spacing-vertical-3xs);
+    --_padding-inline: var(--eds-spacing-horizontal-3xs);
   }
 }

--- a/packages/eds-core-react/src/components/next/Badge/badge.css
+++ b/packages/eds-core-react/src/components/next/Badge/badge.css
@@ -1,28 +1,26 @@
 @layer eds-components {
   .eds-badge {
     /* Pseudo-private vars — override these in variants, never the property directly */
-    --_color: var(--eds-color-text-subtle);
     --_bg: transparent;
-    --_padding-block: var(--eds-spacing-vertical-2xs);
-    --_padding-inline: var(--eds-spacing-horizontal-2xs);
+    --_outline-color: transparent;
 
     display: inline-block;
 
-    padding-block: var(--_padding-block);
-    padding-inline: var(--_padding-inline);
+    padding-block: var(--eds-spacing-vertical-2xs);
+    padding-inline: var(--eds-spacing-horizontal-2xs);
     border-radius: var(--eds-spacing-border-radius-rounded);
 
     font-family: var(--eds-typography-ui-body-font-family);
     font-size: var(--eds-typography-ui-body-sm-font-size);
     font-feature-settings: 'lnum', 'tnum';
-
-    /* 500 = medium weight; no --eds-typography-ui-body-sm-font-weight-* token exists */
-    font-weight: 500;
+    font-weight: var(--eds-typography-ui-body-sm-font-weight-bolder);
     line-height: var(--eds-typography-ui-body-sm-line-height-default);
-    color: var(--_color);
+    color: var(--eds-color-text-subtle);
     white-space: nowrap;
 
     background-color: var(--_bg);
+    outline: var(--eds-sizing-stroke-thin) solid var(--_outline-color);
+    outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
 
     @supports (text-box: trim-both cap alphabetic) {
       text-box: trim-both cap alphabetic;
@@ -35,8 +33,7 @@
     }
 
     &[data-emphasis='low'][data-variant='outlined'] {
-      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-subtle);
-      outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
+      --_outline-color: var(--eds-color-border-subtle);
     }
 
     /* ===== MEDIUM EMPHASIS ===== */
@@ -47,9 +44,7 @@
 
     &[data-emphasis='medium'][data-variant='outlined'] {
       --_bg: var(--eds-color-bg-canvas);
-
-      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-medium);
-      outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
+      --_outline-color: var(--eds-color-border-medium);
     }
   }
 }

--- a/packages/eds-core-react/src/components/next/Badge/badge.css
+++ b/packages/eds-core-react/src/components/next/Badge/badge.css
@@ -1,0 +1,59 @@
+@layer eds-components {
+  .eds-badge {
+    /* Pseudo-private vars — override these in variants, never the property directly */
+    --_color: var(--eds-color-text-subtle);
+    --_bg: transparent;
+    --_padding-block: var(--eds-spacing-vertical-2xs);
+    --_padding-inline: var(--eds-spacing-vertical-2xs);
+
+    display: inline-block;
+
+    padding-block: var(--_padding-block);
+    padding-inline: var(--_padding-inline);
+    border-radius: var(--eds-spacing-border-radius-rounded);
+
+    /* EDS Typography Mono Num: 12px / 500 / lining tabular numbers */
+    font-family: var(--eds-typography-ui-body-font-family);
+    font-size: var(--eds-typography-ui-body-sm-font-size);
+    font-feature-settings: 'lnum', 'tnum';
+    font-weight: 500;
+    line-height: var(--eds-typography-ui-body-sm-line-height-default);
+    color: var(--_color);
+    white-space: nowrap;
+
+    background-color: var(--_bg);
+
+    @supports (text-box: trim-both cap alphabetic) {
+      text-box: trim-both cap alphabetic;
+    }
+
+    /* Neutral: wider horizontal padding (8px vs 6px for tonal variants) */
+    &[data-color-appearance='neutral'] {
+      --_padding-inline: var(--eds-spacing-vertical-xs);
+    }
+
+    /* ===== LOW EMPHASIS ===== */
+
+    &[data-emphasis='low'][data-variant='solid'] {
+      --_bg: var(--eds-color-bg-canvas);
+    }
+
+    &[data-emphasis='low'][data-variant='outlined'] {
+      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-subtle);
+      outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
+    }
+
+    /* ===== MEDIUM EMPHASIS ===== */
+
+    &[data-emphasis='medium'][data-variant='solid'] {
+      --_bg: var(--eds-color-bg-fill-muted-default);
+    }
+
+    &[data-emphasis='medium'][data-variant='outlined'] {
+      --_bg: var(--eds-color-bg-canvas);
+
+      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-medium);
+      outline-offset: calc(-1 * var(--eds-sizing-stroke-thin));
+    }
+  }
+}

--- a/packages/eds-core-react/src/components/next/Badge/index.ts
+++ b/packages/eds-core-react/src/components/next/Badge/index.ts
@@ -1,0 +1,7 @@
+export { Badge } from './Badge'
+export type {
+  BadgeProps,
+  BadgeTone,
+  BadgeEmphasis,
+  BadgeVariant,
+} from './Badge.types'

--- a/packages/eds-core-react/src/components/next/index.css
+++ b/packages/eds-core-react/src/components/next/index.css
@@ -38,4 +38,5 @@
 @import './Menu/menu.css';
 @import './Autocomplete/autocomplete.css';
 @import './Select/select.css';
+@import './Badge/badge.css';
 

--- a/packages/eds-core-react/src/components/next/index.ts
+++ b/packages/eds-core-react/src/components/next/index.ts
@@ -77,3 +77,11 @@ export type { AutocompleteProps } from './Autocomplete'
 
 export { Select } from './Select'
 export type { SelectProps } from './Select'
+
+export { Badge } from './Badge'
+export type {
+  BadgeProps,
+  BadgeTone,
+  BadgeEmphasis,
+  BadgeVariant,
+} from './Badge'


### PR DESCRIPTION
## Summary

Adds `Badge` as an EDS 2.0 component — a compact, non-interactive label for categorising or annotating content in tables, alongside headings, or inline within text.

## Changes

- New `Badge` component in `packages/eds-core-react/src/components/next/Badge/`
- 6 tones (`neutral`, `accent`, `success`, `info`, `warning`, `danger`), 2 emphasis levels (`low`, `medium`), and 2 variants (`solid`, `outlined`)
- Figma Code Connect, Storybook stories, and jest-axe accessibility tests

Closes #4791

## Test plan

- [ ] Run `npx jest --testPathPatterns="next/Badge" --no-coverage` — all 11 tests pass
- [ ] Open Storybook under `EDS 2.0 (beta) / Data Display / Badge` and verify all stories render correctly
- [ ] Check Density story shows visibly smaller badges under comfortable density