### PR TITLE
docs: make scopeless conventional commits the documented default

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -37,14 +37,17 @@ jobs:
             echo "✅ Title matches Conventional Commits"
           else
             echo "❌ Invalid title: Must follow conventional commit format"
-            echo "   Valid formats:"
+            echo "   Default format (scope is optional and usually omitted):"
             echo "     • type: description"
+            echo "     • type!: breaking change description"
+            echo "   With scope (only when needed — see AGENTS.md):"
             echo "     • type(scope): description"
             echo "     • type(scope)!: breaking change description"
             echo "   Examples:"
+            echo "     • fix: resolve TextArea helper spacing"
             echo "     • feat: add new component"
-            echo "     • fix(eds-tokens): resolve build issue"
-            echo "     • feat(core)!: remove deprecated API"
+            echo "     • chore(config): update release-please config"
+            echo "     • feat!: remove deprecated API"
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,7 +422,7 @@ type: description
 
 **Breaking**: `feat!: remove deprecated prop`
 
-**Scope is optional and usually omitted.** Release-please detects the affected package from file paths, so a scopeless commit still routes correctly. Adding a package scope to a visible type (`feat`, `fix`) forces a version bump for that package regardless of which files changed — including files in `exclude-paths`. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases either way, so a scope on those is harmless. Default to no scope unless one of the exceptions below applies.
+**Scope is optional and usually omitted in this repo.** Most monorepos using release-please *do* use scopes — this repo is a deliberate exception because of the `exclude-paths` configuration in `release-please-config.json`. Storybook, tests, README, config, and other non-publishable files are excluded from triggering releases based on file path. Adding a package scope to a visible type (`feat`, `fix`) bypasses that exclusion and forces a bump regardless of which files changed. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases either way, so a scope on those is harmless. Default to no scope unless one of the exceptions below applies.
 
 **When to add a scope:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,7 +422,7 @@ type: description
 
 **Breaking**: `feat!: remove deprecated prop`
 
-**Scope is optional and usually omitted.** Release-please detects the affected package from file paths, so a scopeless commit still routes correctly. Adding a package scope forces a version bump for that package regardless of which files changed, so default to no scope unless one of the exceptions below applies.
+**Scope is optional and usually omitted.** Release-please detects the affected package from file paths, so a scopeless commit still routes correctly. Adding a package scope to a visible type (`feat`, `fix`) forces a version bump for that package regardless of which files changed — including files in `exclude-paths`. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases either way, so a scope on those is harmless. Default to no scope unless one of the exceptions below applies.
 
 **When to add a scope:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,18 +415,26 @@ Component docs live in `apps/design-system-docs/docs/components/{category}/{comp
 ## Conventional Commits
 
 ```
-type(scope): description
+type: description
 ```
 
 **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
 
-**Scopes (packages)**: `eds-core-react`, `eds-data-grid-react`, `eds-icons`, `eds-lab-react`, `eds-tailwind`, `eds-tokens`, `eds-tokens-build`, `eds-tokens-sync`, `eds-utils`, `design-system-docs`, `eds-color-palette-generator`, `eds-demo`, `figma-broker`
+**Breaking**: `feat!: remove deprecated prop`
 
-**Scopes (infrastructure)**: `config`, `github`, `build`, `deps`, `docs`, `devcontainer`
+**Scope is optional and usually omitted.** Release-please detects the affected package from file paths, so a scopeless commit still routes correctly. Adding a package scope forces a version bump for that package regardless of which files changed, so default to no scope unless one of the exceptions below applies.
 
-**Breaking**: `feat(eds-core-react)!: remove deprecated prop`
+**When to add a scope:**
 
-**Scope and release-please interaction**: Release-please detects packages from file paths — you don't always need a package scope. Using a package scope with a visible type forces a bump regardless of which files changed. For non-publishable changes (config, Storybook, tests, README, docs), use hidden types: `chore`, `build`, `ci`, `docs`, or `test`.
+- The commit touches a single package and the file paths don't make that obvious from the diff (rare — usually the path makes it clear).
+- It's an infrastructure scope (`config`, `github`, `build`, `deps`, `docs`, `devcontainer`) for changes that don't belong to any package.
+
+**Available scopes (when needed):**
+
+- Packages: `eds-core-react`, `eds-data-grid-react`, `eds-icons`, `eds-lab-react`, `eds-tailwind`, `eds-tokens`, `eds-tokens-build`, `eds-tokens-sync`, `eds-utils`, `design-system-docs`, `eds-color-palette-generator`, `eds-demo`, `figma-broker`
+- Infrastructure: `config`, `github`, `build`, `deps`, `docs`, `devcontainer`
+
+For non-publishable changes (config, Storybook, tests, README, docs), use hidden types: `chore`, `build`, `ci`, `docs`, or `test`.
 
 **PR titles** must also follow the conventional commits format — they appear in changelogs and merge history.
 

--- a/documentation/how-to/CONVENTIONAL_COMMITS.md
+++ b/documentation/how-to/CONVENTIONAL_COMMITS.md
@@ -34,30 +34,36 @@ When using "Squash and merge", the PR title becomes the commit message in the de
 ## Required Format
 
 ```
+type: description
+```
+
+Scope is optional and usually omitted — see [Scope and Release-Please Interaction](#scope-and-release-please-interaction). The full form is:
+
+```
 type(scope): description
 ```
 
 ### Components
 
 - **type**: The type of change (required)
-- **scope**: The package or area affected (optional)
+- **scope**: The package or area affected (optional — usually omitted)
 - **description**: Brief description of the change (required)
 
 ## Supported Types
 
-| Type       | Description                           | Example                                                  |
-| ---------- | ------------------------------------- | -------------------------------------------------------- |
-| `feat`     | New feature                           | `feat(eds-core-react): add button variants`              |
-| `fix`      | Bug fix                               | `fix(eds-icons): resolve alignment issues`               |
-| `docs`     | Documentation changes                 | `docs: update installation guide`                        |
-| `style`    | Code style changes (formatting, etc.) | `style(eds-tokens): improve naming consistency`          |
-| `refactor` | Code refactoring                      | `refactor(eds-core-react): simplify component structure` |
-| `perf`     | Performance improvements              | `perf(eds-data-grid): optimize rendering`                |
-| `test`     | Adding or updating tests              | `test(eds-utils): add validation tests`                  |
-| `build`    | Build system changes                  | `build: update webpack configuration`                    |
-| `ci`       | CI/CD changes                         | `ci: add automated release workflow`                     |
-| `chore`    | Maintenance tasks                     | `chore: update dependencies`                             |
-| `revert`   | Revert previous changes               | `revert: undo button color changes`                      |
+| Type       | Description                           | Example                                       |
+| ---------- | ------------------------------------- | --------------------------------------------- |
+| `feat`     | New feature                           | `feat: add button variants`                   |
+| `fix`      | Bug fix                               | `fix: resolve icon alignment issues`          |
+| `docs`     | Documentation changes                 | `docs: update installation guide`             |
+| `style`    | Code style changes (formatting, etc.) | `style: improve token naming consistency`     |
+| `refactor` | Code refactoring                      | `refactor: simplify component structure`      |
+| `perf`     | Performance improvements              | `perf: optimize data grid rendering`          |
+| `test`     | Adding or updating tests              | `test: add utility validation tests`          |
+| `build`    | Build system changes                  | `build: update webpack configuration`         |
+| `ci`       | CI/CD changes                         | `ci: add automated release workflow`          |
+| `chore`    | Maintenance tasks                     | `chore: update dependencies`                  |
+| `revert`   | Revert previous changes               | `revert: undo button color changes`           |
 
 ## Supported Scopes
 

--- a/documentation/how-to/CONVENTIONAL_COMMITS.md
+++ b/documentation/how-to/CONVENTIONAL_COMMITS.md
@@ -11,17 +11,18 @@
 5. [Examples](#examples)
    - [Valid PR Titles](#valid-pr-titles)
    - [Invalid PR Titles](#invalid-pr-titles)
-6. [Emojis (Optional)](#emojis-optional)
-7. [Breaking Changes](#breaking-changes)
-8. [Enforcement](#enforcement)
-9. [Why This Matters](#why-this-matters)
-10. [Maintaining the Workflow](#maintaining-the-workflow)
+6. [Scope and Release-Please Interaction](#scope-and-release-please-interaction)
+7. [Emojis (Optional)](#emojis-optional)
+8. [Breaking Changes](#breaking-changes)
+9. [Enforcement](#enforcement)
+10. [Why This Matters](#why-this-matters)
+11. [Maintaining the Workflow](#maintaining-the-workflow)
     - [Workflow Location](#workflow-location)
     - [Adding New Scopes](#adding-new-scopes)
     - [Testing Changes](#testing-changes)
-11. [VSCode Integration](#vscode-integration)
+12. [VSCode Integration](#vscode-integration)
     - [Conventional Commits Plugin](#conventional-commits-plugin)
-12. [Need Help?](#need-help)
+13. [Need Help?](#need-help)
 
 ---
 
@@ -105,13 +106,19 @@ refactor(eds-tokens, eds-icons): standardize naming conventions
 
 ### Valid PR Titles
 
-✅ `feat(eds-core-react): add new button variant`
-✅ `fix(eds-icons): resolve icon alignment in Safari`
-✅ `docs(design-system-docs): update component guidelines`
-✅ `style(eds-tokens): improve color naming`
-✅ `feat(eds-core-react, eds-utils): add shared validation logic`
-✅ `chore: update project dependencies`
+Scopeless (the default — see [Scope and Release-Please Interaction](#scope-and-release-please-interaction)):
+
+✅ `feat: add new button variant`
+✅ `fix: resolve icon alignment in Safari`
 ✅ `docs: add setup instructions to README`
+✅ `chore: update project dependencies`
+✅ `refactor: simplify component structure`
+
+With scope (only when needed):
+
+✅ `chore(config): update release-please exclude-paths`
+✅ `ci(github): fix PR title workflow regex`
+✅ `feat(eds-core-react, eds-utils): add shared validation logic` (cross-package)
 
 ### Invalid PR Titles
 
@@ -131,9 +138,9 @@ Release-please detects which packages are affected based on **file paths** — y
 
 ### When to use a scope
 
-- **Package scope** (`eds-core-react`, `eds-tokens`, etc.): Only when the commit message alone doesn't make the package clear, or for changelog readability. Be aware this forces a bump regardless of `exclude-paths`.
+- **No scope** (default): Use this for most commits — release-please figures out the affected package from file paths, and `exclude-paths` keeps non-publishable files (Storybook, tests, README, config) from triggering releases.
+- **Package scope** (`eds-core-react`, `eds-tokens`, etc.): Only when the commit message alone doesn't make the package clear, or for changelog readability. Be aware this forces a bump regardless of `exclude-paths` when combined with a visible type (`feat`, `fix`).
 - **Infrastructure scope** (`config`, `github`, `build`, `deps`): For changes that don't belong to a specific package.
-- **No scope**: Perfectly fine for most commits — release-please will figure it out from the file paths.
 
 ### Avoiding unnecessary version bumps
 


### PR DESCRIPTION
## Summary

- AI assistants (Claude Code, Copilot, the @claude review action) have been adding package scopes to PR titles by default (e.g. `fix(eds-core-react): ...`) — see #4986 for a recent example.
- Root cause: `AGENTS.md` and `CONVENTIONAL_COMMITS.md` both present `type(scope): description` as the canonical format. The fact that scope is optional and usually unnecessary in **this** repo lives several sections deep in `CONVENTIONAL_COMMITS.md`, so AI assistants reading the top of the docs never see it.
- This PR promotes `type: description` to the primary format example everywhere, and reframes scope as the exception with explicit guidance on when to use it.

## Why scopeless here (this is repo-specific)

In most monorepos using release-please, scopes are conventional and expected. **This repo is a deliberate exception** because of the `exclude-paths` setup in `release-please-config.json` (added in #4572). Storybook, tests, README, config, and other non-publishable files are excluded from triggering releases based on file path. Adding a package scope to a visible type (`feat`, `fix`) bypasses that exclusion and forces a bump on commits that path-based detection would otherwise correctly ignore.

So in this repo: path-based detection is the source of truth, and scopeless titles let it do its job. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases regardless, so scope on those is harmless. The new AGENTS.md wording reflects this.

## Changes

- **`AGENTS.md`** — format example is now `type: description`; the "When to add a scope" section is explicit about the default being no scope and lists the narrow cases (single-package commits where paths aren't obvious, infrastructure scopes for non-package changes).
- **`documentation/how-to/CONVENTIONAL_COMMITS.md`** — same change at the top of the doc; "Supported Types" table examples updated to scopeless variants (scope examples already exist further down in the dedicated scopes sections).
- **`.github/workflows/pr-title-check.yml`** — error message now shows the scopeless format first and labels the scoped form as "only when needed". No regex change — both forms remain valid.

## Test plan

- [ ] PR title check passes for this PR's own title (`docs: ...` with no scope)
- [ ] Verify scoped PR titles (e.g. `fix(eds-core-react): ...`) still validate — the regex was not changed
- [ ] Skim the updated sections in AGENTS.md and CONVENTIONAL_COMMITS.md for consistency