### PR TITLE
fix: rely on parent flex gap for Field helper-message spacing

### DIFF
--- a/packages/eds-core-react/src/components/next/Field/field.css
+++ b/packages/eds-core-react/src/components/next/Field/field.css
@@ -62,13 +62,6 @@
 
   .eds-field__helper-message {
     margin: 0;
-
-    /* Density-aware gap above helper-message (overrides parent gap).
-       Matches TextArea's .helper-row spacing for consistency across all
-       Field-based inputs. Longhand follows shorthand to win the cascade. */
-    margin-block-start: calc(
-      var(--eds-selectable-space-horizontal) - var(--eds-generic-gap-vertical)
-    );
     color: var(--_eds-field-helper-color);
   }
 

--- a/packages/eds-core-react/src/components/next/Field/field.css
+++ b/packages/eds-core-react/src/components/next/Field/field.css
@@ -41,8 +41,8 @@
     display: block;
 
     font-size: var(--eds-typography-ui-body-md-font-size);
-    line-height: var(--eds-typography-ui-body-md-line-height-default);
     font-weight: var(--eds-typography-ui-body-md-font-weight-normal);
+    line-height: var(--eds-typography-ui-body-md-line-height-default);
     color: var(--_eds-field-label-color);
   }
 
@@ -62,10 +62,12 @@
 
   .eds-field__helper-message {
     margin: 0;
-    /* Tighten spacing above helper-message to 3xs (overrides parent gap).
-       Longhand follows shorthand to win the cascade. */
+
+    /* Density-aware gap above helper-message (overrides parent gap).
+       Matches TextArea's .helper-row spacing for consistency across all
+       Field-based inputs. Longhand follows shorthand to win the cascade. */
     margin-block-start: calc(
-      var(--eds-spacing-vertical-3xs) - var(--eds-generic-gap-vertical)
+      var(--eds-selectable-space-horizontal) - var(--eds-generic-gap-vertical)
     );
     color: var(--_eds-field-helper-color);
   }

--- a/packages/eds-core-react/src/components/next/TextArea/textarea.css
+++ b/packages/eds-core-react/src/components/next/TextArea/textarea.css
@@ -39,13 +39,6 @@
       gap: var(--eds-typography-gap-horizontal);
       align-items: baseline;
       inline-size: 100%;
-      margin-block-start: calc(
-        var(--eds-selectable-space-horizontal) - var(--eds-generic-gap-vertical)
-      );
-    }
-
-    & .eds-field__helper-message {
-      margin-block-start: 0;
     }
 
     & .char-count {


### PR DESCRIPTION
## Summary

Remove the `margin-block-start` overrides on `.eds-field__helper-message` (in `field.css`) and on `.helper-row` / `.eds-field__helper-message` (in `textarea.css`). The helper-message now inherits the standard gap from the parent `.eds-field` flex `gap: var(--eds-generic-gap-vertical)` — same as every other Field child.

**Background:**
- The original override (`calc(--eds-spacing-vertical-3xs - --eds-generic-gap-vertical) = -4px`) was a "tightening" hack to give helper-message a 4px gap instead of 8px.
- Issue #5042 asked us to standardise on `--eds-selectable-space-horizontal` (the token TextArea's `.helper-row` already used, set in #4986).
- During review @millus pointed out that with both tokens equal, the calc resolves to 0 — the override becomes a no-op. The visible gap already comes from the parent flex gap.
- Removing the overrides is simpler, makes helper-message behave like any other Field child, and stays consistent across all Field-based inputs (TextField, Select, Search, Autocomplete, TextArea, Checkbox, Radio, Switch).

Closes #5042. Follow-up to #4986 / #4977.

## Known follow-up

While debugging this PR we noticed `--eds-generic-gap-vertical` does not re-resolve at `[data-density="comfortable"]`, so all Field-children gaps stay at 8px in comfortable density (Figma spec is 6px). That is a separate token-build bug tracked in #5090 — fixing it there will automatically give Field components density-aware gaps without further component changes.

## Test plan

- [x] 209 tests pass across affected components
- [x] Visually verified in Storybook — helper-message gap matches across TextField, TextArea, Select, Autocomplete in both spacious + comfortable density (consistent 8px in both today, will become 8/6 once #5090 lands)
- [x] Confirmed no per-component override of `.eds-field__helper-message` exists in Search, Autocomplete, Checkbox, Radio, Switch, Select, TextField CSS files
- [ ] Reviewer to verify Checkbox with `helperMessage` prop visually (no Storybook story currently exercises this path)