### PR TITLE
chore: add prepublishOnly to publishable packages

### DIFF
--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "build": "rollup -c && tsc -p tsconfig.build.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tsc -p tsconfig.test.json && jest --ci",
     "test:watch": "tsc-watch -p tsconfig.test.json --onFirstSuccess  \"jest --watch\"",
     "test:update-snapshots": "jest --updateSnapshot",

--- a/packages/eds-data-grid-react/package.json
+++ b/packages/eds-data-grid-react/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "rollup -c && tsc -p tsconfig.build.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tsc -p tsconfig.test.json && jest --ci",
     "test:watch": "tsc-watch -p tsconfig.test.json --onFirstSuccess  \"jest --watch\"",
     "test:update-snapshots": "jest --updateSnapshot",

--- a/packages/eds-icons/package.json
+++ b/packages/eds-icons/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "rollup -c && tsc",
     "dev": "rollup -c -w",
+    "prepublishOnly": "pnpm run build",
     "types": "tsc"
   },
   "keywords": [

--- a/packages/eds-lab-react/package.json
+++ b/packages/eds-lab-react/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "rollup -c && tsc -p tsconfig.build.json",
+    "prepublishOnly": "pnpm run build",
     "test": "tsc -p tsconfig.test.json && jest --ci",
     "test:watch": "tsc-watch -p tsconfig.test.json --onFirstSuccess  \"jest --watch\"",
     "test:update-snapshots": "jest --updateSnapshot",

--- a/packages/eds-tokens/package.json
+++ b/packages/eds-tokens/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "build": "rollup -c && pnpm run types",
     "dev": "rollup -c -w",
+    "prepublishOnly": "pnpm run build",
     "types": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/eds-utils/package.json
+++ b/packages/eds-utils/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "rollup -c && tsc -p tsconfig.build.json",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "types": "tsc -p tsconfig.build.json"


### PR DESCRIPTION
## Summary

- Adds `"prepublishOnly": "pnpm run build"` to all six publishable packages (`eds-core-react`, `eds-data-grid-react`, `eds-icons`, `eds-lab-react`, `eds-tokens`, `eds-utils`).
- `chore:` so this PR alone does **not** trigger any version bumps. Republishing the broken `eds-icons` bundle is handled separately (see #5111).

## Motivation

`@equinor/eds-icons@1.5.0` on npm is missing the `dark_mode` icon despite [#4926](https://github.com/equinor/design-system/pull/4926) merging it. The two `Publish icons` runs on 2026-05-20 both built a correct tarball but failed the actual `pnpm publish` step with `npm error 404 '@equinor/eds-icons@1.5.0' is not in this registry` (npm trusted-publisher policy). The version that ended up on npm was published manually from a local checkout whose `dist/` pre-dated the `dark_mode` merge — a different shasum, smaller files, and no `dark_mode`.

`prepublishOnly: pnpm run build` makes that mistake impossible: pnpm rebuilds `dist/` before any publish, whether triggered by CI or run locally.

## Why chore: instead of fix:

A `fix:` commit touching every `package.json` would patch-bump all six packages via release-please. That would mean six changelog entries and six npm releases for what is purely a publishing-pipeline safety net. Using `chore:` keeps the change quiet; eds-icons specifically will be republished as a targeted follow-up.

## Test plan

- [ ] CI for this PR passes.
- [ ] After merge, verify release-please does **not** open or update a release PR off the back of this commit (since `chore:` is hidden).
- [ ] Follow-up: separately republish `@equinor/eds-icons@1.5.1` with a complete bundle (tracked in #5111).