### PR TITLE
fix(eds-icons): republish to include dark_mode icon

### DIFF
--- a/packages/eds-icons/README.md
+++ b/packages/eds-icons/README.md
@@ -5,7 +5,7 @@ This package is a collection of the `system icons` from the Equinor Design Syste
 ## Installation
 
 ```sh
-npm install @equinor/eds-icons 
+npm install @equinor/eds-icons
 ```
 If you use Typescript, make sure you have typescript >= 3.8 as a devDependency:
 ```sh


### PR DESCRIPTION
## Summary

Forces release-please to patch-bump `@equinor/eds-icons` from `1.5.0` to `1.5.1` so a fresh CI build can be published — the current `1.5.0` tarball on npm is missing the `dark_mode` icon.

## Context

`@equinor/eds-icons@1.5.0` should contain the `dark_mode` icon added in #4926, but it doesn't:

\`\`\`
npm pack @equinor/eds-icons@1.5.0
grep -c dark_mode package/dist/esm/data.js
# → 0
\`\`\`

Investigation showed: the two `Publish icons` runs on 2026-05-20 both built a correct tarball but failed at `pnpm publish` with `E404` (npm trusted-publisher mismatch — same class of issue as #4932). The version that ended up on npm was manually published from a local checkout whose `dist/` pre-dated the `dark_mode` merge. Different shasum, smaller files, no `dark_mode`. Full incident notes: #5111.

## Why the scope

This commit only touches `packages/eds-icons/README.md` (in `exclude-paths`). Without scope, release-please wouldn't bump `eds-icons` off this commit. With `fix(eds-icons):`, the scope override in our release-please configuration forces a patch bump regardless of file paths.

## What this PR is not

- It is not a code fix to `eds-icons`. The source already has `dark_mode` — the issue was always in publishing.
- It does not touch `.release-please-manifest.json`. Release-please will update the manifest itself when it opens the next release PR.
- It does not include the `prepublishOnly` safety net — that is #5109 (should land first, but not a hard blocker since CI publish runs its own build).

## Test plan

- [ ] CI passes.
- [ ] After merge, release-please opens / updates a release PR bumping **only** `eds-icons` from `1.5.0` to `1.5.1`.
- [ ] Merging the release PR triggers `Publish icons`. With trusted-publisher now configured for `publish_icons.yaml`, the publish step should succeed.
- [ ] Verify `1.5.1` on npm includes `dark_mode`:
  \`\`\`
  npm pack @equinor/eds-icons@1.5.1 && tar -xzf equinor-eds-icons-1.5.1.tgz && grep -c dark_mode package/dist/esm/data.js
  \`\`\`
  Expect non-zero.

Closes #5111.