### PR TITLE
fix!: convert Field, Switch, Radio, Checkbox BEM classes to flat class names

### DIFF
--- a/packages/eds-core-react/src/components/next/Checkbox/Checkbox.tsx
+++ b/packages/eds-core-react/src/components/next/Checkbox/Checkbox.tsx
@@ -9,9 +9,6 @@ import { Field } from '../Field'
 import { Icon } from '../Icon'
 import type { CheckboxProps } from './Checkbox.types'
 
-const classNames = (...classes: (string | boolean | undefined)[]) =>
-  classes.filter(Boolean).join(' ')
-
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   function Checkbox(
     {
@@ -44,27 +41,23 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           id={inputId}
           aria-checked={indeterminate ? 'mixed' : undefined}
           aria-describedby={helperMessage ? helperMessageId : undefined}
-          className="eds-checkbox__input"
+          className="input"
           disabled={disabled}
           ref={inputRef}
           data-indeterminate={indeterminate}
           {...rest}
         />
-        <span className="eds-checkbox__icon-wrapper">
-          <Icon
-            data={checkbox}
-            size="lg"
-            className="eds-checkbox__icon eds-checkbox__icon--checked"
-          />
+        <span className="icon-wrapper">
+          <Icon data={checkbox} size="lg" className="icon icon-checked" />
           <Icon
             data={checkbox_outline}
             size="lg"
-            className="eds-checkbox__icon eds-checkbox__icon--unchecked"
+            className="icon icon-unchecked"
           />
           <Icon
             data={checkbox_indeterminate}
             size="lg"
-            className="eds-checkbox__icon eds-checkbox__icon--indeterminate"
+            className="icon icon-indeterminate"
           />
         </span>
       </>
@@ -96,7 +89,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
     return (
       <span
-        className={classNames('eds-checkbox', 'eds-checkbox--standalone')}
+        className="eds-checkbox"
+        data-standalone={true}
         data-color-appearance={disabled ? 'neutral' : 'accent'}
         data-disabled={disabled || undefined}
       >

--- a/packages/eds-core-react/src/components/next/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`Checkbox (next) matches snapshot 1`] = `
     data-space-proportions="squished"
   >
     <input
-      class="eds-checkbox__input"
+      class="input"
       data-indeterminate="false"
       id="test-id"
       type="checkbox"
     />
     <span
-      class="eds-checkbox__icon-wrapper"
+      class="icon-wrapper"
     >
       <svg
         aria-hidden="true"
-        class="eds-icon eds-checkbox__icon eds-checkbox__icon--checked"
+        class="eds-icon icon icon-checked"
         data-icon-size="lg"
         data-testid="eds-icon"
         fill="currentColor"
@@ -35,7 +35,7 @@ exports[`Checkbox (next) matches snapshot 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="eds-icon eds-checkbox__icon eds-checkbox__icon--unchecked"
+        class="eds-icon icon icon-unchecked"
         data-icon-size="lg"
         data-testid="eds-icon"
         fill="currentColor"
@@ -50,7 +50,7 @@ exports[`Checkbox (next) matches snapshot 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="eds-icon eds-checkbox__icon eds-checkbox__icon--indeterminate"
+        class="eds-icon icon icon-indeterminate"
         data-icon-size="lg"
         data-testid="eds-icon"
         fill="currentColor"
@@ -65,7 +65,7 @@ exports[`Checkbox (next) matches snapshot 1`] = `
       </svg>
     </span>
     <label
-      class="eds-field__label"
+      class="label"
       data-baseline="center"
       for="test-id"
     >

--- a/packages/eds-core-react/src/components/next/Checkbox/checkbox.css
+++ b/packages/eds-core-react/src/components/next/Checkbox/checkbox.css
@@ -3,28 +3,141 @@
     --_checkbox-icon-color: var(--eds-color-bg-fill-emphasis-default);
     --_checkbox-hover-color: var(--eds-color-bg-fill-muted-default);
     --_checkbox-icon-size: var(--eds-sizing-icon-lg);
+
     /* Touch target: 36px spacious, 28px comfortable */
     --_checkbox-touch-target: 2.25rem;
+
     cursor: pointer;
     position: relative;
     box-sizing: border-box;
+
+    [data-density='comfortable'] & {
+      --_checkbox-touch-target: 1.75rem;
+    }
+
+    /* Standalone variant (no label) */
+    &[data-standalone] {
+      position: relative;
+
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      /* Padding calculated from touch target and icon size */
+      padding: calc(
+        (var(--_checkbox-touch-target) - var(--_checkbox-icon-size)) / 2
+      );
+
+      &::before {
+        content: '';
+
+        position: absolute;
+        inset: 0;
+
+        border-radius: var(--eds-spacing-border-radius-pill);
+
+        background-color: transparent;
+
+        transition: background-color 150ms;
+      }
+
+      &:has(.input:focus-visible) {
+        border-radius: var(--eds-spacing-border-radius-pill);
+      }
+
+      @media (hover: hover) and (pointer: fine) {
+        &:hover::before {
+          background-color: var(--_checkbox-hover-color);
+        }
+
+        &[data-disabled='true']:hover::before {
+          background-color: transparent;
+        }
+      }
+    }
+
+    &[data-disabled='true'] {
+      cursor: not-allowed;
+    }
+
+    &:has(.input:focus-visible) {
+      border-radius: var(--eds-spacing-border-radius-rounded);
+      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
+      outline-offset: var(--eds-sizing-stroke-thick);
+    }
+
+    & .icon-wrapper {
+      position: relative;
+
+      overflow: visible;
+      display: inline-flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+
+      line-height: 0;
+    }
+
+    & .input {
+      cursor: pointer;
+
+      position: absolute;
+      z-index: 1;
+      inset: 0;
+
+      margin: 0;
+
+      appearance: none;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+
+      &:focus {
+        outline: none;
+      }
+    }
+
+    & .icon {
+      pointer-events: none;
+      position: relative;
+      flex-shrink: 0;
+      fill: var(--_checkbox-icon-color);
+    }
+
+    &[data-disabled='true'] .icon {
+      fill: var(--eds-color-text-disabled);
+    }
+
+    /* Icon visibility */
+    & .icon-checked,
+    & .icon-indeterminate {
+      display: none;
+    }
+
+    & .icon-unchecked {
+      display: block;
+    }
+
+    &:has(.input:checked) .icon-checked {
+      display: block;
+    }
+
+    &:has(.input:checked) .icon-unchecked {
+      display: none;
+    }
+
+    &:has(.input[data-indeterminate='true']) .icon-indeterminate {
+      display: block;
+    }
+
+    &:has(.input[data-indeterminate='true']) .icon-checked,
+    &:has(.input[data-indeterminate='true']) .icon-unchecked {
+      display: none;
+    }
   }
 
-  [data-density='comfortable'] .eds-checkbox {
-    --_checkbox-touch-target: 1.75rem;
-  }
-
-  .eds-checkbox--standalone {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    /* Padding calculated from touch target and icon size */
-    padding: calc(
-      (var(--_checkbox-touch-target) - var(--_checkbox-icon-size)) / 2
-    );
-  }
-
+  /* Field layout variant */
   .eds-field.eds-checkbox {
     /*
      * Gap compensation for label alignment.
@@ -44,152 +157,52 @@
      * since the icons have different internal padding (Checkbox: 3px, Radio: 2px).
      */
     --_checkbox-gap-compensation: 0.2375rem;
+    --_eds-field-helper-color: var(--eds-color-text-neutral-subtle);
+
     gap: calc(
       var(--eds-generic-gap-horizontal) + var(--_checkbox-gap-compensation)
     );
-    padding-inline: var(--eds-selectable-space-horizontal);
-    padding-block: var(--eds-selectable-space-vertical);
+
     width: auto;
+    padding-block: var(--eds-selectable-space-vertical);
+    padding-inline: var(--eds-selectable-space-horizontal);
     border-radius: var(--eds-spacing-border-radius-rounded);
+
     transition: background-color 150ms;
-  }
 
-  .eds-checkbox[data-disabled='true'] {
-    cursor: not-allowed;
-  }
-
-  .eds-checkbox__icon-wrapper {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    flex-shrink: 0;
-    overflow: visible;
-    line-height: 0;
-  }
-
-  /*
-   * Negative margin to match Figma's icon container padding.
-   *
-   * In Figma, the icon container has internal padding that positions the icon
-   * inward from the component edge. We replicate this with negative margin to:
-   * 1. Align the icon's left edge with Figma's design
-   * 2. Keep the component's padding consistent with other Field-based components
-   *
-   * The gap compensation (--_checkbox-gap-compensation) counteracts this for
-   * proper label spacing. See the gap compensation comment above for details.
-   */
-  .eds-field.eds-checkbox .eds-checkbox__icon-wrapper {
-    margin-block: -6px;
-    margin-inline: -4.8px;
-  }
-
-  .eds-checkbox--standalone::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: var(--eds-spacing-border-radius-pill);
-    background-color: transparent;
-    transition: background-color 150ms;
-  }
-
-  @media (hover: hover) and (pointer: fine) {
-    .eds-checkbox--standalone:hover::before {
-      background-color: var(--_checkbox-hover-color);
+    & .icon-wrapper {
+      /*
+       * Negative margin to match Figma's icon container padding.
+       *
+       * In Figma, the icon container has internal padding that positions the icon
+       * inward from the component edge. We replicate this with negative margin to:
+       * 1. Align the icon's left edge with Figma's design
+       * 2. Keep the component's padding consistent with other Field-based components
+       *
+       * The gap compensation (--_checkbox-gap-compensation) counteracts this for
+       * proper label spacing. See the gap compensation comment above for details.
+       */
+      margin-block: -6px;
+      margin-inline: -4.8px;
     }
 
-    .eds-checkbox--standalone[data-disabled='true']:hover::before {
-      background-color: transparent;
+    & label {
+      cursor: pointer;
     }
 
-    .eds-field.eds-checkbox:hover {
-      background-color: var(--_checkbox-hover-color);
+    &[data-disabled='true'] label {
+      cursor: not-allowed;
+      color: var(--eds-color-text-disabled);
     }
 
-    .eds-field.eds-checkbox[data-disabled='true']:hover {
-      background-color: transparent;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background-color: var(--_checkbox-hover-color);
+      }
+
+      &[data-disabled='true']:hover {
+        background-color: transparent;
+      }
     }
-  }
-
-  .eds-checkbox__input {
-    appearance: none;
-    position: absolute;
-    inset: 0;
-    margin: 0;
-    cursor: pointer;
-    z-index: 1;
-  }
-
-  .eds-checkbox__input:disabled {
-    cursor: not-allowed;
-  }
-
-  .eds-checkbox__input:focus {
-    outline: none;
-  }
-
-  .eds-checkbox:has(.eds-checkbox__input:focus-visible) {
-    outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
-    outline-offset: var(--eds-sizing-stroke-thick);
-    border-radius: var(--eds-spacing-border-radius-rounded);
-  }
-
-  .eds-checkbox--standalone:has(.eds-checkbox__input:focus-visible) {
-    border-radius: var(--eds-spacing-border-radius-pill);
-  }
-
-  .eds-checkbox__icon {
-    position: relative;
-    pointer-events: none;
-    fill: var(--_checkbox-icon-color);
-    flex-shrink: 0;
-  }
-
-  .eds-checkbox[data-disabled='true'] .eds-checkbox__icon {
-    fill: var(--eds-color-text-disabled);
-  }
-
-  /* Icon visibility */
-  .eds-checkbox__icon--checked,
-  .eds-checkbox__icon--indeterminate {
-    display: none;
-  }
-
-  .eds-checkbox__icon--unchecked {
-    display: block;
-  }
-
-  .eds-checkbox:has(.eds-checkbox__input:checked) .eds-checkbox__icon--checked {
-    display: block;
-  }
-
-  .eds-checkbox:has(.eds-checkbox__input:checked)
-    .eds-checkbox__icon--unchecked {
-    display: none;
-  }
-
-  .eds-checkbox:has(.eds-checkbox__input[data-indeterminate='true'])
-    .eds-checkbox__icon--indeterminate {
-    display: block;
-  }
-
-  .eds-checkbox:has(.eds-checkbox__input[data-indeterminate='true'])
-    .eds-checkbox__icon--checked,
-  .eds-checkbox:has(.eds-checkbox__input[data-indeterminate='true'])
-    .eds-checkbox__icon--unchecked {
-    display: none;
-  }
-
-  .eds-field.eds-checkbox .eds-field__label {
-    cursor: pointer;
-  }
-
-  .eds-field.eds-checkbox[data-disabled='true'] .eds-field__label {
-    color: var(--eds-color-text-disabled);
-    cursor: not-allowed;
-  }
-
-  .eds-field.eds-checkbox[data-color-appearance='accent'] {
-    --_eds-field-helper-color: var(--eds-color-text-neutral-subtle);
   }
 }

--- a/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.Description.tsx
@@ -9,9 +9,7 @@ export const FieldDescription = forwardRef<
     <p
       ref={ref}
       data-baseline="center"
-      className={['eds-field__description', className]
-        .filter(Boolean)
-        .join(' ')}
+      className={['description', className].filter(Boolean).join(' ')}
       {...rest}
     >
       {children}

--- a/packages/eds-core-react/src/components/next/Field/Field.HelperMessage.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.HelperMessage.tsx
@@ -27,9 +27,7 @@ export const HelperMessage = forwardRef<
       data-baseline="grid"
       id={id}
       role={role}
-      className={['eds-field__helper-message', className]
-        .filter(Boolean)
-        .join(' ')}
+      className={['helper-message', className].filter(Boolean).join(' ')}
       {...rest}
     >
       {children}

--- a/packages/eds-core-react/src/components/next/Field/Field.Label.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.Label.tsx
@@ -7,11 +7,11 @@ export const FieldLabel = forwardRef<HTMLLabelElement, FieldLabelProps>(
       <label
         ref={ref}
         data-baseline="center"
-        className={['eds-field__label', className].filter(Boolean).join(' ')}
+        className={['label', className].filter(Boolean).join(' ')}
         {...rest}
       >
         {children}
-        {indicator && <span className="eds-field__indicator">{indicator}</span>}
+        {indicator && <span className="indicator">{indicator}</span>}
       </label>
     )
   },

--- a/packages/eds-core-react/src/components/next/Field/Field.test.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.test.tsx
@@ -202,7 +202,7 @@ describe('Field.HelperMessage', () => {
       </Field.HelperMessage>,
     )
     const helper = screen.getByTestId('helper')
-    expect(helper).toHaveClass('eds-field__helper-message')
+    expect(helper).toHaveClass('helper-message')
   })
 
   test('accepts role prop for accessibility', () => {

--- a/packages/eds-core-react/src/components/next/Field/field.css
+++ b/packages/eds-core-react/src/components/next/Field/field.css
@@ -16,65 +16,65 @@
 
     /* Shared font-family — inherits to all text children */
     font-family: var(--eds-typography-ui-body-font-family);
-  }
 
-  /* Horizontal layout for toggle inputs (checkbox, radio, switch) */
-  .eds-field:is([data-position='start'], [data-position='end']) {
-    flex-flow: row wrap;
-    gap: var(--eds-generic-gap-horizontal);
-    align-items: center;
-  }
+    /* Horizontal layout for toggle inputs (checkbox, radio, switch) */
+    &:is([data-position='start'], [data-position='end']) {
+      flex-flow: row wrap;
+      gap: var(--eds-generic-gap-horizontal);
+      align-items: center;
+    }
 
-  .eds-field[data-position='end'] {
-    flex-direction: row-reverse;
-  }
+    &[data-position='end'] {
+      flex-direction: row-reverse;
+    }
 
-  /* Description and helper message span full width below in horizontal layout */
-  .eds-field:is([data-position='start'], [data-position='end'])
-    :is(.eds-field__description, .eds-field__helper-message, [role='alert']) {
-    flex-basis: 100%;
-  }
+    /* Description and helper message span full width below in horizontal layout */
+    &:is([data-position='start'], [data-position='end'])
+      :is(.description, .helper-message, [role='alert']) {
+      flex-basis: 100%;
+    }
 
-  /* Label uses data-baseline="center" for text-box trim + grid-snap padding —
-     see [data-baseline='center'] rule in eds-tokens/src/css/typography.css */
-  .eds-field__label {
-    display: block;
+    /* Label uses data-baseline="center" for text-box trim + grid-snap padding —
+       see [data-baseline='center'] rule in eds-tokens/src/css/typography.css */
+    & .label {
+      display: block;
 
-    font-size: var(--eds-typography-ui-body-md-font-size);
-    font-weight: var(--eds-typography-ui-body-md-font-weight-normal);
-    line-height: var(--eds-typography-ui-body-md-line-height-default);
-    color: var(--_eds-field-label-color);
-  }
+      font-size: var(--eds-typography-ui-body-md-font-size);
+      font-weight: var(--eds-typography-ui-body-md-font-weight-normal);
+      line-height: var(--eds-typography-ui-body-md-line-height-default);
+      color: var(--_eds-field-label-color);
+    }
 
-  .eds-field__indicator {
-    margin-inline-start: var(--eds-selectable-space-horizontal);
+    & .indicator {
+      margin-inline-start: var(--eds-selectable-space-horizontal);
 
-    font-size: var(--eds-typography-ui-body-sm-font-size);
-    line-height: var(--eds-typography-ui-body-sm-line-height-default);
-    color: var(--_eds-field-indicator-color);
-    vertical-align: middle;
-  }
+      font-size: var(--eds-typography-ui-body-sm-font-size);
+      line-height: var(--eds-typography-ui-body-sm-line-height-default);
+      color: var(--_eds-field-indicator-color);
+      vertical-align: middle;
+    }
 
-  .eds-field__description {
-    margin: 0;
-    color: var(--_eds-field-description-color);
-  }
+    & .description {
+      margin: 0;
+      color: var(--_eds-field-description-color);
+    }
 
-  .eds-field__helper-message {
-    margin: 0;
-    color: var(--_eds-field-helper-color);
-  }
+    & .helper-message {
+      margin: 0;
+      color: var(--_eds-field-helper-color);
+    }
 
-  /* data-baseline="grid" on these elements handles text-box trim via
-     [data-baseline='grid'] in eds-tokens/src/css/typography.css */
-  .eds-field__description,
-  .eds-field__helper-message {
-    font-size: var(--eds-typography-ui-body-sm-font-size);
-    line-height: var(--eds-typography-ui-body-sm-line-height-default);
-  }
+    /* data-baseline="grid" on these elements handles text-box trim via
+       [data-baseline='grid'] in eds-tokens/src/css/typography.css */
+    & .description,
+    & .helper-message {
+      font-size: var(--eds-typography-ui-body-sm-font-size);
+      line-height: var(--eds-typography-ui-body-sm-line-height-default);
+    }
 
-  /* Only helper message changes color when disabled */
-  .eds-field[data-disabled='true'] {
-    --_eds-field-helper-color: var(--eds-color-text-disabled);
+    /* Only helper message changes color when disabled */
+    &[data-disabled='true'] {
+      --_eds-field-helper-color: var(--eds-color-text-disabled);
+    }
   }
 }

--- a/packages/eds-core-react/src/components/next/Radio/Radio.tsx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.tsx
@@ -8,9 +8,6 @@ import { Field } from '../Field'
 import { Icon } from '../Icon'
 import type { RadioProps } from './Radio.types'
 
-const classNames = (...classes: (string | boolean | undefined)[]) =>
-  classes.filter(Boolean).join(' ')
-
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   { label, disabled = false, id: providedId, ...rest },
   ref,
@@ -23,21 +20,21 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
       <input
         type="radio"
         id={inputId}
-        className="eds-radio__input"
+        className="input"
         disabled={disabled}
         ref={ref}
         {...rest}
       />
-      <span className="eds-radio__icon-wrapper">
+      <span className="icon-wrapper">
         <Icon
           data={radio_button_selected}
           size="lg"
-          className="eds-radio__icon eds-radio__icon--checked"
+          className="icon icon-checked"
         />
         <Icon
           data={radio_button_unselected}
           size="lg"
-          className="eds-radio__icon eds-radio__icon--unchecked"
+          className="icon icon-unchecked"
         />
       </span>
     </>
@@ -62,7 +59,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 
   return (
     <span
-      className={classNames('eds-radio', 'eds-radio--standalone')}
+      className="eds-radio"
+      data-standalone={true}
       data-color-appearance={disabled ? 'neutral' : 'accent'}
       data-disabled={disabled || undefined}
     >

--- a/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Radio/__snapshots__/Radio.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`Radio (next) matches snapshot 1`] = `
     data-space-proportions="squished"
   >
     <input
-      class="eds-radio__input"
+      class="input"
       id="test-id"
       name="test"
       type="radio"
     />
     <span
-      class="eds-radio__icon-wrapper"
+      class="icon-wrapper"
     >
       <svg
         aria-hidden="true"
-        class="eds-icon eds-radio__icon eds-radio__icon--checked"
+        class="eds-icon icon icon-checked"
         data-icon-size="lg"
         data-testid="eds-icon"
         fill="currentColor"
@@ -35,7 +35,7 @@ exports[`Radio (next) matches snapshot 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="eds-icon eds-radio__icon eds-radio__icon--unchecked"
+        class="eds-icon icon icon-unchecked"
         data-icon-size="lg"
         data-testid="eds-icon"
         fill="currentColor"
@@ -50,7 +50,7 @@ exports[`Radio (next) matches snapshot 1`] = `
       </svg>
     </span>
     <label
-      class="eds-field__label"
+      class="label"
       data-baseline="center"
       for="test-id"
     >

--- a/packages/eds-core-react/src/components/next/Radio/radio.css
+++ b/packages/eds-core-react/src/components/next/Radio/radio.css
@@ -3,26 +3,128 @@
     --_radio-icon-color: var(--eds-color-bg-fill-emphasis-default);
     --_radio-hover-color: var(--eds-color-bg-fill-muted-default);
     --_radio-icon-size: var(--eds-sizing-icon-lg);
+
     /* Touch target: 36px spacious, 28px comfortable */
     --_radio-touch-target: 2.25rem;
+
     cursor: pointer;
     position: relative;
     box-sizing: border-box;
+
+    [data-density='comfortable'] & {
+      --_radio-touch-target: 1.75rem;
+    }
+
+    /* Standalone variant (no label) */
+    &[data-standalone] {
+      position: relative;
+
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      /* Padding calculated from touch target and icon size */
+      padding: calc((var(--_radio-touch-target) - var(--_radio-icon-size)) / 2);
+
+      &::before {
+        content: '';
+
+        position: absolute;
+        inset: 0;
+
+        border-radius: var(--eds-spacing-border-radius-pill);
+
+        background-color: transparent;
+
+        transition: background-color 150ms;
+      }
+
+      &:has(.input:focus-visible) {
+        border-radius: var(--eds-spacing-border-radius-pill);
+      }
+
+      @media (hover: hover) and (pointer: fine) {
+        &:hover::before {
+          background-color: var(--_radio-hover-color);
+        }
+
+        &[data-disabled='true']:hover::before {
+          background-color: transparent;
+        }
+      }
+    }
+
+    &[data-disabled='true'] {
+      cursor: not-allowed;
+    }
+
+    &:has(.input:focus-visible) {
+      border-radius: var(--eds-spacing-border-radius-rounded);
+      outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
+      outline-offset: var(--eds-sizing-stroke-thick);
+    }
+
+    & .icon-wrapper {
+      position: relative;
+
+      overflow: visible;
+      display: inline-flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+
+      line-height: 0;
+    }
+
+    & .input {
+      cursor: pointer;
+
+      position: absolute;
+      z-index: 1;
+      inset: 0;
+
+      margin: 0;
+
+      appearance: none;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+
+      &:focus {
+        outline: none;
+      }
+    }
+
+    & .icon {
+      pointer-events: none;
+      flex-shrink: 0;
+      fill: var(--_radio-icon-color);
+    }
+
+    &[data-disabled='true'] .icon {
+      fill: var(--eds-color-text-disabled);
+    }
+
+    /* Icon visibility */
+    & .icon-checked {
+      display: none;
+    }
+
+    & .icon-unchecked {
+      display: block;
+    }
+
+    &:has(.input:checked) .icon-checked {
+      display: block;
+    }
+
+    &:has(.input:checked) .icon-unchecked {
+      display: none;
+    }
   }
 
-  [data-density='comfortable'] .eds-radio {
-    --_radio-touch-target: 1.75rem;
-  }
-
-  .eds-radio--standalone {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    /* Padding calculated from touch target and icon size */
-    padding: calc((var(--_radio-touch-target) - var(--_radio-icon-size)) / 2);
-  }
-
+  /* Field layout variant */
   .eds-field.eds-radio {
     /*
      * Gap compensation for label alignment.
@@ -42,133 +144,51 @@
      * since the icons have different internal padding (Checkbox: 3px, Radio: 2px).
      */
     --_radio-gap-compensation: 0.2375rem;
+
     gap: calc(
       var(--eds-generic-gap-horizontal) + var(--_radio-gap-compensation)
     );
-    padding-inline: var(--eds-selectable-space-horizontal);
-    padding-block: var(--eds-selectable-space-vertical);
+
     width: auto;
+    padding-block: var(--eds-selectable-space-vertical);
+    padding-inline: var(--eds-selectable-space-horizontal);
     border-radius: var(--eds-spacing-border-radius-rounded);
+
     transition: background-color 150ms;
-  }
 
-  .eds-radio[data-disabled='true'] {
-    cursor: not-allowed;
-  }
-
-  .eds-radio__icon-wrapper {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    flex-shrink: 0;
-    overflow: visible;
-    line-height: 0;
-  }
-
-  /*
-   * Negative margin to match Figma's icon container padding.
-   *
-   * In Figma, the icon container has internal padding that positions the icon
-   * inward from the component edge. We replicate this with negative margin to:
-   * 1. Align the icon's left edge with Figma's design
-   * 2. Keep the component's padding consistent with other Field-based components
-   *
-   * The gap compensation (--_radio-gap-compensation) counteracts this for
-   * proper label spacing. See the gap compensation comment above for details.
-   */
-  .eds-field.eds-radio .eds-radio__icon-wrapper {
-    margin-block: -6px;
-    margin-inline: -4.8px;
-  }
-
-  .eds-radio--standalone::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: var(--eds-spacing-border-radius-pill);
-    background-color: transparent;
-    transition: background-color 150ms;
-  }
-
-  @media (hover: hover) and (pointer: fine) {
-    .eds-radio--standalone:hover::before {
-      background-color: var(--_radio-hover-color);
+    & .icon-wrapper {
+      /*
+       * Negative margin to match Figma's icon container padding.
+       *
+       * In Figma, the icon container has internal padding that positions the icon
+       * inward from the component edge. We replicate this with negative margin to:
+       * 1. Align the icon's left edge with Figma's design
+       * 2. Keep the component's padding consistent with other Field-based components
+       *
+       * The gap compensation (--_radio-gap-compensation) counteracts this for
+       * proper label spacing. See the gap compensation comment above for details.
+       */
+      margin-block: -6px;
+      margin-inline: -4.8px;
     }
 
-    .eds-radio--standalone[data-disabled='true']:hover::before {
-      background-color: transparent;
+    & label {
+      cursor: pointer;
     }
 
-    .eds-field.eds-radio:hover {
-      background-color: var(--_radio-hover-color);
+    &[data-disabled='true'] label {
+      cursor: not-allowed;
+      color: var(--eds-color-text-disabled);
     }
 
-    .eds-field.eds-radio[data-disabled='true']:hover {
-      background-color: transparent;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background-color: var(--_radio-hover-color);
+      }
+
+      &[data-disabled='true']:hover {
+        background-color: transparent;
+      }
     }
-  }
-
-  .eds-radio__input {
-    appearance: none;
-    position: absolute;
-    inset: 0;
-    margin: 0;
-    cursor: pointer;
-    z-index: 1;
-  }
-
-  .eds-radio__input:disabled {
-    cursor: not-allowed;
-  }
-
-  .eds-radio__input:focus {
-    outline: none;
-  }
-
-  .eds-radio:has(.eds-radio__input:focus-visible) {
-    outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
-    outline-offset: var(--eds-sizing-stroke-thick);
-    border-radius: var(--eds-spacing-border-radius-rounded);
-  }
-
-  .eds-radio--standalone:has(.eds-radio__input:focus-visible) {
-    border-radius: var(--eds-spacing-border-radius-pill);
-  }
-
-  .eds-radio__icon {
-    pointer-events: none;
-    fill: var(--_radio-icon-color);
-    flex-shrink: 0;
-  }
-
-  .eds-radio[data-disabled='true'] .eds-radio__icon {
-    fill: var(--eds-color-text-disabled);
-  }
-
-  /* Icon visibility */
-  .eds-radio__icon--checked {
-    display: none;
-  }
-
-  .eds-radio__icon--unchecked {
-    display: block;
-  }
-
-  .eds-radio:has(.eds-radio__input:checked) .eds-radio__icon--checked {
-    display: block;
-  }
-
-  .eds-radio:has(.eds-radio__input:checked) .eds-radio__icon--unchecked {
-    display: none;
-  }
-
-  .eds-field.eds-radio .eds-field__label {
-    cursor: pointer;
-  }
-
-  .eds-field.eds-radio[data-disabled='true'] .eds-field__label {
-    color: var(--eds-color-text-disabled);
-    cursor: not-allowed;
   }
 }

--- a/packages/eds-core-react/src/components/next/Switch/Switch.tsx
+++ b/packages/eds-core-react/src/components/next/Switch/Switch.tsx
@@ -46,14 +46,14 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
       data-color-appearance={disabled ? 'neutral' : 'accent'}
     >
       <span
-        className="eds-switch__control"
+        className="control"
         data-color-appearance={!disabled && isChecked ? 'accent' : 'neutral'}
       >
         <input
           type="checkbox"
           role="switch"
           id={inputId}
-          className="eds-switch__input"
+          className="input"
           disabled={disabled}
           ref={ref}
           checked={isControlled ? controlledChecked : undefined}
@@ -61,8 +61,8 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(function Switch(
           onChange={handleChange}
           {...rest}
         />
-        <span className="eds-switch__track">
-          <span className="eds-switch__handle" />
+        <span className="track">
+          <span className="handle" />
         </span>
       </span>
       <Field.Label htmlFor={inputId}>{label}</Field.Label>

--- a/packages/eds-core-react/src/components/next/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/Switch/__snapshots__/Switch.test.tsx.snap
@@ -11,25 +11,25 @@ exports[`Switch (next) matches snapshot 1`] = `
     data-space-proportions="squished"
   >
     <span
-      class="eds-switch__control"
+      class="control"
       data-color-appearance="neutral"
     >
       <input
-        class="eds-switch__input"
+        class="input"
         id="test-id"
         role="switch"
         type="checkbox"
       />
       <span
-        class="eds-switch__track"
+        class="track"
       >
         <span
-          class="eds-switch__handle"
+          class="handle"
         />
       </span>
     </span>
     <label
-      class="eds-field__label"
+      class="label"
       data-baseline="center"
       for="test-id"
     >

--- a/packages/eds-core-react/src/components/next/Switch/switch.css
+++ b/packages/eds-core-react/src/components/next/Switch/switch.css
@@ -34,10 +34,8 @@
     border-radius: var(--eds-spacing-border-radius-rounded);
 
     transition: background-color 150ms;
-  }
 
-  .eds-switch {
-    &:has(.eds-switch__input:focus-visible) {
+    &:has(.input:focus-visible) {
       outline: var(--eds-sizing-stroke-thin) solid var(--eds-color-border-focus);
       outline-offset: var(--eds-sizing-stroke-thick);
     }
@@ -46,105 +44,103 @@
       cursor: not-allowed;
     }
 
-    & .eds-field__label {
+    & label {
       cursor: pointer;
     }
 
-    &[data-disabled='true'] .eds-field__label {
+    &[data-disabled='true'] label {
       cursor: not-allowed;
       color: var(--eds-color-text-disabled);
+    }
+
+    &:has(.input:checked) .handle {
+      inset-inline-start: calc(100% - var(--_handle-size));
+    }
+
+    &:has(.input:disabled) .handle {
+      background-color: var(--eds-color-bg-disabled);
+    }
+
+    & .control {
+      display: inline-flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+
+      min-block-size: var(--_icon-size);
+
+      /* Negative margin for alignment with Checkbox/Radio icons */
+      margin-block: -6px;
+      margin-inline: -1.9px;
+
+      [data-density='comfortable'] & {
+        margin-inline: -2.1px;
+      }
+    }
+
+    & .input {
+      cursor: pointer;
+
+      position: absolute;
+      z-index: 1;
+      inset: 0;
+
+      margin: 0;
+
+      appearance: none;
+
+      &:focus {
+        outline: none;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+    }
+
+    & .track {
+      pointer-events: none;
+
+      position: relative;
+
+      display: inline-block;
+
+      inline-size: var(--_track-width);
+      block-size: var(--_track-height);
+      border-radius: var(--eds-spacing-border-radius-pill);
+
+      background-color: var(--eds-color-bg-fill-muted-default);
+
+      transition: background-color 150ms;
+    }
+
+    & .handle {
+      pointer-events: none;
+
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-start: 0;
+      translate: 0 -50%;
+
+      inline-size: var(--_handle-size);
+      block-size: var(--_handle-size);
+      border-radius: var(--eds-spacing-border-radius-pill);
+
+      background-color: var(--eds-color-bg-fill-emphasis-default);
+
+      transition:
+        inset-inline-start 150ms,
+        background-color 150ms;
     }
 
     @media (hover: hover) and (pointer: fine) {
       &:hover:not([data-disabled='true']) {
         background-color: var(--_switch-hover-color);
       }
-    }
-  }
 
-  .eds-switch__control {
-    display: inline-flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-
-    min-block-size: var(--_icon-size);
-
-    /* Negative margin for alignment with Checkbox/Radio icons */
-    margin-block: -6px;
-    margin-inline: -1.9px;
-  }
-
-  [data-density='comfortable'] .eds-switch__control {
-    margin-inline: -2.1px;
-  }
-
-  .eds-switch__input {
-    cursor: pointer;
-
-    position: absolute;
-    z-index: 1;
-    inset: 0;
-
-    margin: 0;
-
-    appearance: none;
-
-    &:focus {
-      outline: none;
-    }
-
-    &:disabled {
-      cursor: not-allowed;
-    }
-  }
-
-  .eds-switch__track {
-    pointer-events: none;
-
-    position: relative;
-
-    display: inline-block;
-
-    inline-size: var(--_track-width);
-    block-size: var(--_track-height);
-    border-radius: var(--eds-spacing-border-radius-pill);
-
-    background-color: var(--eds-color-bg-fill-muted-default);
-
-    transition: background-color 150ms;
-
-    @media (hover: hover) and (pointer: fine) {
-      .eds-switch:hover:not([data-disabled='true']) & {
+      &:hover:not([data-disabled='true']) .track {
         background-color: var(--_track-hover-bg);
       }
-    }
-  }
-
-  .eds-switch__handle {
-    pointer-events: none;
-
-    position: absolute;
-    inset-block-start: 50%;
-    inset-inline-start: 0;
-    translate: 0 -50%;
-
-    inline-size: var(--_handle-size);
-    block-size: var(--_handle-size);
-    border-radius: var(--eds-spacing-border-radius-pill);
-
-    background-color: var(--eds-color-bg-fill-emphasis-default);
-
-    transition:
-      inset-inline-start 150ms,
-      background-color 150ms;
-
-    .eds-switch:has(.eds-switch__input:checked) & {
-      inset-inline-start: calc(100% - var(--_handle-size));
-    }
-
-    .eds-switch:has(.eds-switch__input:disabled) & {
-      background-color: var(--eds-color-bg-disabled);
     }
   }
 }

--- a/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/eds-core-react/src/components/next/TextField/__snapshots__/TextField.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
       class="eds-text-field__header"
     >
       <label
-        class="eds-field__label"
+        class="label"
         data-baseline="center"
         for="test-id-input"
       >
@@ -17,7 +17,7 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
       </label>
     </div>
     <p
-      class="eds-field__description"
+      class="description"
       data-baseline="center"
       id="test-id-description"
     >
@@ -43,7 +43,7 @@ exports[`TextField (Next EDS 2.0) Matches snapshot 1`] = `
       />
     </div>
     <p
-      class="eds-field__helper-message"
+      class="helper-message"
       data-baseline="grid"
       id="test-id-helper-message"
     >


### PR DESCRIPTION
## Summary

Converts Field, Switch, Radio, and Checkbox from BEM-style class names to the flat class name convention used by Button, Chip, and Avatar. These four components must land together because Radio, Checkbox, and Switch all have CSS rules that cross-reference Field's internal class names. Part of [#5104](https://github.com/equinor/design-system/issues/5104).

## Changes

**Field** (`eds-field__*` → flat):
- `eds-field__label` → `label`
- `eds-field__indicator` → `indicator`
- `eds-field__description` → `description`
- `eds-field__helper-message` → `helper-message`

**Switch** (`eds-switch__*` → flat):
- `eds-switch__control` → `control`
- `eds-switch__input` → `input`
- `eds-switch__track` → `track`
- `eds-switch__handle` → `handle`

**Radio** (`eds-radio__*` → flat, modifier → data attribute):
- `eds-radio__icon-wrapper` → `icon-wrapper`
- `eds-radio__input` → `input`
- `eds-radio__icon` → `icon`
- `eds-radio__icon--checked` → `icon-checked`
- `eds-radio__icon--unchecked` → `icon-unchecked`
- `eds-radio--standalone` (class modifier) → `data-standalone` attribute

**Checkbox** (`eds-checkbox__*` → flat, modifier → data attribute):
- `eds-checkbox__icon-wrapper` → `icon-wrapper`
- `eds-checkbox__input` → `input`
- `eds-checkbox__icon` → `icon`
- `eds-checkbox__icon--checked` → `icon-checked`
- `eds-checkbox__icon--unchecked` → `icon-unchecked`
- `eds-checkbox__icon--indeterminate` → `icon-indeterminate`
- `eds-checkbox--standalone` (class modifier) → `data-standalone` attribute

All four CSS files are restructured to use full CSS nesting. Cross-component selectors that previously referenced `.eds-field__label` by class now target the native `label` element instead, removing the coupling to Field's internal class names.

**BREAKING CHANGE:** Consumers targeting any of these class names directly in their own CSS must update to the new flat names.

Closes part of #5104

## Design decisions

**`--standalone` becomes `data-standalone`** rather than a CSS class `.standalone` — AGENTS.md convention says variants and states use `data-*` attributes, not modifier classes. `standalone` is a layout variant so a data attribute is the right fit.

**Cross-component selectors use `label` (native element) rather than `.label`** — Radio, Checkbox, and Switch previously reached into Field's internals with `.eds-field__label`. Updating to `label` (the HTML element Field always renders for its label) removes the class name coupling entirely, so a future Field rename won't silently break these components.

## Test plan

- [ ] `npx jest --testPathPatterns="next/Field|next/Switch|next/Radio|next/Checkbox" --no-coverage` — 72 tests pass
- [ ] Start Storybook and verify all four components render correctly:
  - Field: label, indicator, description, helper message all styled correctly
  - Switch: track, handle, checked state, disabled state
  - Radio: standalone (no label) and with label, checked state, disabled state
  - Checkbox: standalone, with label, checked/indeterminate/disabled states