### PR TITLE
chore: make release-please exclude-paths repo-root-relative

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,24 +7,24 @@
       "package-name": "@equinor/eds-core-react",
       "component": "eds-core-react",
       "exclude-paths": [
-        "src/components/next",
-        ".storybook",
-        "stories",
-        "tests",
-        ".gitignore",
-        ".cachebust",
-        "rollup.config.js",
-        "jest.config.cjs",
-        "jest.setup.ts",
-        "tsconfig.json",
-        "tsconfig.build.json",
-        "tsconfig.test.json",
-        "playwright.config.ts",
-        "Dockerfile.storybook",
-        "nginx.conf",
-        "README.md",
-        "FIGMA_CODE_CONNECT.md",
-        "figma.config.json"
+        "packages/eds-core-react/src/components/next",
+        "packages/eds-core-react/.storybook",
+        "packages/eds-core-react/stories",
+        "packages/eds-core-react/tests",
+        "packages/eds-core-react/.gitignore",
+        "packages/eds-core-react/.cachebust",
+        "packages/eds-core-react/rollup.config.js",
+        "packages/eds-core-react/jest.config.cjs",
+        "packages/eds-core-react/jest.setup.ts",
+        "packages/eds-core-react/tsconfig.json",
+        "packages/eds-core-react/tsconfig.build.json",
+        "packages/eds-core-react/tsconfig.test.json",
+        "packages/eds-core-react/playwright.config.ts",
+        "packages/eds-core-react/Dockerfile.storybook",
+        "packages/eds-core-react/nginx.conf",
+        "packages/eds-core-react/README.md",
+        "packages/eds-core-react/FIGMA_CODE_CONNECT.md",
+        "packages/eds-core-react/figma.config.json"
       ]
     },
     "packages/eds-core-react/src/components/next": {
@@ -37,17 +37,17 @@
       "package-name": "@equinor/eds-data-grid-react",
       "component": "eds-data-grid-react",
       "exclude-paths": [
-        ".storybook",
-        "src/tests",
-        "src/stories",
-        "src/EdsDataGrid.stories.tsx",
-        "jest.config.ts",
-        "jest.setup.ts",
-        "rollup.config.js",
-        "tsconfig.json",
-        "tsconfig.build.json",
-        "tsconfig.test.json",
-        "README.md"
+        "packages/eds-data-grid-react/.storybook",
+        "packages/eds-data-grid-react/src/tests",
+        "packages/eds-data-grid-react/src/stories",
+        "packages/eds-data-grid-react/src/EdsDataGrid.stories.tsx",
+        "packages/eds-data-grid-react/jest.config.ts",
+        "packages/eds-data-grid-react/jest.setup.ts",
+        "packages/eds-data-grid-react/rollup.config.js",
+        "packages/eds-data-grid-react/tsconfig.json",
+        "packages/eds-data-grid-react/tsconfig.build.json",
+        "packages/eds-data-grid-react/tsconfig.test.json",
+        "packages/eds-data-grid-react/README.md"
       ]
     },
     "packages/eds-icons": {
@@ -55,9 +55,9 @@
       "package-name": "@equinor/eds-icons",
       "component": "eds-icons",
       "exclude-paths": [
-        "rollup.config.js",
-        "tsconfig.json",
-        "README.md"
+        "packages/eds-icons/rollup.config.js",
+        "packages/eds-icons/tsconfig.json",
+        "packages/eds-icons/README.md"
       ]
     },
     "packages/eds-lab-react": {
@@ -65,19 +65,19 @@
       "package-name": "@equinor/eds-lab-react",
       "component": "eds-lab-react",
       "exclude-paths": [
-        ".storybook",
-        "stories",
-        "src/stories",
-        "babel.config.cjs",
-        "jest.config.cjs",
-        "jest.setup.ts",
-        "rollup.config.js",
-        "tsconfig.json",
-        "tsconfig.build.json",
-        "tsconfig.test.json",
-        "Dockerfile.storybook",
-        "nginx.conf",
-        "README.md"
+        "packages/eds-lab-react/.storybook",
+        "packages/eds-lab-react/stories",
+        "packages/eds-lab-react/src/stories",
+        "packages/eds-lab-react/babel.config.cjs",
+        "packages/eds-lab-react/jest.config.cjs",
+        "packages/eds-lab-react/jest.setup.ts",
+        "packages/eds-lab-react/rollup.config.js",
+        "packages/eds-lab-react/tsconfig.json",
+        "packages/eds-lab-react/tsconfig.build.json",
+        "packages/eds-lab-react/tsconfig.test.json",
+        "packages/eds-lab-react/Dockerfile.storybook",
+        "packages/eds-lab-react/nginx.conf",
+        "packages/eds-lab-react/README.md"
       ]
     },
     "packages/eds-tokens": {
@@ -85,19 +85,19 @@
       "package-name": "@equinor/eds-tokens",
       "component": "eds-tokens",
       "exclude-paths": [
-        "tokens",
-        "build-generate-variables",
-        "scripts",
-        ".vscode",
-        ".gitignore",
-        "rollup.config.js",
-        "tsconfig.json",
-        "vite.generate-variables.config.ts",
-        "palette-config.json",
-        "token-config.json",
-        "tokens.json",
-        "README.md",
-        "CLAUDE.md"
+        "packages/eds-tokens/tokens",
+        "packages/eds-tokens/build-generate-variables",
+        "packages/eds-tokens/scripts",
+        "packages/eds-tokens/.vscode",
+        "packages/eds-tokens/.gitignore",
+        "packages/eds-tokens/rollup.config.js",
+        "packages/eds-tokens/tsconfig.json",
+        "packages/eds-tokens/vite.generate-variables.config.ts",
+        "packages/eds-tokens/palette-config.json",
+        "packages/eds-tokens/token-config.json",
+        "packages/eds-tokens/tokens.json",
+        "packages/eds-tokens/README.md",
+        "packages/eds-tokens/CLAUDE.md"
       ]
     },
     "packages/eds-utils": {
@@ -105,12 +105,12 @@
       "package-name": "@equinor/eds-utils",
       "component": "eds-utils",
       "exclude-paths": [
-        "rollup.config.js",
-        "tsconfig.json",
-        "tsconfig.build.json",
-        "vitest.config.ts",
-        "vitest.setup.ts",
-        "README.md"
+        "packages/eds-utils/rollup.config.js",
+        "packages/eds-utils/tsconfig.json",
+        "packages/eds-utils/tsconfig.build.json",
+        "packages/eds-utils/vitest.config.ts",
+        "packages/eds-utils/vitest.setup.ts",
+        "packages/eds-utils/README.md"
       ]
     }
   },

--- a/.github/release-please-config.md
+++ b/.github/release-please-config.md
@@ -68,7 +68,7 @@ The `eds-core-react` package uses a **dual release strategy** to support both st
   "release-type": "node",
   "package-name": "@equinor/eds-core-react",
   "component": "eds-core-react",
-  "exclude-paths": ["src/components/next"]
+  "exclude-paths": ["packages/eds-core-react/src/components/next"]
 }
 ```
 
@@ -100,6 +100,8 @@ The `eds-core-react` package uses a **dual release strategy** to support both st
 ### Exclude Paths
 
 All packages use `exclude-paths` to prevent non-publishable files from triggering version bumps. This includes config files, test files, Storybook, documentation, and build tooling.
+
+**Paths are resolved relative to the repository root**, not to the package directory, and matched as directory prefixes (release-please checks that a file path starts with `<exclude-path>/`). Always write the full path including the package prefix — e.g. `packages/eds-core-react/src/components/next`, **not** `src/components/next`. A package-relative entry silently matches nothing, which previously let `/next`-only commits leak into the stable `eds-core-react` release.
 
 **Important limitation:** `exclude-paths` only filters file-path-based detection. If a commit has a **scope that matches a package's `component` name** (e.g. `feat(eds-core-react): ...`), it will trigger a release for that package regardless of `exclude-paths`. To avoid this, use non-release-triggering types (`chore`, `build`, `ci`, `test`) for commits that only touch excluded files. See `documentation/how-to/CONVENTIONAL_COMMITS.md` for guidance.
 


### PR DESCRIPTION
## Problem

release-please keeps adding a spurious `eds-core-react` release (most recently `2.7.0` with **Dialog EDS 2.0**) to every release PR, even though Dialog was only released to beta (`eds-core-react-next@v2.8.0-beta.1`). This has required manual cleanup of each release PR (e.g. #5106, #5116).

## Root cause

release-please resolves `exclude-paths` **relative to the repository root** and matches them by prefix — a file is only excluded when it starts with `${excludePath}/` (see [`commit-exclude.ts`](https://github.com/googleapis/release-please/blob/main/src/util/commit-exclude.ts) and the [manifest docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md): *"path segment should be a folder relative to repository root"*).

Our config listed them **package-relative**, e.g. `"src/components/next"`. The actual file path is `packages/eds-core-react/src/components/next/Dialog/Dialog.tsx`, which does **not** start with `src/components/next/`. So the exclusions never matched and excluded **nothing** — every next-only `feat`/`fix` leaked into the parent `eds-core-react` release.

## Fix

Prefix every `exclude-path` with its package path so it resolves correctly from the repo root. This affects all packages (not just core — `eds-tokens`, `eds-data-grid-react`, etc. had the same broken paths).

After this merges, release-please will correctly exclude the `next` subfolder, storybook, tests, and config files. The pending spurious core release in #5116 should disappear on the next release-please run.

No behaviour change for legitimate source commits — `exclude-paths` can only ever *exclude*.
