### PR TITLE
docs: clarify EDS 2.0 vs eds-core-react@3.x naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ See our [storybook](https://storybook.eds.equinor.com/) for more examples.
 
 We're developing the next generation of EDS components under the `/next` entry point. These components are available as **beta releases** for early testing and feedback.
 
-> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate, and the numbers happen to be close. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
+> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate; the numbers line up by coincidence. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
 
 #### Installation
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ See our [storybook](https://storybook.eds.equinor.com/) for more examples.
 
 We're developing the next generation of EDS components under the `/next` entry point. These components are available as **beta releases** for early testing and feedback.
 
+> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate, and the numbers happen to be close. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
+
 #### Installation
 
 ```sh

--- a/apps/design-system-docs/docs/about/about_eds.md
+++ b/apps/design-system-docs/docs/about/about_eds.md
@@ -58,7 +58,7 @@ Start building immediately with tools designed for your workflow.
 
 ## Versioning
 
-"EDS 2.0" is the name of the next generation of the design system. Its components currently live in beta under the `/next` entry point of the `eds-core-react` package, alongside the stable EDS 1 components.
+"EDS 2.0" is the name of the next generation of the design system. Its components currently live in beta under the `/next` entry point of the `eds-core-react` package, alongside the stable EDS 1 components. The package itself is on version `2.x` today, so an installed `eds-core-react@2.x` matching "EDS 2.0" is also a coincidence.
 
 When EDS 2.0 stabilises, the components move out of `/next` and EDS 1 is deprecated. Because removing EDS 1 is a breaking change, the package bumps to `eds-core-react@3.0.0`.
 

--- a/apps/design-system-docs/docs/about/about_eds.md
+++ b/apps/design-system-docs/docs/about/about_eds.md
@@ -56,6 +56,16 @@ EDS provides everything you need to build consistent, accessible interfaces:
 
 Start building immediately with tools designed for your workflow.
 
+## Versioning
+
+"EDS 2.0" is the name of the next generation of the design system. Its components currently live in beta under the `/next` entry point of the `eds-core-react` package, alongside the stable EDS 1 components.
+
+When EDS 2.0 stabilises, the components move out of `/next` and EDS 1 is deprecated. Because removing EDS 1 is a breaking change, the package bumps to `eds-core-react@3.0.0`.
+
+:::info
+The numbers line up by coincidence: "2.0" is the design system name, and "3.0.0" is the semver consequence of removing EDS 1. There is no "EDS 3.0" — the package version and the design system name are separate things.
+:::
+
 ## Support & Community
 
 Visit our [Support page](../support/support.md) for help channels, office hours, and direct access to our team.

--- a/apps/design-system-docs/docs/about/getting-started/develop/getting_started_development.md
+++ b/apps/design-system-docs/docs/about/getting-started/develop/getting_started_development.md
@@ -19,6 +19,10 @@ npm install @equinor/eds-core-react
 yarn add @equinor/eds-core-react
 ```
 
+:::note
+"EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are not the same — see [Versioning](../../about_eds.md#versioning) for the relationship.
+:::
+
 ### Load fonts
 
 EDS components use the **Equinor** font family. EDS 2.0 (`next`) components additionally require **Inter**. Add the EDS variable font stylesheet to your HTML `<head>` to load both:

--- a/packages/eds-core-react/README.md
+++ b/packages/eds-core-react/README.md
@@ -21,7 +21,7 @@ import { Button, Typography } from '@equinor/eds-core-react'
 
 ⚠️ **Experimental** – For testing and feedback only. Not production-ready.
 
-> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
+> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate; the numbers line up by coincidence. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
 
 ```bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/README.md
+++ b/packages/eds-core-react/README.md
@@ -21,6 +21,8 @@ import { Button, Typography } from '@equinor/eds-core-react'
 
 ⚠️ **Experimental** – For testing and feedback only. Not production-ready.
 
+> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
+
 ```bash
 npm install @equinor/eds-core-react@beta
 ```

--- a/packages/eds-core-react/stories/docs/EDS2.mdx
+++ b/packages/eds-core-react/stories/docs/EDS2.mdx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 Welcome to the next generation of the Equinor Design System! 🎉
 
-> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate, and the numbers happen to be close. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
+> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate; the numbers line up by coincidence. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
 
 ## What is EDS 2.0?
 

--- a/packages/eds-core-react/stories/docs/EDS2.mdx
+++ b/packages/eds-core-react/stories/docs/EDS2.mdx
@@ -6,6 +6,8 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 Welcome to the next generation of the Equinor Design System! 🎉
 
+> **Note on naming:** "EDS 2.0" is the design system name; `eds-core-react` is the package version (semver). They are separate, and the numbers happen to be close. See [Versioning](https://eds.equinor.com/docs/about/about_eds#versioning) for the full explanation.
+
 ## What is EDS 2.0?
 
 EDS 2.0 is a complete redesign of our component library, bringing:


### PR DESCRIPTION
## Summary

- Add a canonical **Versioning** section to the About EDS page explaining that "EDS 2.0" is the design system name and `eds-core-react@3.0.0` is the semver consequence of deprecating EDS 1 — they are separate things and there is no "EDS 3.0".
- Cross-reference the section from the dev getting-started page, root README, package README (visible on npm), and the Storybook "About EDS 2.0" page.
- One canonical explanation, short pointers elsewhere — single place to maintain.

## Why

Internal and external confusion has been growing around "EDS 2.0" vs "EDS 3.0" (the upcoming package major). This gives us one link to share whenever the wrong term shows up.

## Test plan

- [ ] Docusaurus builds and the Versioning anchor (`#versioning`) resolves on the About EDS page
- [ ] Storybook builds and the "About EDS 2.0" page renders the new note
- [ ] Links from READMEs to `eds.equinor.com/docs/about/about_eds#versioning` resolve once merged and deployed