### PR TITLE
chore: add tokens studio agent and cli setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,6 +27,8 @@ User-invokable prompts triggered with `/command-name`.
 | ----------------------- | ------------------------------------- | -------------------------------------------------------- |
 | `/new-component`        | `/new-component Button`               | Scaffold a new EDS 2.0 component with all required files |
 | `/create-component-doc` | `/create-component-doc <raw content>` | Restructure raw content into component documentation     |
+| `/accessibility-audit`  | `/accessibility-audit <url>`          | Audit a page or Storybook story against WCAG 2.1 AA      |
+| `/audit-harnesses`      | `/audit-harnesses`                    | Audit AI harness configs for drift across tools          |
 | `/tokens-studio`        | `/tokens-studio <task>`               | Tokens Studio platform / studio CLI pipeline assistant   |
 
 ## Hooks

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,6 +27,7 @@ User-invokable prompts triggered with `/command-name`.
 | ----------------------- | ------------------------------------- | -------------------------------------------------------- |
 | `/new-component`        | `/new-component Button`               | Scaffold a new EDS 2.0 component with all required files |
 | `/create-component-doc` | `/create-component-doc <raw content>` | Restructure raw content into component documentation     |
+| `/tokens-studio`        | `/tokens-studio <task>`               | Tokens Studio platform / studio CLI pipeline assistant   |
 
 ## Hooks
 

--- a/.claude/commands/tokens-studio.md
+++ b/.claude/commands/tokens-studio.md
@@ -9,7 +9,7 @@ Help with the Tokens Studio platform and `studio` CLI task described in **$ARGUM
 ## Steps
 
 1. Verify before asserting: run `pnpm exec studio <command> --help` from `packages/eds-tokens` for CLI questions, and fetch the relevant `documentation-v2.tokens.studio` page for platform questions — do not answer from memory alone.
-2. Classify every command against the safety rubric in the canonical doc before running it. Ask the user before anything that mutates remote state (`exports create/update/delete`, `config remove --delete-files`). `studio auth login` is interactive — the user runs it themselves.
+2. Classify every command against the safety rubric in the canonical doc before running it. Ask the user before anything the rubric classifies as remote-mutating — shortcut aliases (`studio logout` = `auth logout`) count too. `studio auth login` is interactive — the user runs it themselves.
 3. If the installed CLI version differs from the snapshot in the canonical doc, tell the user and offer to regenerate the snapshot section.
 
 If `$ARGUMENTS` is empty, ask what the user wants to do with Tokens Studio before proceeding.

--- a/.claude/commands/tokens-studio.md
+++ b/.claude/commands/tokens-studio.md
@@ -1,0 +1,15 @@
+# Tokens Studio Pipeline Assistant
+
+Help with the Tokens Studio platform and `studio` CLI task described in **$ARGUMENTS** — pulling tokens, export configurations, `.studio.json`, auth, branches/releases, or building the new token pipeline.
+
+> **Canonical reference:** [`documentation/agent-instructions/TOKENS_STUDIO.md`](../../documentation/agent-instructions/TOKENS_STUDIO.md) — platform concepts, CLI setup, configuration model, command overview, safety rubric, and how to stay current. The legacy Figma-REST pipeline is documented in [`documentation/how-to/TOKEN_SYSTEM_GUIDE.md`](../../documentation/how-to/TOKEN_SYSTEM_GUIDE.md).
+
+@../../documentation/agent-instructions/TOKENS_STUDIO.md
+
+## Steps
+
+1. Verify before asserting: run `pnpm exec studio <command> --help` from `packages/eds-tokens` for CLI questions, and fetch the relevant `documentation-v2.tokens.studio` page for platform questions — do not answer from memory alone.
+2. Classify every command against the safety rubric in the canonical doc before running it. Ask the user before anything that mutates remote state (`exports create/update/delete`, `config remove --delete-files`). `studio auth login` is interactive — the user runs it themselves.
+3. If the installed CLI version differs from the snapshot in the canonical doc, tell the user and offer to regenerate the snapshot section.
+
+If `$ARGUMENTS` is empty, ask what the user wants to do with Tokens Studio before proceeding.

--- a/.github/prompts/tokens-studio.prompt.md
+++ b/.github/prompts/tokens-studio.prompt.md
@@ -12,5 +12,5 @@ Help with the following Tokens Studio task, following the canonical doc above: $
 ## Steps
 
 1. Verify before asserting: run `pnpm exec studio <command> --help` from `packages/eds-tokens` for CLI questions, and fetch the relevant `documentation-v2.tokens.studio` page for platform questions — do not answer from memory alone.
-2. Classify every command against the safety rubric in the canonical doc before running it. Ask the user before anything that mutates remote state (`exports create/update/delete`, `config remove --delete-files`). `studio auth login` is interactive — the user runs it themselves.
+2. Classify every command against the safety rubric in the canonical doc before running it. Ask the user before anything the rubric classifies as remote-mutating — shortcut aliases (`studio logout` = `auth logout`) count too. `studio auth login` is interactive — the user runs it themselves.
 3. If the installed CLI version differs from the snapshot in the canonical doc, tell the user and offer to regenerate the snapshot section.

--- a/.github/prompts/tokens-studio.prompt.md
+++ b/.github/prompts/tokens-studio.prompt.md
@@ -1,0 +1,16 @@
+---
+mode: agent
+description: Help with the Tokens Studio platform and studio CLI (pull, exports, config, auth, pipeline)
+---
+
+# Tokens Studio Pipeline Assistant
+
+> **Canonical reference:** [`documentation/agent-instructions/TOKENS_STUDIO.md`](../../documentation/agent-instructions/TOKENS_STUDIO.md) — platform concepts, CLI setup, configuration model, command overview, safety rubric, and how to stay current. The legacy Figma-REST pipeline is documented in [`documentation/how-to/TOKEN_SYSTEM_GUIDE.md`](../../documentation/how-to/TOKEN_SYSTEM_GUIDE.md).
+
+Help with the following Tokens Studio task, following the canonical doc above: ${input:task}
+
+## Steps
+
+1. Verify before asserting: run `pnpm exec studio <command> --help` from `packages/eds-tokens` for CLI questions, and fetch the relevant `documentation-v2.tokens.studio` page for platform questions — do not answer from memory alone.
+2. Classify every command against the safety rubric in the canonical doc before running it. Ask the user before anything that mutates remote state (`exports create/update/delete`, `config remove --delete-files`). `studio auth login` is interactive — the user runs it themselves.
+3. If the installed CLI version differs from the snapshot in the canonical doc, tell the user and offer to regenerate the snapshot section.

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -53,7 +53,7 @@ Primary agents are selectable by the user and run as the main conversation agent
 |-------|-------------|-------|
 | `build` | Development agent with EDS conventions | All (asks for git commit/push/branch) |
 | `advisor` | Read-only architectural advice and code reviews | Read-only (no write/edit/bash) |
-| `tokens-studio` | Tokens Studio pipeline assistant (studio CLI, pull, exports, config) | All (asks for git commit/push + remote-mutating studio commands) |
+| `tokens-studio` | Tokens Studio pipeline assistant (studio CLI, pull, exports, config) | All (asks for git commit/push/branch, gh, and remote-mutating studio commands) |
 
 ### Sub-Agents
 

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -53,6 +53,7 @@ Primary agents are selectable by the user and run as the main conversation agent
 |-------|-------------|-------|
 | `build` | Development agent with EDS conventions | All (asks for git commit/push/branch) |
 | `advisor` | Read-only architectural advice and code reviews | Read-only (no write/edit/bash) |
+| `tokens-studio` | Tokens Studio pipeline assistant (studio CLI, pull, exports, config) | All (asks for git commit/push + remote-mutating studio commands) |
 
 ### Sub-Agents
 
@@ -214,7 +215,8 @@ Refer to AGENTS.md for full conventions.
 │   ├── figma-component.md  # Sub-agent: Figma-to-code
 │   ├── accessibility-audit.md  # Sub-agent: A11y auditor
 │   ├── component-doc.md    # Sub-agent: Documentation
-│   └── audit-harnesses.md  # Sub-agent: Harness auditor
+│   ├── audit-harnesses.md  # Sub-agent: Harness auditor
+│   └── tokens-studio.md    # Primary: Tokens Studio pipeline assistant
 ```
 
 ## Best Practices

--- a/.opencode/agent/tokens-studio.md
+++ b/.opencode/agent/tokens-studio.md
@@ -1,6 +1,10 @@
 ---
 description: Tokens Studio pipeline assistant — studio CLI, pull, exports, config, auth
 mode: primary
+# The ask-list below must be kept in sync with the safety rubric in
+# documentation/agent-instructions/TOKENS_STUDIO.md as the CLI grows —
+# with allow-by-default, a new remote-mutating subcommand in a future
+# CLI version is auto-approved until it is added here.
 permission:
   bash:
     '*': 'allow'

--- a/.opencode/agent/tokens-studio.md
+++ b/.opencode/agent/tokens-studio.md
@@ -6,12 +6,15 @@ permission:
     '*': 'allow'
     'git commit*': 'ask'
     'git push*': 'ask'
-    '*exports create*': 'ask'
-    '*exports update*': 'ask'
-    '*exports delete*': 'ask'
-    '*exports duplicate*': 'ask'
-    '*config remove*': 'ask'
-    '*auth logout*': 'ask'
+    'git checkout -b*': 'ask'
+    'git branch*': 'ask'
+    'gh *': 'ask'
+    '*studio exports create*': 'ask'
+    '*studio exports update*': 'ask'
+    '*studio exports delete*': 'ask'
+    '*studio exports duplicate*': 'ask'
+    '*studio auth logout*': 'ask'
+    '*studio logout*': 'ask'
 ---
 
 You help build and run the Tokens Studio-based token pipeline: the `studio` CLI, `.studio.json` configuration, token pulls, export configurations, authentication, and platform concepts (branches, releases, DTCG).
@@ -21,5 +24,5 @@ You help build and run the Tokens Studio-based token pipeline: the `studio` CLI,
 ## Flow
 
 1. Verify before asserting: run `pnpm exec studio <command> --help` from `packages/eds-tokens` for CLI questions, and fetch the relevant `documentation-v2.tokens.studio` page for platform questions — do not answer from memory alone.
-2. Classify every command against the safety rubric in the canonical doc before running it. Commands that mutate remote state (`exports create/update/delete`, `config remove --delete-files`) require explicit user approval — the permission config above enforces this. `studio auth login` is interactive — the user runs it themselves.
+2. Classify every command against the safety rubric in the canonical doc before running it. Commands that mutate remote state or credentials require explicit user approval — the permission config above backstops the common forms, but shortcut aliases and future commands may not match a glob, so classify against the rubric first. `studio auth login` is interactive — the user runs it themselves.
 3. If the installed CLI version differs from the snapshot in the canonical doc, tell the user and offer to regenerate the snapshot section.

--- a/.opencode/agent/tokens-studio.md
+++ b/.opencode/agent/tokens-studio.md
@@ -1,0 +1,25 @@
+---
+description: Tokens Studio pipeline assistant — studio CLI, pull, exports, config, auth
+mode: primary
+permission:
+  bash:
+    '*': 'allow'
+    'git commit*': 'ask'
+    'git push*': 'ask'
+    '*exports create*': 'ask'
+    '*exports update*': 'ask'
+    '*exports delete*': 'ask'
+    '*exports duplicate*': 'ask'
+    '*config remove*': 'ask'
+    '*auth logout*': 'ask'
+---
+
+You help build and run the Tokens Studio-based token pipeline: the `studio` CLI, `.studio.json` configuration, token pulls, export configurations, authentication, and platform concepts (branches, releases, DTCG).
+
+> **Canonical reference:** [`documentation/agent-instructions/TOKENS_STUDIO.md`](../../documentation/agent-instructions/TOKENS_STUDIO.md) — platform concepts, CLI setup, configuration model, command overview, safety rubric, and how to stay current. The legacy Figma-REST pipeline is documented in [`documentation/how-to/TOKEN_SYSTEM_GUIDE.md`](../../documentation/how-to/TOKEN_SYSTEM_GUIDE.md).
+
+## Flow
+
+1. Verify before asserting: run `pnpm exec studio <command> --help` from `packages/eds-tokens` for CLI questions, and fetch the relevant `documentation-v2.tokens.studio` page for platform questions — do not answer from memory alone.
+2. Classify every command against the safety rubric in the canonical doc before running it. Commands that mutate remote state (`exports create/update/delete`, `config remove --delete-files`) require explicit user approval — the permission config above enforces this. `studio auth login` is interactive — the user runs it themselves.
+3. If the installed CLI version differs from the snapshot in the canonical doc, tell the user and offer to regenerate the snapshot section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,12 @@ If you need to verify a secret file's shape, report length + first/last few char
 
 **Enforcement matrix:**
 
-| Harness        | Enforcement                                                                                 |
-| -------------- | ------------------------------------------------------------------------------------------- |
-| Claude Code    | Hard-enforced via `.claude/settings.json` `permissions.deny` + `.claude/hooks/read_hook.js` |
-| Copilot CLI    | Hard-enforced via `.github/hooks/block-secrets.json` + `.github/hooks/block-secrets.js`     |
-| Copilot in IDE | Agent-respected only — IDE Copilot does not run the CLI hook; follow this rule manually     |
-| OpenCode       | Agent-respected only — `permission.bash` covers commands, not file reads                    |
+| Harness        | Enforcement                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| Claude Code    | Hard-enforced via `.claude/settings.json` `permissions.deny` + `.claude/hooks/read_hook.js`|
+| Copilot CLI    | Hard-enforced via `.github/hooks/block-secrets.json` + `.github/hooks/block-secrets.js`    |
+| Copilot in IDE | Agent-respected only — IDE Copilot does not run the CLI hook; follow this rule manually    |
+| OpenCode       | Agent-respected only — `permission.bash` covers commands, not file reads                   |
 
 ## Code Formatting
 
@@ -426,7 +426,7 @@ type: description
 
 **Breaking**: `feat!: remove deprecated prop`
 
-**Scope is optional and usually omitted in this repo.** Most monorepos using release-please _do_ use scopes — this repo is a deliberate exception because of the `exclude-paths` configuration in `release-please-config.json`. Storybook, tests, README, config, and other non-publishable files are excluded from triggering releases based on file path. Adding a package scope to a visible type (`feat`, `fix`) bypasses that exclusion and forces a bump regardless of which files changed. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases either way, so a scope on those is harmless. Default to no scope unless one of the exceptions below applies.
+**Scope is optional and usually omitted in this repo.** Most monorepos using release-please *do* use scopes — this repo is a deliberate exception because of the `exclude-paths` configuration in `release-please-config.json`. Storybook, tests, README, config, and other non-publishable files are excluded from triggering releases based on file path. Adding a package scope to a visible type (`feat`, `fix`) bypasses that exclusion and forces a bump regardless of which files changed. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases either way, so a scope on those is harmless. Default to no scope unless one of the exceptions below applies.
 
 **When to add a scope:**
 
@@ -471,17 +471,17 @@ Non-obvious EDS 2.0 patterns are documented in `documentation/adr/`. Read the re
 
 This file is the canonical source. Tool-specific configs add only what's unique to that tool:
 
-| File                              | Purpose                                                                 |
-| --------------------------------- | ----------------------------------------------------------------------- |
-| `.claude/CLAUDE.md`               | Claude Code: hooks, slash commands, settings                            |
-| `.claude/settings.json`           | Claude Code: `permissions.deny` for secrets + hook wiring               |
-| `.claude/rules/*.md`              | Claude Code: path-scoped rules (`/next`, `*.figma.tsx`)                 |
-| `.github/copilot-instructions.md` | GitHub Copilot: hub for path-scoped `applyTo` instructions              |
-| `.github/instructions/*.md`       | GitHub Copilot: file-pattern specific rules                             |
-| `.github/hooks/block-secrets.*`   | Copilot CLI: `preToolUse` hook blocking secret-file access              |
+| File                              | Purpose                                                    |
+| --------------------------------- | ---------------------------------------------------------- |
+| `.claude/CLAUDE.md`               | Claude Code: hooks, slash commands, settings               |
+| `.claude/settings.json`           | Claude Code: `permissions.deny` for secrets + hook wiring  |
+| `.claude/rules/*.md`              | Claude Code: path-scoped rules (`/next`, `*.figma.tsx`)    |
+| `.github/copilot-instructions.md` | GitHub Copilot: hub for path-scoped `applyTo` instructions |
+| `.github/instructions/*.md`       | GitHub Copilot: file-pattern specific rules                |
+| `.github/hooks/block-secrets.*`   | Copilot CLI: `preToolUse` hook blocking secret-file access |
 | `.github/hooks/format-on-edit.*`  | Copilot CLI: `postToolUse` hook running eslint/stylelint --fix on edits |
-| `.opencode/agent/*.md`            | OpenCode: agent definitions                                             |
-| `.github/workflows/claude.yml`    | `@claude` GitHub Action: system prompt points here                      |
+| `.opencode/agent/*.md`            | OpenCode: agent definitions                                |
+| `.github/workflows/claude.yml`    | `@claude` GitHub Action: system prompt points here         |
 
 When adding new conventions, update **this file** and let the tool-specific files reference it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,12 @@ If you need to verify a secret file's shape, report length + first/last few char
 
 **Enforcement matrix:**
 
-| Harness        | Enforcement                                                                                |
-| -------------- | ------------------------------------------------------------------------------------------ |
-| Claude Code    | Hard-enforced via `.claude/settings.json` `permissions.deny` + `.claude/hooks/read_hook.js`|
-| Copilot CLI    | Hard-enforced via `.github/hooks/block-secrets.json` + `.github/hooks/block-secrets.js`    |
-| Copilot in IDE | Agent-respected only — IDE Copilot does not run the CLI hook; follow this rule manually    |
-| OpenCode       | Agent-respected only — `permission.bash` covers commands, not file reads                   |
+| Harness        | Enforcement                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------- |
+| Claude Code    | Hard-enforced via `.claude/settings.json` `permissions.deny` + `.claude/hooks/read_hook.js` |
+| Copilot CLI    | Hard-enforced via `.github/hooks/block-secrets.json` + `.github/hooks/block-secrets.js`     |
+| Copilot in IDE | Agent-respected only — IDE Copilot does not run the CLI hook; follow this rule manually     |
+| OpenCode       | Agent-respected only — `permission.bash` covers commands, not file reads                    |
 
 ## Code Formatting
 
@@ -412,6 +412,10 @@ For running an accessibility audit on a deployed page or Storybook story, see [`
 
 Component docs live in `apps/design-system-docs/docs/components/{category}/{component}.md`. For writing or reviewing them — tone of voice, formatting (British English, no em-dashes, admonitions), section order, output template, Storybook iframes workflow, sidebar registration, verification checklist — see [`documentation/agent-instructions/COMPONENT_DOC_STYLE.md`](./documentation/agent-instructions/COMPONENT_DOC_STYLE.md). Harness entry points (`/create-component-doc` in Claude Code, the `structure_components_prompt` / `verify_components_prompt` in Copilot, the `component-doc` agent in OpenCode) all reference that doc.
 
+## Tokens Studio Pipeline
+
+EDS is adopting the Tokens Studio platform as the source for a new token pipeline, replacing the legacy Figma-REST sync over time. For platform concepts (organizations, projects, branches, releases), `studio` CLI setup and commands, the `.studio.json` configuration model, the safety rubric for CLI commands, and how to verify against live sources instead of answering from memory, see [`documentation/agent-instructions/TOKENS_STUDIO.md`](./documentation/agent-instructions/TOKENS_STUDIO.md). Harness entry points (`/tokens-studio` in Claude Code, the `tokens-studio` prompt in Copilot, the `tokens-studio` agent in OpenCode) all reference that doc. The legacy pipeline remains documented in [`documentation/how-to/TOKEN_SYSTEM_GUIDE.md`](./documentation/how-to/TOKEN_SYSTEM_GUIDE.md).
+
 ## Conventional Commits
 
 ```
@@ -422,7 +426,7 @@ type: description
 
 **Breaking**: `feat!: remove deprecated prop`
 
-**Scope is optional and usually omitted in this repo.** Most monorepos using release-please *do* use scopes — this repo is a deliberate exception because of the `exclude-paths` configuration in `release-please-config.json`. Storybook, tests, README, config, and other non-publishable files are excluded from triggering releases based on file path. Adding a package scope to a visible type (`feat`, `fix`) bypasses that exclusion and forces a bump regardless of which files changed. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases either way, so a scope on those is harmless. Default to no scope unless one of the exceptions below applies.
+**Scope is optional and usually omitted in this repo.** Most monorepos using release-please _do_ use scopes — this repo is a deliberate exception because of the `exclude-paths` configuration in `release-please-config.json`. Storybook, tests, README, config, and other non-publishable files are excluded from triggering releases based on file path. Adding a package scope to a visible type (`feat`, `fix`) bypasses that exclusion and forces a bump regardless of which files changed. Hidden types (`chore`, `build`, `ci`, `docs`, `test`) don't trigger releases either way, so a scope on those is harmless. Default to no scope unless one of the exceptions below applies.
 
 **When to add a scope:**
 
@@ -467,17 +471,17 @@ Non-obvious EDS 2.0 patterns are documented in `documentation/adr/`. Read the re
 
 This file is the canonical source. Tool-specific configs add only what's unique to that tool:
 
-| File                              | Purpose                                                    |
-| --------------------------------- | ---------------------------------------------------------- |
-| `.claude/CLAUDE.md`               | Claude Code: hooks, slash commands, settings               |
-| `.claude/settings.json`           | Claude Code: `permissions.deny` for secrets + hook wiring  |
-| `.claude/rules/*.md`              | Claude Code: path-scoped rules (`/next`, `*.figma.tsx`)    |
-| `.github/copilot-instructions.md` | GitHub Copilot: hub for path-scoped `applyTo` instructions |
-| `.github/instructions/*.md`       | GitHub Copilot: file-pattern specific rules                |
-| `.github/hooks/block-secrets.*`   | Copilot CLI: `preToolUse` hook blocking secret-file access |
+| File                              | Purpose                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------- |
+| `.claude/CLAUDE.md`               | Claude Code: hooks, slash commands, settings                            |
+| `.claude/settings.json`           | Claude Code: `permissions.deny` for secrets + hook wiring               |
+| `.claude/rules/*.md`              | Claude Code: path-scoped rules (`/next`, `*.figma.tsx`)                 |
+| `.github/copilot-instructions.md` | GitHub Copilot: hub for path-scoped `applyTo` instructions              |
+| `.github/instructions/*.md`       | GitHub Copilot: file-pattern specific rules                             |
+| `.github/hooks/block-secrets.*`   | Copilot CLI: `preToolUse` hook blocking secret-file access              |
 | `.github/hooks/format-on-edit.*`  | Copilot CLI: `postToolUse` hook running eslint/stylelint --fix on edits |
-| `.opencode/agent/*.md`            | OpenCode: agent definitions                                |
-| `.github/workflows/claude.yml`    | `@claude` GitHub Action: system prompt points here         |
+| `.opencode/agent/*.md`            | OpenCode: agent definitions                                             |
+| `.github/workflows/claude.yml`    | `@claude` GitHub Action: system prompt points here                      |
 
 When adding new conventions, update **this file** and let the tool-specific files reference it.
 

--- a/documentation/agent-instructions/HARNESS_AUDIT.md
+++ b/documentation/agent-instructions/HARNESS_AUDIT.md
@@ -16,7 +16,7 @@ This is a **read-only** workflow. The agent must not edit, create, or delete fil
   - Copilot CLI specifically: `.github/hooks/*.{json,js}`
 - **OpenCode** — `.opencode/agent/*.md`, `.opencode/README.md`
 
-**Out of scope** — do not audit configs for Cursor, Cline, Aider, Continue, Windsurf, Zed, Gemini CLI, Codex, or any other harness. If a stray `.cursorrules` / `.clinerules` / `.windsurfrules` / `GEMINI.md` etc. exists, note it under *Open questions* ("found a config for an out-of-scope harness — confirm intent or delete") — do not write findings against it.
+**Out of scope** — do not audit configs for Cursor, Cline, Aider, Continue, Windsurf, Zed, Gemini CLI, Codex, or any other harness. If a stray `.cursorrules` / `.clinerules` / `.windsurfrules` / `GEMINI.md` etc. exists, note it under _Open questions_ ("found a config for an out-of-scope harness — confirm intent or delete") — do not write findings against it.
 
 **Cross-harness surfaces** (canonical, shared by all three in-scope harnesses):
 
@@ -77,26 +77,27 @@ For each finding, quote offending lines with `path:line` references.
 
 A developer must not lose access to a workflow by switching harnesses. Build a matrix:
 
-| Capability (intent)          | Claude Code            | Copilot                                  | OpenCode             |
-| ---------------------------- | ---------------------- | ---------------------------------------- | -------------------- |
-| Scaffold new EDS 2.0 component | `/new-component`     | `new-component` prompt                   | `eds-component` agent |
-| Accessibility audit          | `/accessibility-audit` | `accessibility-audit` prompt             | `accessibility-audit` agent |
-| Structure component doc      | `/create-component-doc`| `structure_components_prompt`            | `component-doc` agent |
-| Verify component doc         | (covered by the same)  | `verify_components_prompt`               | (covered by the same) |
-| Re-sync harnesses (this audit) | `/audit-harnesses`   | `audit-harnesses` prompt                 | `audit-harnesses` agent |
-| Read-only advisor            | `.claude/rules/advisor.md` (general scope) | (none) | `advisor` primary agent |
+| Capability (intent)            | Claude Code                                | Copilot                       | OpenCode                    |
+| ------------------------------ | ------------------------------------------ | ----------------------------- | --------------------------- |
+| Scaffold new EDS 2.0 component | `/new-component`                           | `new-component` prompt        | `eds-component` agent       |
+| Accessibility audit            | `/accessibility-audit`                     | `accessibility-audit` prompt  | `accessibility-audit` agent |
+| Structure component doc        | `/create-component-doc`                    | `structure_components_prompt` | `component-doc` agent       |
+| Verify component doc           | (covered by the same)                      | `verify_components_prompt`    | (covered by the same)       |
+| Re-sync harnesses (this audit) | `/audit-harnesses`                         | `audit-harnesses` prompt      | `audit-harnesses` agent     |
+| Tokens Studio pipeline         | `/tokens-studio`                           | `tokens-studio` prompt        | `tokens-studio` agent       |
+| Read-only advisor              | `.claude/rules/advisor.md` (general scope) | (none)                        | `advisor` primary agent     |
 
-Rows are *intent*, not exact filenames. If the team adds a new workflow, the row should appear in all three harnesses (or be intentionally one-harness with the reason documented). Any gap is a finding.
+Rows are _intent_, not exact filenames. If the team adds a new workflow, the row should appear in all three harnesses (or be intentionally one-harness with the reason documented). Any gap is a finding.
 
 ### Step 5 — Path-scoped rule consistency
 
 Check that path-scoped rules covering the same intent in different harnesses target the **same glob/path set**.
 
-| Intent           | Claude Code (`.claude/rules/`)            | Copilot (`.github/instructions/`) |
-| ---------------- | ----------------------------------------- | --------------------------------- |
-| EDS 2.0 component code | `eds-component.md` paths frontmatter | `react.instructions.md` + `ts.instructions.md` + `styling.instructions.md` `applyTo` |
-| Figma Code Connect files | `figma-component.md` paths           | `figma.instructions.md` `applyTo` |
-| Global / markdown / TS | (none)                                 | `global-coding`, `markdown`, `ts` `applyTo` |
+| Intent                   | Claude Code (`.claude/rules/`)       | Copilot (`.github/instructions/`)                                                    |
+| ------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------ |
+| EDS 2.0 component code   | `eds-component.md` paths frontmatter | `react.instructions.md` + `ts.instructions.md` + `styling.instructions.md` `applyTo` |
+| Figma Code Connect files | `figma-component.md` paths           | `figma.instructions.md` `applyTo`                                                    |
+| Global / markdown / TS   | (none)                               | `global-coding`, `markdown`, `ts` `applyTo`                                          |
 
 Mismatched globs are findings. Each rule's documented scope should also still hit real files (`find` returns results).
 
@@ -177,6 +178,6 @@ _Canonical source:_ <path or "none declared">
 
 - **Read-only.** Do not edit, create, or delete files. Do not run formatters, linters, or tests. Do not commit anything.
 - **Cite, don't paraphrase.** Every finding must have a `path:line` reference and a short quote.
-- **No speculation.** If you are unsure whether something is a real divergence (e.g. you can't tell whether a harness surface is in use), put it in *Open questions*, not *Findings*.
-- **Stay in scope.** Only audit Claude Code, GitHub Copilot, and OpenCode. Other harness configs go to *Open questions*.
+- **No speculation.** If you are unsure whether something is a real divergence (e.g. you can't tell whether a harness surface is in use), put it in _Open questions_, not _Findings_.
+- **Stay in scope.** Only audit Claude Code, GitHub Copilot, and OpenCode. Other harness configs go to _Open questions_.
 - **Single output file.** Print the report to chat (or write to the path the user specifies). Do not scatter notes across multiple files.

--- a/documentation/agent-instructions/HARNESS_AUDIT.md
+++ b/documentation/agent-instructions/HARNESS_AUDIT.md
@@ -16,7 +16,7 @@ This is a **read-only** workflow. The agent must not edit, create, or delete fil
   - Copilot CLI specifically: `.github/hooks/*.{json,js}`
 - **OpenCode** — `.opencode/agent/*.md`, `.opencode/README.md`
 
-**Out of scope** — do not audit configs for Cursor, Cline, Aider, Continue, Windsurf, Zed, Gemini CLI, Codex, or any other harness. If a stray `.cursorrules` / `.clinerules` / `.windsurfrules` / `GEMINI.md` etc. exists, note it under _Open questions_ ("found a config for an out-of-scope harness — confirm intent or delete") — do not write findings against it.
+**Out of scope** — do not audit configs for Cursor, Cline, Aider, Continue, Windsurf, Zed, Gemini CLI, Codex, or any other harness. If a stray `.cursorrules` / `.clinerules` / `.windsurfrules` / `GEMINI.md` etc. exists, note it under *Open questions* ("found a config for an out-of-scope harness — confirm intent or delete") — do not write findings against it.
 
 **Cross-harness surfaces** (canonical, shared by all three in-scope harnesses):
 
@@ -77,27 +77,27 @@ For each finding, quote offending lines with `path:line` references.
 
 A developer must not lose access to a workflow by switching harnesses. Build a matrix:
 
-| Capability (intent)            | Claude Code                                | Copilot                       | OpenCode                    |
-| ------------------------------ | ------------------------------------------ | ----------------------------- | --------------------------- |
-| Scaffold new EDS 2.0 component | `/new-component`                           | `new-component` prompt        | `eds-component` agent       |
-| Accessibility audit            | `/accessibility-audit`                     | `accessibility-audit` prompt  | `accessibility-audit` agent |
-| Structure component doc        | `/create-component-doc`                    | `structure_components_prompt` | `component-doc` agent       |
-| Verify component doc           | (covered by the same)                      | `verify_components_prompt`    | (covered by the same)       |
-| Re-sync harnesses (this audit) | `/audit-harnesses`                         | `audit-harnesses` prompt      | `audit-harnesses` agent     |
-| Tokens Studio pipeline         | `/tokens-studio`                           | `tokens-studio` prompt        | `tokens-studio` agent       |
-| Read-only advisor              | `.claude/rules/advisor.md` (general scope) | (none)                        | `advisor` primary agent     |
+| Capability (intent)          | Claude Code            | Copilot                                  | OpenCode             |
+| ---------------------------- | ---------------------- | ---------------------------------------- | -------------------- |
+| Scaffold new EDS 2.0 component | `/new-component`     | `new-component` prompt                   | `eds-component` agent |
+| Accessibility audit          | `/accessibility-audit` | `accessibility-audit` prompt             | `accessibility-audit` agent |
+| Structure component doc      | `/create-component-doc`| `structure_components_prompt`            | `component-doc` agent |
+| Verify component doc         | (covered by the same)  | `verify_components_prompt`               | (covered by the same) |
+| Re-sync harnesses (this audit) | `/audit-harnesses`   | `audit-harnesses` prompt                 | `audit-harnesses` agent |
+| Tokens Studio pipeline       | `/tokens-studio`       | `tokens-studio` prompt                   | `tokens-studio` agent |
+| Read-only advisor            | `.claude/rules/advisor.md` (general scope) | (none) | `advisor` primary agent |
 
-Rows are _intent_, not exact filenames. If the team adds a new workflow, the row should appear in all three harnesses (or be intentionally one-harness with the reason documented). Any gap is a finding.
+Rows are *intent*, not exact filenames. If the team adds a new workflow, the row should appear in all three harnesses (or be intentionally one-harness with the reason documented). Any gap is a finding.
 
 ### Step 5 — Path-scoped rule consistency
 
 Check that path-scoped rules covering the same intent in different harnesses target the **same glob/path set**.
 
-| Intent                   | Claude Code (`.claude/rules/`)       | Copilot (`.github/instructions/`)                                                    |
-| ------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------ |
-| EDS 2.0 component code   | `eds-component.md` paths frontmatter | `react.instructions.md` + `ts.instructions.md` + `styling.instructions.md` `applyTo` |
-| Figma Code Connect files | `figma-component.md` paths           | `figma.instructions.md` `applyTo`                                                    |
-| Global / markdown / TS   | (none)                               | `global-coding`, `markdown`, `ts` `applyTo`                                          |
+| Intent           | Claude Code (`.claude/rules/`)            | Copilot (`.github/instructions/`) |
+| ---------------- | ----------------------------------------- | --------------------------------- |
+| EDS 2.0 component code | `eds-component.md` paths frontmatter | `react.instructions.md` + `ts.instructions.md` + `styling.instructions.md` `applyTo` |
+| Figma Code Connect files | `figma-component.md` paths           | `figma.instructions.md` `applyTo` |
+| Global / markdown / TS | (none)                                 | `global-coding`, `markdown`, `ts` `applyTo` |
 
 Mismatched globs are findings. Each rule's documented scope should also still hit real files (`find` returns results).
 
@@ -178,6 +178,6 @@ _Canonical source:_ <path or "none declared">
 
 - **Read-only.** Do not edit, create, or delete files. Do not run formatters, linters, or tests. Do not commit anything.
 - **Cite, don't paraphrase.** Every finding must have a `path:line` reference and a short quote.
-- **No speculation.** If you are unsure whether something is a real divergence (e.g. you can't tell whether a harness surface is in use), put it in _Open questions_, not _Findings_.
-- **Stay in scope.** Only audit Claude Code, GitHub Copilot, and OpenCode. Other harness configs go to _Open questions_.
+- **No speculation.** If you are unsure whether something is a real divergence (e.g. you can't tell whether a harness surface is in use), put it in *Open questions*, not *Findings*.
+- **Stay in scope.** Only audit Claude Code, GitHub Copilot, and OpenCode. Other harness configs go to *Open questions*.
 - **Single output file.** Print the report to chat (or write to the path the user specifies). Do not scatter notes across multiple files.

--- a/documentation/agent-instructions/TOKENS_STUDIO.md
+++ b/documentation/agent-instructions/TOKENS_STUDIO.md
@@ -6,13 +6,7 @@ Tokens Studio (the platform at `tokens.studio`) is the successor to the Tokens S
 
 ## Relationship to the legacy pipeline
 
-The current production pipeline is documented in [`documentation/how-to/TOKEN_SYSTEM_GUIDE.md`](../how-to/TOKEN_SYSTEM_GUIDE.md) and consists of:
-
-- `packages/eds-tokens-sync` — bidirectional Figma REST API sync (`sync-figma-to-tokens` / `sync-tokens-to-figma`) keyed by Figma file keys in `packages/eds-tokens/token-config.json`
-- `packages/eds-tokens-build` — Style Dictionary generation and build scripts
-- `packages/eds-tokens` — token JSON source (`tokens/{fileKey}/`) and built CSS/JS/TS output (`build/`)
-
-The Tokens Studio pipeline replaces the **sync source** (Figma REST → Studio platform). The generation/build stages are being reworked separately. Do not assume the legacy `token-config.json` file keys, sync scripts, or JSON layout apply to Studio-pulled tokens — they are different systems that coexist during the migration.
+The current production pipeline — bidirectional Figma REST sync (`packages/eds-tokens-sync`) plus Style Dictionary generation and build (`packages/eds-tokens-build` → `packages/eds-tokens`) — is documented in [`documentation/how-to/TOKEN_SYSTEM_GUIDE.md`](../how-to/TOKEN_SYSTEM_GUIDE.md); read that guide for its details rather than restating them here. The Tokens Studio pipeline replaces the **sync source** (Figma REST → Studio platform). The generation/build stages are being reworked separately. Do not assume the legacy sync scripts, file-key configuration, or JSON layout apply to Studio-pulled tokens — they are different systems that coexist during the migration.
 
 ## Platform concepts
 
@@ -42,10 +36,10 @@ The CLI is `@tokens-studio/studio-cli` (binary name `studio`), installed as a **
 ```json
 {
   "sources": {
-    "eds-test-3": {
+    "my-tokens": {
       "project": "proj_abc123",
       "branch": "main",
-      "output": "src/tokens/eds-test-3"
+      "output": "src/tokens/my-tokens"
     }
   }
 }
@@ -53,7 +47,7 @@ The CLI is `@tokens-studio/studio-cli` (binary name `studio`), installed as a **
 
 - Sources can reference a `branch`, a `release`, or a `tag` — pin to a release for reproducible builds.
 - Pull formats are `raw` (default), `dtcg`, and `css`. **There is no TypeScript pull format** — pull raw/DTCG JSON and generate TS locally, as the existing Style Dictionary build does for `build/ts/*`.
-- `studio config show` displays the config; `studio config remove <alias>` removes a source (`--delete-files` also deletes the downloaded tokens).
+- `studio config show` displays the config; `studio config remove <alias>` (alias `rm`) removes a source from `.studio.json`. It does **not** delete already-pulled token files — clean those up manually.
 - `.studio.json` is meant to be committed for team consistency.
 
 ## Command overview
@@ -65,9 +59,11 @@ The CLI is `@tokens-studio/studio-cli` (binary name `studio`), installed as a **
 | `studio tokens watch [alias]`                     | WebSocket watch — auto-pulls when tokens change remotely                                                                                                                                                                                                              |
 | `studio exports list / show / templates / schema` | Inspect saved export configurations, preset templates, and the JSON schema per format (`--format css` etc.)                                                                                                                                                           |
 | `studio exports preview <name-or-id>`             | Render an export without saving anything (`--out` to write files, omit for a summary; `--config-file` to override)                                                                                                                                                    |
-| `studio exports create / update / duplicate`      | Create or modify a saved export configuration (`--format`, `--name`, `--template`, `--config-file`)                                                                                                                                                                   |
+| `studio exports create`                           | Create a saved export configuration — `--format` and `--name` required; `--template`, `--config-file` optional                                                                                                                                                        |
+| `studio exports update <name-or-id>`              | Modify a saved configuration: `--name` (rename), `--template`, `--config-file` (replaces the config wholesale), `--clear-config`. The format cannot be changed — create a new configuration instead                                                                   |
+| `studio exports duplicate <name-or-id>`           | Clone a configuration; its only flag is `--new-name` (defaults to `<source> (copy)`)                                                                                                                                                                                  |
 | `studio exports run <name-or-id> --out <dir>`     | Run a saved export configuration and write the output                                                                                                                                                                                                                 |
-| `studio exports delete`                           | Delete a saved export configuration — **destructive, remote**                                                                                                                                                                                                         |
+| `studio exports delete <name-or-id>`              | Delete a saved export configuration (`--force` skips the confirmation prompt) — **destructive, remote**                                                                                                                                                               |
 
 Export formats on the platform: CSS Variables, DTCG JSON, Raw JSON, and Figma Variables. Aliases: `studio pull` = `tokens pull`, `studio login`/`logout` = `auth login`/`logout`, `studio init` = `config init`. Global flags everywhere: `--json`, `--verbose`, `--host`.
 
@@ -76,8 +72,8 @@ Export formats on the platform: CSS Variables, DTCG JSON, Raw JSON, and Figma Va
 Classify every command before running it:
 
 - **Safe, run freely:** any `--help`, `studio info`, `auth status`, `config show`, `exports list/show/templates/schema`, `exports preview` (without `--out`), `tokens pull --dry-run`.
-- **Overwrites local files (fine in a clean git tree, mention it):** `tokens pull` without `--dry-run`, `exports run`/`exports preview --out`.
-- **Mutates remote state — always ask the user first:** `exports create/update/duplicate/delete`, `config remove --delete-files`, `auth logout`, and any push-like or write-scoped command that appears in future CLI versions. When in doubt, treat a command as remote-mutating until `--help` proves otherwise.
+- **Edits or overwrites local files (fine in a clean git tree, mention it):** `tokens pull` without `--dry-run`, `exports run`/`exports preview --out`, `config init/add/remove` (edit `.studio.json` only).
+- **Mutates remote state or credentials — always ask the user first:** `exports create/update/duplicate/delete`, `auth logout` (revokes and deletes stored credentials), and any push-like or write-scoped command that appears in future CLI versions. Remember the shortcut aliases (`studio logout` = `auth logout`) count too. When in doubt, treat a command as remote-mutating until `--help` proves otherwise.
 
 ## Staying current
 
@@ -105,4 +101,4 @@ studio
 └── flags       --host --json --no-color --verbose
 ```
 
-Known state in this repo at snapshot time: CLI installed as devDep in `packages/eds-tokens`, approved in `onlyBuiltDependencies`, no `.studio.json` committed yet (pipeline exploration happens on the `chore/tokens-pipeline` branch against the "EDS Test 3" project).
+Known state in this repo at snapshot time: CLI installed as a devDependency of `packages/eds-tokens` and approved in `onlyBuiltDependencies`; no `.studio.json` committed yet.

--- a/documentation/agent-instructions/TOKENS_STUDIO.md
+++ b/documentation/agent-instructions/TOKENS_STUDIO.md
@@ -21,7 +21,6 @@ The CLI is `@tokens-studio/studio-cli` (binary name `studio`), installed as a **
 
 - Run it from `packages/eds-tokens` via `pnpm exec studio <command>` (the binary is not on the global PATH). Package scripts get `node_modules/.bin` automatically, so `package.json` scripts can call `studio` directly.
 - The package downloads its binary in a postinstall script. pnpm 10 blocks build scripts by default, so the package must be listed under `onlyBuiltDependencies` in the repo-root `pnpm-workspace.yaml`. If the binary is missing ("Studio CLI binary not found"), check that list, then `pnpm rebuild @tokens-studio/studio-cli`.
-- npm dist-tags: `latest` plus an `rc` channel for release candidates.
 
 ## Authentication
 

--- a/documentation/agent-instructions/TOKENS_STUDIO.md
+++ b/documentation/agent-instructions/TOKENS_STUDIO.md
@@ -1,0 +1,108 @@
+# Tokens Studio Pipeline
+
+This is the canonical playbook for working with the **Tokens Studio platform** and its `studio` CLI in this repository. Harness-specific entry points (`/tokens-studio` in Claude Code, the `tokens-studio` prompt in Copilot, the `tokens-studio` agent in OpenCode) reference this file rather than restating it.
+
+Tokens Studio (the platform at `tokens.studio`) is the successor to the Tokens Studio Figma plugin: a collaborative web platform for managing design tokens with Git-like branching, immutable releases, and a CLI for pulling tokens into codebases. EDS is adopting it as the source for a new token pipeline, replacing the legacy Figma-REST-API sync over time.
+
+## Relationship to the legacy pipeline
+
+The current production pipeline is documented in [`documentation/how-to/TOKEN_SYSTEM_GUIDE.md`](../how-to/TOKEN_SYSTEM_GUIDE.md) and consists of:
+
+- `packages/eds-tokens-sync` — bidirectional Figma REST API sync (`sync-figma-to-tokens` / `sync-tokens-to-figma`) keyed by Figma file keys in `packages/eds-tokens/token-config.json`
+- `packages/eds-tokens-build` — Style Dictionary generation and build scripts
+- `packages/eds-tokens` — token JSON source (`tokens/{fileKey}/`) and built CSS/JS/TS output (`build/`)
+
+The Tokens Studio pipeline replaces the **sync source** (Figma REST → Studio platform). The generation/build stages are being reworked separately. Do not assume the legacy `token-config.json` file keys, sync scripts, or JSON layout apply to Studio-pulled tokens — they are different systems that coexist during the migration.
+
+## Platform concepts
+
+- **Organization → Project → Branch/Release.** An organization (e.g. "Equinor Design System") contains projects; each project has a permanent `main` branch (the approved source of truth) plus short-lived work branches.
+- **Branching** is Git-like and event-sourced: branches isolate token changes, go through branch reviews, and merge back to `main`. Everything token-related is branch-aware (tokens, token sets, theme groups, variable collections).
+- **Releases** are immutable snapshots of a branch's resolved tokens, named with semantic versions. Releases trigger webhooks/CI integrations. Pinning a pipeline to a release (rather than a branch head) gives reproducible builds.
+- **Token format** follows the W3C DTCG (Design Token Community Group) interchange format; the platform can also emit raw token-set JSON and CSS variables.
+
+## CLI setup in this repo
+
+The CLI is `@tokens-studio/studio-cli` (binary name `studio`), installed as a **devDependency of `packages/eds-tokens`** — never a runtime dependency, and never installed with `npm` (this is a pnpm workspace; `npm install` fails on `workspace:` protocol deps).
+
+- Run it from `packages/eds-tokens` via `pnpm exec studio <command>` (the binary is not on the global PATH). Package scripts get `node_modules/.bin` automatically, so `package.json` scripts can call `studio` directly.
+- The package downloads its binary in a postinstall script. pnpm 10 blocks build scripts by default, so the package must be listed under `onlyBuiltDependencies` in the repo-root `pnpm-workspace.yaml`. If the binary is missing ("Studio CLI binary not found"), check that list, then `pnpm rebuild @tokens-studio/studio-cli`.
+- npm dist-tags: `latest` plus an `rc` channel for release candidates.
+
+## Authentication
+
+- **Interactive (local dev):** `studio auth login` — device flow (browser + QR code). Credentials are stored in the OS keychain (macOS Keychain / Linux Secret Service / Windows Credential Manager; 1Password CLI if detected). This is interactive — the user runs it themselves, not the agent. `studio auth status` shows login state and token expiry; `studio auth logout` revokes and removes credentials.
+- **CI:** service account tokens (long-lived, project-scoped, read and/or write, created under Integrations → Service Account Tokens in the platform) via the `STUDIO_SERVICE_TOKEN` environment variable or `--service-token-file <path>`. The `--ci` flag forces CI auth and disables interactive prompts. OIDC is auto-detected in GitHub Actions, GitLab CI, Bitbucket Pipelines, and Azure Pipelines — prefer OIDC over long-lived tokens where possible. Treat service tokens as secrets per `AGENTS.md` § Secrets & Credentials.
+- Other environment variables: `STUDIO_API_URL` (API override), `STUDIO_PROXY`, `STUDIO_CA_BUNDLE`.
+
+## Configuration (`.studio.json`)
+
+`studio config init` creates `.studio.json`; `studio config add <alias>` adds a token source (interactively, or with `--project <uuid> --branch <name> --format <fmt> --output <dir>`). The file maps aliases to sources:
+
+```json
+{
+  "sources": {
+    "eds-test-3": {
+      "project": "proj_abc123",
+      "branch": "main",
+      "output": "src/tokens/eds-test-3"
+    }
+  }
+}
+```
+
+- Sources can reference a `branch`, a `release`, or a `tag` — pin to a release for reproducible builds.
+- Pull formats are `raw` (default), `dtcg`, and `css`. **There is no TypeScript pull format** — pull raw/DTCG JSON and generate TS locally, as the existing Style Dictionary build does for `build/ts/*`.
+- `studio config show` displays the config; `studio config remove <alias>` removes a source (`--delete-files` also deletes the downloaded tokens).
+- `.studio.json` is meant to be committed for team consistency.
+
+## Command overview
+
+| Command                                           | What it does                                                                                                                                                                                                                                                          |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `studio info`                                     | CLI version, configuration, and auth status                                                                                                                                                                                                                           |
+| `studio tokens pull [alias]`                      | Download token-set `.json` files plus `$themes.json` and `$metadata.json` to the source's output dir. No alias = pull all sources. Flags: `--dry-run`, `--force`, `--partial` (changed files only), `--file` (one file), `--locked` (exact lockfile versions), `--ci` |
+| `studio tokens watch [alias]`                     | WebSocket watch — auto-pulls when tokens change remotely                                                                                                                                                                                                              |
+| `studio exports list / show / templates / schema` | Inspect saved export configurations, preset templates, and the JSON schema per format (`--format css` etc.)                                                                                                                                                           |
+| `studio exports preview <name-or-id>`             | Render an export without saving anything (`--out` to write files, omit for a summary; `--config-file` to override)                                                                                                                                                    |
+| `studio exports create / update / duplicate`      | Create or modify a saved export configuration (`--format`, `--name`, `--template`, `--config-file`)                                                                                                                                                                   |
+| `studio exports run <name-or-id> --out <dir>`     | Run a saved export configuration and write the output                                                                                                                                                                                                                 |
+| `studio exports delete`                           | Delete a saved export configuration — **destructive, remote**                                                                                                                                                                                                         |
+
+Export formats on the platform: CSS Variables, DTCG JSON, Raw JSON, and Figma Variables. Aliases: `studio pull` = `tokens pull`, `studio login`/`logout` = `auth login`/`logout`, `studio init` = `config init`. Global flags everywhere: `--json`, `--verbose`, `--host`.
+
+## Safety rubric
+
+Classify every command before running it:
+
+- **Safe, run freely:** any `--help`, `studio info`, `auth status`, `config show`, `exports list/show/templates/schema`, `exports preview` (without `--out`), `tokens pull --dry-run`.
+- **Overwrites local files (fine in a clean git tree, mention it):** `tokens pull` without `--dry-run`, `exports run`/`exports preview --out`.
+- **Mutates remote state — always ask the user first:** `exports create/update/duplicate/delete`, `config remove --delete-files`, `auth logout`, and any push-like or write-scoped command that appears in future CLI versions. When in doubt, treat a command as remote-mutating until `--help` proves otherwise.
+
+## Staying current
+
+The CLI and platform are young and move fast (v0.1.x as of the snapshot below). **Never answer Tokens Studio questions from memory alone.** In order of authority:
+
+1. **The installed CLI is ground truth for commands.** Run `pnpm exec studio <command> --help` from `packages/eds-tokens` before asserting flags or behaviour. Help output is safe to run at any depth.
+2. **The current docs site** is `https://documentation-v2.tokens.studio/` — fetch the relevant page when a question goes beyond the CLI surface. Key pages: `/cli/overview.html`, `/cli/authentication.html`, `/cli/configuration.html`, `/cli/pulling-tokens.html`, `/branching/how-branching-works.html`, `/releases/creating-a-release.html`, `/tokens/exporting-tokens.html`, `/integrations/service-account-tokens.html`, `/integrations/ci-cd-triggers.html`.
+   ⚠️ `https://documentation.tokens.studio/` is the **legacy** docs site (old `tokensstudio` CLI, `.tokensstudio.json` config) — do not mix the two.
+3. **Version check:** `npm view @tokens-studio/studio-cli dist-tags` shows `latest` and `rc`. Compare against the installed version (`studio --version`). If the installed version is newer than the snapshot below, regenerate the snapshot from `--help` output.
+
+## Snapshot (July 2026, studio-cli 0.1.7)
+
+Regenerate this section when the installed CLI version changes — run `studio --help` and the subcommand helps, and update the command table above if anything moved.
+
+```
+studio
+├── auth        login | logout | status
+├── config      init | add | remove | show
+├── tokens      pull | watch          (alias: t; shortcut: studio pull)
+├── exports     list | show | create | update | delete | duplicate
+│               templates | schema | preview | run
+├── info
+├── completion
+├── init / login / logout / pull      (shortcuts)
+└── flags       --host --json --no-color --verbose
+```
+
+Known state in this repo at snapshot time: CLI installed as devDep in `packages/eds-tokens`, approved in `onlyBuiltDependencies`, no `.studio.json` committed yet (pipeline exploration happens on the `chore/tokens-pipeline` branch against the "EDS Test 3" project).

--- a/packages/eds-tokens/package.json
+++ b/packages/eds-tokens/package.json
@@ -100,6 +100,7 @@
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
+    "@tokens-studio/studio-cli": "^0.1.7",
     "@types/node": "^25.5.2",
     "copyfiles": "^2.4.1",
     "lightningcss-cli": "^1.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,13 +698,13 @@ importers:
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@storybook/addon-docs':
         specifier: ^10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
       '@storybook/addon-links':
         specifier: ^10.4.6
         version: 10.4.6(@types/react@19.2.17)(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@storybook/react-vite':
         specifier: ^10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -740,7 +740,7 @@ importers:
         version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+        version: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^30.4.1
         version: 30.4.1
@@ -776,7 +776,7 @@ importers:
         version: 3.0.2(rollup@4.62.2)
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+        version: 4.0.2(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
       storybook:
         specifier: 10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -826,6 +826,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.3
         version: 16.0.3(rollup@4.62.2)
+      '@tokens-studio/studio-cli':
+        specifier: ^0.1.7
+        version: 0.1.7
       '@types/node':
         specifier: ^25.5.2
         version: 25.6.0
@@ -5078,6 +5081,11 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tokens-studio/studio-cli@0.1.7':
+    resolution: {integrity: sha512-tRL/qPqIkyGIVN3pYZ2U6T7HbGVwCJ0mMYtH61TRUadtD8S3p8y/MlaMOlvV+JBSpHUPuatzo/74aliGUbBnrA==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
@@ -16914,6 +16922,42 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/pattern': 30.4.0
+      '@jest/reporters': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 25.9.3
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.4.1
+      jest-config: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-resolve-dependencies: 30.4.2
+      jest-runner: 30.4.2
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      jest-watcher: 30.4.1
+      pretty-format: 30.4.1
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   '@jest/core@30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.4.1
@@ -17180,11 +17224,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -18384,10 +18428,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       react: 19.2.7
@@ -18433,12 +18477,12 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.3.0
-      vite: 8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -18464,14 +18508,14 @@ snapshots:
       vite: 8.1.0(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.16)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.62.2
-      vite: 8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.16)
 
   '@storybook/global@5.0.0': {}
@@ -18538,11 +18582,11 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.16))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -18552,7 +18596,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tsconfig-paths: 4.2.0
-      vite: 8.1.0(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -18820,6 +18864,8 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tokens-studio/studio-cli@0.1.7': {}
 
   '@ts-morph/common@0.28.1':
     dependencies:
@@ -23079,6 +23125,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jest-cli@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
@@ -23158,6 +23223,38 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.3
       ts-node: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.3
+      ts-node: 10.9.2(@types/node@25.9.3)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23598,6 +23695,19 @@ snapshots:
       '@jest/types': 30.4.1
       import-local: 3.2.0
       jest-cli: 30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      '@jest/types': 30.4.1
+      import-local: 3.2.0
+      jest-cli: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25701,13 +25811,13 @@ snapshots:
       postcss: 8.5.16
       ts-node: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
 
-  postcss-load-config@3.1.4(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)):
+  postcss-load-config@3.1.4(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.3
     optionalDependencies:
       postcss: 8.5.16
-      ts-node: 10.9.2(@types/node@25.9.4)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.9.3)(typescript@5.9.3)
 
   postcss-loader@7.3.4(postcss@8.5.16)(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.16)):
     dependencies:
@@ -26892,7 +27002,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  rollup-plugin-postcss@4.0.2(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)):
+  rollup-plugin-postcss@4.0.2(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
@@ -26901,7 +27011,7 @@ snapshots:
       p-queue: 6.6.2
       pify: 5.0.0
       postcss: 8.5.16
-      postcss-load-config: 3.1.4(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+      postcss-load-config: 3.1.4(postcss@8.5.16)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
       postcss-modules: 4.3.1(postcss@8.5.16)
       promise.series: 0.2.0
       resolve: 1.22.12
@@ -27944,6 +28054,25 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.3
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 9.0.0
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -28398,6 +28527,22 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.6.0
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.48.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vite@8.1.0(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rolldown: 1.1.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
 
 onlyBuiltDependencies:
   - lightningcss-cli
+  - '@tokens-studio/studio-cli'


### PR DESCRIPTION
> [!NOTE]
> **First draft.** The Tokens Studio pipeline is still being explored (#5108), so this doc is a starting point, not a finished spec — we will update it as the pipeline work progresses. The dated snapshot section in `TOKENS_STUDIO.md` is designed to be regenerated whenever the installed CLI version changes.

## Why

EDS is adopting the Tokens Studio platform for the new token pipeline (#5108), but the repo had no knowledge of it — the agent instructions only cover the legacy Figma-REST sync. This adds a cross-harness "tokens-studio" assistant so all three harnesses can help with the studio CLI, pulls, exports, and platform concepts, plus the CLI dev dependency itself so the documented setup works out of the box.

## What

- **`documentation/agent-instructions/TOKENS_STUDIO.md`** — canonical playbook: platform concepts (org/project/branch/release), CLI setup in this repo, `.studio.json` model, command overview, a safety rubric (safe / overwrites-local / mutates-remote), and a "staying current" section instructing agents to verify against `studio --help` and the current docs site instead of answering from memory. Every CLI claim is verified against the installed binary (v0.1.7).
- Thin entry points per harness, following the existing canonical-docs pattern:
  - `.claude/commands/tokens-studio.md` → `/tokens-studio`
  - `.github/prompts/tokens-studio.prompt.md` → `tokens-studio` prompt
  - `.opencode/agent/tokens-studio.md` → `tokens-studio` agent (permission config asks before git branch/PR actions and remote-mutating studio commands, matching `build.md`)
- **CLI setup**: `@tokens-studio/studio-cli` as devDependency of `eds-tokens` + `onlyBuiltDependencies` approval in `pnpm-workspace.yaml` (its postinstall downloads the binary) + lockfile.
- Registrations: new section in `AGENTS.md`, capability-parity row in `HARNESS_AUDIT.md`, slash-command table in `.claude/CLAUDE.md` (also adds the previously missing `/accessibility-audit` and `/audit-harnesses` rows), agent table in `.opencode/README.md`.

The devDependency does not affect the published `@equinor/eds-tokens` artifact.

## Review

A ten-finding self-review (CLI fact-check against the binary, cross-harness consistency, content-loss audit of reformatting, conventions/duplication) was applied in the second commit — including removing a nonexistent CLI flag the vendor docs describe but v0.1.7 lacks, and reverting unrelated Prettier reformatting so `AGENTS.md`/`HARNESS_AUDIT.md` diffs are additions-only.
