### PR TITLE
feat: add robots.txt and sitemap lastmod metadata for documentation site

### DIFF
--- a/apps/design-system-docs/docusaurus.config.ts
+++ b/apps/design-system-docs/docusaurus.config.ts
@@ -58,6 +58,9 @@ const config: Config = {
             // Add additional CSS files here
           ],
         },
+        sitemap: {
+          lastmod: 'datetime',
+        },
       } satisfies Preset.Options,
     ],
   ],

--- a/apps/design-system-docs/static/robots.txt
+++ b/apps/design-system-docs/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
As requested in [RITM4175160](https://equinor.service-now.com/nav_to.do?uri=sc_req_item.do%3Fsys_id=437e3e42fbfc0318a947fa43aeefdca9), this PR updates Docusaurus SEO output by:

1. Adding lastmod metadata (datetime) in sitemap.xml to help crawlers detect recently changed pages and index incrementally.
2. Adding robots.txt with a crawl policy.