### PR TITLE
fix: update Docusaurus site URL to the correct domain

### DIFF
--- a/apps/design-system-docs/docusaurus.config.ts
+++ b/apps/design-system-docs/docusaurus.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
   //   v4: true, // Improve compatibility with the upcoming Docusaurus v4
   // },
 
-  url: 'https://equinor.github.io',
+  url: 'https://eds.equinor.com',
   baseUrl: '/',
 
   organizationName: 'equinor',


### PR DESCRIPTION
## Problem

The Docusaurus `sitemap.xml` (and other absolute URLs generated by Docusaurus, e.g. canonical links, OpenGraph tags) were being built from the `url` field in `docusaurus.config.ts`, which was still set to `https://equinor.github.io`. This is a leftover from before the docs site moved to Radix, and doesn't match where the site is actually hosted (`https://eds.equinor.com`), so search engines and crawlers were being pointed at the wrong domain.

## Change

- Updated `url` in `apps/design-system-docs/docusaurus.config.ts` from `https://equinor.github.io` to `https://eds.equinor.com`.

The `@docusaurus/plugin-sitemap` config has no `siteUrl` override, so it derives every entry from `url` + `baseUrl` + page path — this single change is enough to fix the generated `sitemap.xml`, canonical URLs, and OG tags.

## Testing

- Ran a local Docusaurus build (`pnpm run build` in `apps/design-system-docs`) and confirmed `build/sitemap.xml` now uses `https://eds.equinor.com/...` for every entry.
- Pushed to the `feat/docusaurus-sitemap-domain-fix` branch and verified the dev instance built and deployed successfully in Radix.

## Notes

- Dynamically deriving the domain per-environment (for test instances in Radix) was considered but shelved for now (this PR only fixes the production domain).