### PR TITLE
ci: add scheduled git backup of Tokens Studio tokens

### DIFF
--- a/.github/workflows/tokens_studio_backup.yaml
+++ b/.github/workflows/tokens_studio_backup.yaml
@@ -11,6 +11,8 @@ on:
   schedule:
     # Hourly, off the whole hour to avoid the GitHub cron rush
     - cron: '23 * * * *'
+  # Dispatch from main only — the OIDC subject must match the inbound
+  # CI integration's refs/heads/main pattern; any other ref gets a 403
   workflow_dispatch:
 # A slow run must not race the next hourly tick on the shared branch
 concurrency:
@@ -24,9 +26,10 @@ jobs:
     permissions:
       # OIDC token so the studio CLI can authenticate against the
       # Tokens Studio CI integration (no service token needed).
-      # Scheduled and dispatched runs execute on main, so the token
-      # subject matches the integration's subject pattern
-      # (repo:equinor/design-system:ref:refs/heads/main).
+      # Scheduled runs always execute on main, so the token subject
+      # matches the integration's subject pattern
+      # (repo:equinor/design-system:ref:refs/heads/main). Manual
+      # dispatches must also pick main — see the trigger comment.
       id-token: write
       # Push backup commits to the tokens-studio-backup branch
       contents: write

--- a/.github/workflows/tokens_studio_backup.yaml
+++ b/.github/workflows/tokens_studio_backup.yaml
@@ -1,0 +1,98 @@
+name: Tokens Studio backup
+# Tokens Studio has no undo/rollback — only a read-only version history
+# of releases. Plugin changes push to the platform in real time, so a
+# designer mistake propagates immediately and the release workflow only
+# snapshots at release moments. This job is the safety net in between:
+# it pulls the current state of every token source on a schedule and
+# commits changes to the orphan branch `tokens-studio-backup`, giving us
+# diffs, history and a recovery point independent of the platform.
+# Recovery instructions: documentation/agent-instructions/TOKENS_STUDIO.md
+on:
+  schedule:
+    # Hourly, off the whole hour to avoid the GitHub cron rush
+    - cron: '23 * * * *'
+  workflow_dispatch:
+# A slow run must not race the next hourly tick on the shared branch
+concurrency:
+  group: tokens-studio-backup
+  cancel-in-progress: false
+jobs:
+  backup-tokens:
+    name: Back up tokens from Tokens Studio
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # OIDC token so the studio CLI can authenticate against the
+      # Tokens Studio CI integration (no service token needed).
+      # Scheduled and dispatched runs execute on main, so the token
+      # subject matches the integration's subject pattern
+      # (repo:equinor/design-system:ref:refs/heads/main).
+      id-token: write
+      # Push backup commits to the tokens-studio-backup branch
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      # The branch was seeded manually once (orphan, README only) so
+      # this checkout can always assume it exists
+      - name: Checkout backup branch
+        uses: actions/checkout@v7
+        with:
+          ref: tokens-studio-backup
+          path: backup
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.16.0'
+      # Same key as _setup.yml so the store cache is shared with the
+      # other workflows
+      - name: Cache pnpm-store
+        uses: actions/cache@v6
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-and-store-force-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --force
+      # No alias argument = pull every source configured in
+      # packages/eds-tokens/.studio.json (token sets + $themes.json +
+      # $metadata.json). --verbose because the run is unattended — the
+      # Actions log is the only place to diagnose a bad pull
+      - name: Pull tokens from Tokens Studio
+        run: pnpm --filter @equinor/eds-tokens exec studio tokens pull --ci --verbose
+      # Aliases and output dirs are read from .studio.json so a config
+      # rename (e.g. the planned eds-test-3 → eds) never requires a
+      # workflow change. Each source lands at backup/<alias>/;
+      # --delete keeps removals visible in the diff
+      - name: Sync pulled sources into the backup branch
+        run: |
+          jq -r '.configurations | to_entries[] | "\(.key)\t\(.value.output)"' packages/eds-tokens/.studio.json |
+          while IFS=$'\t' read -r alias output; do
+            echo "Syncing $alias (packages/eds-tokens/$output → backup/$alias)"
+            rsync -a --delete "packages/eds-tokens/$output/" "backup/$alias/"
+          done
+      - name: Commit and push backup
+        working-directory: backup
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if git diff --cached --quiet; then
+            echo 'No token changes since last backup'
+          else
+            git commit -m "chore: tokens backup $(date -u +%Y-%m-%dT%H:%M:%SZ) (run ${GITHUB_RUN_ID})"
+            git push origin tokens-studio-backup
+          fi
+      # The run is unattended and hourly — a broken backup must not be
+      # silent, or the safety net quietly stops existing
+      - name: log-errors-to-slack
+        uses: act10ns/slack@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: failure()

--- a/documentation/agent-instructions/TOKENS_STUDIO.md
+++ b/documentation/agent-instructions/TOKENS_STUDIO.md
@@ -91,9 +91,20 @@ Classify every command before running it:
 `.github/workflows/tokens_studio_release.yaml` runs on every Tokens Studio release and opens/updates an automated PR (branch `tokens-studio-release`) with the full token state:
 
 1. **Trigger:** the outbound **CI Trigger** in Studio (Integrations → CI Triggers, `eds-tokens-release`) sends a `repository_dispatch` event (type `tokens-release`) to this repo on `release.created`. It can be fired manually with its **Test** button.
-2. **Auth:** the workflow authenticates back to Studio via GitHub OIDC against the inbound **CI Integration** (Integrations → CI Integration (Inbound); subject pattern `repo:equinor/design-system:ref:refs/heads/main`, read-only). The outbound trigger and the inbound integration are **separate configs** — a 403 `No matching CI integration found` from `studio ... --ci` means the *inbound* integration is missing or misconfigured, no matter how healthy the trigger looks.
+2. **Auth:** the workflow authenticates back to Studio via GitHub OIDC against the inbound **CI Integration** (Integrations → CI Integration (Inbound); subject pattern `repo:equinor/design-system:ref:refs/heads/main`, read-only). The outbound trigger and the inbound integration are **separate configs** — a 403 `No matching CI integration found` from `studio ... --ci` means the _inbound_ integration is missing or misconfigured, no matter how healthy the trigger looks.
 3. **Steps:** `studio tokens pull` (raw token sets → `src/tokens/<alias>/`), `studio exports run` for the two saved configurations — `EDS-CSS` (css) and `EDS-DTCG` (dtcg), referenced by ID — into `src/tokens/css/` and `src/tokens/dtcg/`, then `pnpm run generate:ts-tokens` which combines DTCG structure with evaluated CSS values into TS modules in `src/tokens/ts/` (see the script header in `packages/eds-tokens/scripts/generate-ts-tokens.mjs` for the mechanics, including CSS Color 4 gamut mapping).
 4. **Output:** all three directories are committed to the release PR. They are **generated — never edit them by hand**, and they are not yet wired into the package `exports` map.
+
+## Backup & recovery
+
+The platform has **no undo, rollback or restore** — only a read-only version history of releases — and plugin changes push to Studio in real time. `.github/workflows/tokens_studio_backup.yaml` is the safety net for everything between releases: every hour (cron `23 * * * *`, plus manual `workflow_dispatch`) it runs `studio tokens pull` for all sources in `.studio.json` and commits changes to the orphan branch **`tokens-studio-backup`** (one directory per source alias — never merge this branch). Runs that find no changes make no commit. Auth is the same inbound CI Integration as the release pipeline — no extra setup. Failures alert via the Slack step; an hourly backup that fails silently is no safety net.
+
+**Recovery is manual — the CLI has no push command (only `pull`/`watch`):**
+
+1. On the `tokens-studio-backup` branch, find the last good state: `git log --stat -- <alias>/`, then `git diff` between commits to locate when the bad change landed (hourly granularity).
+2. Extract the affected token-set JSON from that commit: `git show <commit>:<alias>/<set>.json`.
+3. Re-import the JSON into Tokens Studio (plugin / file upload), coordinated with the designers — never restore over in-progress work without agreeing on the target state first.
+4. If the mistake also made it into a Studio release, the `tokens-studio-release` PR history holds the same data at release granularity.
 
 ## Staying current
 
@@ -121,4 +132,4 @@ studio
 └── flags       --host --json --no-color --verbose
 ```
 
-Known state in this repo at snapshot time: CLI installed as a devDependency of `packages/eds-tokens` and approved in `onlyBuiltDependencies`. `.studio.json` lives in `packages/eds-tokens` (single source alias `eds-test-3`, project `4952a007-699a-4124-a043-124e80cc28d6`, branch `main`, format raw — the test-phase alias/output is due a production-shaped rename). Two saved export configurations on the project: `EDS-CSS` (css, id `39d37416-632b-4f04-b49b-cfaec63e3baa`, prefix `eds`, split layout, density base comfortable) and `EDS-DTCG` (dtcg, id `019463d4-9bef-4e37-9425-6de80eec87c8`). CI auth is OIDC (`id-token: write` + `--ci`) — no service token stored. See § The release pipeline for the workflow chain.
+Known state in this repo at snapshot time: CLI installed as a devDependency of `packages/eds-tokens` and approved in `onlyBuiltDependencies`. `.studio.json` lives in `packages/eds-tokens` (single source alias `eds-test-3`, project `4952a007-699a-4124-a043-124e80cc28d6`, branch `main`, format raw — the test-phase alias/output is due a production-shaped rename). Two saved export configurations on the project: `EDS-CSS` (css, id `39d37416-632b-4f04-b49b-cfaec63e3baa`, prefix `eds`, split layout, density base comfortable) and `EDS-DTCG` (dtcg, id `019463d4-9bef-4e37-9425-6de80eec87c8`). CI auth is OIDC (`id-token: write` + `--ci`) — no service token stored. Two workflows use it: `tokens_studio_release.yaml` (release-triggered, § The release pipeline) and `tokens_studio_backup.yaml` (hourly cron, § Backup & recovery).


### PR DESCRIPTION
Closes #5154

Tokens Studio has no undo/rollback — only a read-only version history of releases — and plugin changes push to the platform in real time, so designer mistakes propagate immediately. The release workflow only snapshots at release moments; everything in between is uncovered.

## What

- **New workflow `tokens_studio_backup.yaml`**: hourly cron (`23 * * * *`, plus `workflow_dispatch`) that runs `studio tokens pull --ci` for all sources in `packages/eds-tokens/.studio.json` and commits changes to the orphan branch `tokens-studio-backup` (one directory per source alias). Runs with no changes make no commit. Timestamped commit messages give an hourly-granularity recovery history.
- **Auth**: GitHub OIDC against the existing inbound CI Integration — scheduled runs always execute on `main`, so the token subject matches (manual dispatches must also pick `main`) the integration's subject pattern. No new secrets.
- **Rename-proof**: aliases and output dirs are read from `.studio.json` with `jq`, so the planned `eds-test-3` → `eds` rename (#5171) requires no workflow change.
- **Docs**: new "Backup & recovery" section in `documentation/agent-instructions/TOKENS_STUDIO.md`, including the manual recovery path (the CLI has no push command — restore = re-import JSON in Tokens Studio, coordinated with the designers).

## Notes

- The `tokens-studio-backup` branch is seeded manually (orphan, README only) so the workflow's checkout can always assume it exists. Never merge that branch.
- Failure alerts via the standard Slack step — an hourly safety net that fails silently is no safety net.

## Verification (after merge)

1. Trigger via `workflow_dispatch` → green run, snapshot commit on `tokens-studio-backup`
2. Trigger again immediately → green run, "No token changes since last backup", no commit
3. Next hourly run after a real token change in Studio → readable diff commit
