### PR TITLE
ci: simplify Tokens Studio backup workflow

### DIFF
--- a/.github/workflows/tokens_studio_backup.yaml
+++ b/.github/workflows/tokens_studio_backup.yaml
@@ -7,6 +7,11 @@ name: Tokens Studio backup
 # commits changes to the orphan branch `tokens-studio-backup`, giving us
 # diffs, history and a recovery point independent of the platform.
 # Recovery instructions: documentation/agent-instructions/TOKENS_STUDIO.md
+#
+# The CLI is installed standalone with npm outside the pnpm workspace —
+# a full workspace install just to obtain one binary is not worth two
+# minutes every hour. npm cannot run inside the workspace (workspace:
+# protocol deps), hence the --prefix install into the runner home.
 on:
   schedule:
     # Hourly, off the whole hour to avoid the GitHub cron rush
@@ -43,29 +48,30 @@ jobs:
         with:
           ref: tokens-studio-backup
           path: backup
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24.16.0'
-      # Same key as _setup.yml so the store cache is shared with the
-      # other workflows
-      - name: Cache pnpm-store
+      # The version follows the semver range in package.json (single
+      # source of truth) rather than the lockfile-exact version — for a
+      # read-only pull that drift is acceptable
+      - name: Resolve studio CLI version
+        id: cli-version
+        run: echo "version=$(jq -r '.devDependencies["@tokens-studio/studio-cli"]' packages/eds-tokens/package.json)" >> "$GITHUB_OUTPUT"
+      # Caches the installed CLI (including the platform binary its
+      # postinstall downloads) — a warm run skips npm entirely
+      - name: Cache studio CLI
+        id: cache-cli
         uses: actions/cache@v6
         with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-and-store-force-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          run_install: false
-      - name: Install dependencies
-        run: pnpm install --force
+          path: ~/studio-cli
+          key: studio-cli-${{ runner.os }}-${{ steps.cli-version.outputs.version }}
+      - name: Install studio CLI
+        if: steps.cache-cli.outputs.cache-hit != 'true'
+        run: npm install --prefix ~/studio-cli "@tokens-studio/studio-cli@${{ steps.cli-version.outputs.version }}" --no-audit --no-fund
       # No alias argument = pull every source configured in
       # packages/eds-tokens/.studio.json (token sets + $themes.json +
       # $metadata.json). --verbose because the run is unattended — the
       # Actions log is the only place to diagnose a bad pull
       - name: Pull tokens from Tokens Studio
-        run: pnpm --filter @equinor/eds-tokens exec studio tokens pull --ci --verbose
+        working-directory: packages/eds-tokens
+        run: ~/studio-cli/node_modules/.bin/studio tokens pull --ci --verbose
       # Aliases and output dirs are read from .studio.json so a config
       # rename (e.g. the planned eds-test-3 → eds) never requires a
       # workflow change. Each source lands at backup/<alias>/;

--- a/.github/workflows/tokens_studio_backup.yaml
+++ b/.github/workflows/tokens_studio_backup.yaml
@@ -48,12 +48,17 @@ jobs:
         with:
           ref: tokens-studio-backup
           path: backup
-      # The version follows the semver range in package.json (single
-      # source of truth) rather than the lockfile-exact version — for a
-      # read-only pull that drift is acceptable
+      # The version spec comes from package.json (single source of
+      # truth). Because the install is cached on the spec string, the
+      # CLI is effectively pinned to the patch resolved on the first
+      # cold run — it only moves when the spec in package.json changes.
+      # That stability is intentional for an unattended backup.
       - name: Resolve studio CLI version
         id: cli-version
-        run: echo "version=$(jq -r '.devDependencies["@tokens-studio/studio-cli"]' packages/eds-tokens/package.json)" >> "$GITHUB_OUTPUT"
+        run: |
+          version=$(jq -er '.devDependencies["@tokens-studio/studio-cli"]' packages/eds-tokens/package.json) \
+            || { echo "::error::@tokens-studio/studio-cli not found in eds-tokens devDependencies"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       # Caches the installed CLI (including the platform binary its
       # postinstall downloads) — a warm run skips npm entirely
       - name: Cache studio CLI
@@ -62,9 +67,19 @@ jobs:
         with:
           path: ~/studio-cli
           key: studio-cli-${{ runner.os }}-${{ steps.cli-version.outputs.version }}
+      # The cache post-step saves even when the job fails, so a partial
+      # install (e.g. network blip during the binary download) would be
+      # cached and poison every later run. Verify the binary and remove
+      # the directory on failure — no directory, nothing to cache
       - name: Install studio CLI
         if: steps.cache-cli.outputs.cache-hit != 'true'
-        run: npm install --prefix ~/studio-cli "@tokens-studio/studio-cli@${{ steps.cli-version.outputs.version }}" --no-audit --no-fund
+        run: |
+          if ! npm install --prefix ~/studio-cli "@tokens-studio/studio-cli@${{ steps.cli-version.outputs.version }}" --no-audit --no-fund \
+            || ! ~/studio-cli/node_modules/.bin/studio --version; then
+            rm -rf ~/studio-cli
+            echo "::error::studio CLI install failed verification"
+            exit 1
+          fi
       # No alias argument = pull every source configured in
       # packages/eds-tokens/.studio.json (token sets + $themes.json +
       # $metadata.json). --verbose because the run is unattended — the

--- a/documentation/agent-instructions/TOKENS_STUDIO.md
+++ b/documentation/agent-instructions/TOKENS_STUDIO.md
@@ -99,6 +99,8 @@ Classify every command before running it:
 
 The platform has **no undo, rollback or restore** — only a read-only version history of releases — and plugin changes push to Studio in real time. `.github/workflows/tokens_studio_backup.yaml` is the safety net for everything between releases: every hour (cron `23 * * * *`, plus manual `workflow_dispatch`) it runs `studio tokens pull` for all sources in `.studio.json` and commits changes to the orphan branch **`tokens-studio-backup`** (one directory per source alias — never merge this branch). Runs that find no changes make no commit. Auth is the same inbound CI Integration as the release pipeline — no extra setup. Failures alert via the Slack step; an hourly backup that fails silently is no safety net.
 
+Unlike the release workflow, the backup does **not** install the pnpm workspace — it installs the CLI standalone with `npm install --prefix` outside the workspace (version resolved from the package's `devDependencies` range) and caches the install. This is the one sanctioned exception to "never install the CLI with npm": npm only fails on `workspace:` protocol deps _inside_ the workspace, and a full workspace install every hour just to obtain one binary is not worth the time.
+
 **Recovery is manual — the CLI has no push command (only `pull`/`watch`):**
 
 1. On the `tokens-studio-backup` branch, find the last good state: `git log --stat -- <alias>/`, then `git diff` between commits to locate when the bad change landed (hourly granularity).


### PR DESCRIPTION
Follow-up to #5175. The backup job reused the release workflow's setup (Node + pnpm + full `pnpm install --force` of the monorepo) purely for consistency — two minutes every hour just to obtain the one `studio` binary.

## What

- Drop `Install Node.js`, `Setup pnpm`, `Cache pnpm-store` and the full workspace install.
- Install the CLI standalone instead: version resolved from `packages/eds-tokens/package.json` (single source of truth), installed with `npm install --prefix` **outside** the pnpm workspace (npm fails on `workspace:` protocol deps inside it), cached keyed on the version so warm runs skip npm entirely.
- Pull/sync/commit/push logic and the Slack failure alert are unchanged.
- Docs: note in `TOKENS_STUDIO.md` § Backup & recovery that this is the one sanctioned exception to "never install the CLI with npm".

Warm runs go from ~2 min to ~20–30 s.

## Trade-off

The CLI version spec comes from `package.json` (`^0.1.7`), and since the install is cached on the spec string, the CLI is effectively pinned to the patch resolved on the first cold run — it only moves when the spec changes. That stability is intentional for an unattended backup.

## Verification (after merge)

Manual `workflow_dispatch` from `main`: first run installs and caches the CLI, pulls, and reports "No token changes since last backup" (or commits a snapshot if designers changed something); a second run should be fully warm.
