### PR TITLE
ci: set cache headers and remove deploy downtime for storybook publish

### DIFF
--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -191,13 +191,23 @@ jobs:
 
           # Every deploy renames all content-hashed assets, so the whole
           # previous assets/* set is stale each run — parallelise the deletes.
+          # Cleanup is best-effort: the new content is already live at this
+          # point, and blobs that survive a transient delete failure are
+          # re-detected as stale on the next deploy. Don't fail the job.
+          set +e
           xargs -r -P 8 -I{} az storage blob delete \
             --container-name '$web' \
             --name '{}' \
             --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
             --output none < /tmp/stale-blobs.txt
+          rc=$?
+          set -e
 
-          echo "✅ Stale blob cleanup completed. Deleted $COUNT stale blobs."
+          if [ "$rc" -eq 0 ]; then
+            echo "✅ Stale blob cleanup completed. Deleted $COUNT stale blobs."
+          else
+            echo "⚠️ Some stale deletes failed (rc=$rc); orphans will be retried on the next deploy"
+          fi
 
       - name: logout 🔓
         run: az logout

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -123,6 +123,8 @@ jobs:
           # after the upload (zero-downtime deploy: upload with --overwrite
           # first, delete stale blobs afterwards). Deleting by name set is
           # deterministic — timestamps would race the Azure server clock.
+          # Must run before the mv of assets/ below, or assets/* drops out of
+          # the set and the cleanup deletes all live assets.
           (cd packages/eds-core-react/storybook-build && find . -type f | sed 's|^\./||') \
             | LC_ALL=C sort > /tmp/deployed-blobs.txt
 
@@ -166,6 +168,13 @@ jobs:
           set -euo pipefail
           echo "Deleting blobs not part of this deploy..."
 
+          # An empty deploy set would classify every blob in the container as
+          # stale and wipe the live site — refuse to continue.
+          if [ ! -s /tmp/deployed-blobs.txt ]; then
+            echo "❌ Deploy set is empty — refusing to run stale cleanup"
+            exit 1
+          fi
+
           az storage blob list \
             --container-name '$web' \
             --num-results '*' \
@@ -177,16 +186,16 @@ jobs:
           # Blobs present in the container but not in this deploy's file set
           LC_ALL=C comm -13 /tmp/deployed-blobs.txt /tmp/existing-blobs.txt > /tmp/stale-blobs.txt
 
-          COUNT=0
-          while IFS= read -r name; do
-            [ -n "$name" ] || continue
-            az storage blob delete \
-              --container-name '$web' \
-              --name "$name" \
-              --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-              --output none
-            COUNT=$((COUNT + 1))
-          done < /tmp/stale-blobs.txt
+          COUNT=$(wc -l < /tmp/stale-blobs.txt | tr -d ' ')
+          echo "Deleting $COUNT stale blobs..."
+
+          # Every deploy renames all content-hashed assets, so the whole
+          # previous assets/* set is stale each run — parallelise the deletes.
+          xargs -r -P 8 -I{} az storage blob delete \
+            --container-name '$web' \
+            --name '{}' \
+            --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+            --output none < /tmp/stale-blobs.txt
 
           echo "✅ Stale blob cleanup completed. Deleted $COUNT stale blobs."
 

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -118,12 +118,13 @@ jobs:
           FILE_COUNT=$(find packages/eds-core-react/storybook-build -type f | wc -l)
           echo "Uploading $FILE_COUNT files..."
 
-          # Blobs modified before this timestamp are orphans from a previous
-          # deploy and are cleaned up after the upload (zero-downtime deploy:
-          # upload with --overwrite first, delete stale blobs afterwards).
-          # Format matches az CLI's lastModified output for safe comparison.
-          DEPLOY_START=$(date -u '+%Y-%m-%dT%H:%M:%S+00:00')
-          echo "deploy-start=$DEPLOY_START" >> "$GITHUB_OUTPUT"
+          # Capture the full set of blob names this deploy produces. Blobs not
+          # in this set are orphans from a previous deploy and are cleaned up
+          # after the upload (zero-downtime deploy: upload with --overwrite
+          # first, delete stale blobs afterwards). Deleting by name set is
+          # deterministic — timestamps would race the Azure server clock.
+          (cd packages/eds-core-react/storybook-build && find . -type f | sed 's|^\./||') \
+            | LC_ALL=C sort > /tmp/deployed-blobs.txt
 
           # 1) Content-hashed assets: cache forever. Uploaded first so the new
           #    index.html never references chunks that don't exist yet.
@@ -156,38 +157,36 @@ jobs:
             --query 'length(@)' \
             --output tsv)
 
-          echo "✅ Deployment completed successfully. Total blobs in container: $UPLOADED"
+          echo "✅ Deployment completed successfully. Total blobs in container (before stale cleanup): $UPLOADED"
 
       - name: Delete stale blobs from previous deploy 🗑️
         env:
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZ_STORYBOOK_CONNECTION_STRING }}
-          DEPLOY_START: ${{ steps.deploy-website.outputs.deploy-start }}
         run: |
           set -euo pipefail
-          echo "Deleting blobs not touched by this deploy (last modified before $DEPLOY_START)..."
+          echo "Deleting blobs not part of this deploy..."
 
-          # ISO timestamps in identical format compare correctly as strings.
-          # The comparison is done in bash because JMESPath only defines
-          # ordering operators for numbers, not strings.
-          BLOBS=$(az storage blob list \
+          az storage blob list \
             --container-name '$web' \
             --num-results '*' \
             --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-            --query '[].[name, properties.lastModified]' \
-            --output tsv)
+            --query '[].name' \
+            --output tsv \
+            | LC_ALL=C sort > /tmp/existing-blobs.txt
+
+          # Blobs present in the container but not in this deploy's file set
+          LC_ALL=C comm -13 /tmp/deployed-blobs.txt /tmp/existing-blobs.txt > /tmp/stale-blobs.txt
 
           COUNT=0
-          while IFS=$'\t' read -r name lastmodified; do
+          while IFS= read -r name; do
             [ -n "$name" ] || continue
-            if [[ "$lastmodified" < "$DEPLOY_START" ]]; then
-              az storage blob delete \
-                --container-name '$web' \
-                --name "$name" \
-                --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-                --output none
-              COUNT=$((COUNT + 1))
-            fi
-          done <<< "$BLOBS"
+            az storage blob delete \
+              --container-name '$web' \
+              --name "$name" \
+              --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+              --output none
+            COUNT=$((COUNT + 1))
+          done < /tmp/stale-blobs.txt
 
           echo "✅ Stale blob cleanup completed. Deleted $COUNT stale blobs."
 

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -183,7 +183,10 @@ jobs:
             --output tsv \
             | LC_ALL=C sort > /tmp/existing-blobs.txt
 
-          # Blobs present in the container but not in this deploy's file set
+          # Blobs present in the container but not in this deploy's file set.
+          # Assumes this workflow is the sole writer to the $web container —
+          # anything uploaded out-of-band (e.g. a manual 404.html) is treated
+          # as stale and deleted on the next deploy.
           LC_ALL=C comm -13 /tmp/deployed-blobs.txt /tmp/existing-blobs.txt > /tmp/stale-blobs.txt
 
           COUNT=$(wc -l < /tmp/stale-blobs.txt | tr -d ' ')

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -101,38 +101,6 @@ jobs:
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
           allow-no-subscriptions: true
 
-      - name: Delete all existing blobs to ensure clean deployment 🗑️
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZ_STORYBOOK_CONNECTION_STRING }}
-        run: |
-          set -euo pipefail
-          echo "Checking existing blobs in container '\$web'..."
-          BLOB_COUNT=$(az storage blob list \
-            --container-name '$web' \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-            --query 'length(@)' \
-            --output tsv)
-
-          if [ "$BLOB_COUNT" -eq 0 ]; then
-            echo "Container already empty."
-          else
-            echo "Deleting $BLOB_COUNT blobs..."
-            az storage blob delete-batch \
-              --source '$web' \
-              --pattern "*" \
-              --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-              --output none
-            echo "Deletion request submitted."
-          fi
-
-          REMAINING=$(az storage blob list \
-            --container-name '$web' \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-            --query 'length(@)' \
-            --output tsv)
-
-          echo "✅ Blob deletion completed. Remaining blobs: $REMAINING"
-
       - name: Deploy to Azure Blob Storage 🚀
         id: deploy-website
         env:
@@ -150,20 +118,78 @@ jobs:
           FILE_COUNT=$(find packages/eds-core-react/storybook-build -type f | wc -l)
           echo "Uploading $FILE_COUNT files..."
 
+          # Blobs modified before this timestamp are orphans from a previous
+          # deploy and are cleaned up after the upload (zero-downtime deploy:
+          # upload with --overwrite first, delete stale blobs afterwards).
+          # Format matches az CLI's lastModified output for safe comparison.
+          DEPLOY_START=$(date -u '+%Y-%m-%dT%H:%M:%S+00:00')
+          echo "deploy-start=$DEPLOY_START" >> "$GITHUB_OUTPUT"
+
+          # 1) Content-hashed assets: cache forever. Uploaded first so the new
+          #    index.html never references chunks that don't exist yet.
+          az storage blob upload-batch \
+            --destination '$web' \
+            --destination-path assets \
+            --source packages/eds-core-react/storybook-build/assets \
+            --content-cache-control 'public, max-age=31536000, immutable' \
+            --overwrite \
+            --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+
+          # 2) Un-hashed files (index.html, iframe.html, sb-manager/**,
+          #    sb-addons/** etc.): browsers must revalidate on every load, or a
+          #    stale bundle mix breaks the Manager UI after each deploy (#5205).
+          #    Revalidation is cheap 304s via ETag/Last-Modified. Move assets/
+          #    aside so it is not re-uploaded with the wrong header.
+          mv packages/eds-core-react/storybook-build/assets /tmp/assets-uploaded
           az storage blob upload-batch \
             --destination '$web' \
             --source packages/eds-core-react/storybook-build \
+            --content-cache-control 'no-cache' \
             --overwrite \
             --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
 
           # Verify upload
           UPLOADED=$(az storage blob list \
             --container-name '$web' \
+            --num-results '*' \
             --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
             --query 'length(@)' \
             --output tsv)
 
           echo "✅ Deployment completed successfully. Total blobs in container: $UPLOADED"
+
+      - name: Delete stale blobs from previous deploy 🗑️
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZ_STORYBOOK_CONNECTION_STRING }}
+          DEPLOY_START: ${{ steps.deploy-website.outputs.deploy-start }}
+        run: |
+          set -euo pipefail
+          echo "Deleting blobs not touched by this deploy (last modified before $DEPLOY_START)..."
+
+          # ISO timestamps in identical format compare correctly as strings.
+          # The comparison is done in bash because JMESPath only defines
+          # ordering operators for numbers, not strings.
+          BLOBS=$(az storage blob list \
+            --container-name '$web' \
+            --num-results '*' \
+            --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+            --query '[].[name, properties.lastModified]' \
+            --output tsv)
+
+          COUNT=0
+          while IFS=$'\t' read -r name lastmodified; do
+            [ -n "$name" ] || continue
+            if [[ "$lastmodified" < "$DEPLOY_START" ]]; then
+              az storage blob delete \
+                --container-name '$web' \
+                --name "$name" \
+                --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+                --output none
+              COUNT=$((COUNT + 1))
+            fi
+          done <<< "$BLOBS"
+
+          echo "✅ Stale blob cleanup completed. Deleted $COUNT stale blobs."
 
       - name: logout 🔓
         run: az logout


### PR DESCRIPTION
Closes #5205

## Problem

Storybook prod serves every file with Front Door's default `cache-control: public, max-age=172800` (48h) because the upload sets no cache headers — including `index.html` and the un-hashed `sb-manager`/`sb-addons` bundles. After each deploy, browsers with a warm cache mix bundles from two different deploys and the Manager UI crashes with `api.getNavAvailability is not a function` (reported by a user on Chrome and Edge; hard refresh fixed it).

The workflow also deleted **all** blobs before uploading, taking the site down for the duration of the upload on every deploy.

## Changes to `publish_storybook.yaml`

- **Content-hashed `assets/*`**: uploaded with `Cache-Control: public, max-age=31536000, immutable` — filenames change on every content change, so caching forever is safe
- **Everything else** (`index.html`, `iframe.html`, `sb-manager/**`, `sb-addons/**`, …): uploaded with `Cache-Control: no-cache` so browsers revalidate on every load — cheap 304s via the ETag/Last-Modified headers already served
- **Zero-downtime deploy**: the delete-all-before-upload step is replaced with upload-with-overwrite followed by deletion of stale blobs only (those with `lastModified` older than deploy start). Hashed assets are uploaded before `index.html`, so the live page never references chunks that don't exist yet
- The stale-blob comparison is done in bash rather than a JMESPath query — JMESPath only defines ordering operators for numbers, so a date-string query could silently match nothing
- The existing `purge-cdn` job is unchanged; it handles the Front Door edge cache, this PR handles browser caches

## Verification

- YAML parses; `bash -n` passes on all run steps
- After merge, the push-to-main dev deploy allows checking headers with `curl -sI` (`no-cache` on `index.html`, `immutable` on `assets/*`)
- On the next production publish, verify Front Door honors the origin headers on https://storybook.eds.equinor.com — if it still serves `max-age=172800`, the Front Door caching rule overrides origin and needs an infra follow-up