### PR TITLE
ci: give each workflow a unique setup cache key

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_setup.yml
     secrets: inherit
     with:
-      cacheKey: ${{ github.sha }}
+      cacheKey: ${{ github.sha }}-setup-checks
       checkout_paths: packages apps scripts .github documentation
   packages:
     name: Process packages
@@ -35,7 +35,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-setup-checks
       - name: Fallback checkout (cache miss)
         if: steps.setup-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v7

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_setup.yml
     secrets: inherit
     with:
-      cacheKey: ${{ github.sha }}
+      cacheKey: ${{ github.sha }}-setup-core-react
       checkout_paths: packages scripts
       tag: ${{ github.event.inputs.npm-tag }}
   packages:
@@ -45,7 +45,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-setup-core-react
       - name: Use "dist" cache
         id: dist-cache
         uses: actions/cache@v6

--- a/.github/workflows/publish_data_grid.yaml
+++ b/.github/workflows/publish_data_grid.yaml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/_setup.yml
     secrets: inherit
     with:
-      cacheKey: ${{ github.sha }}
+      cacheKey: ${{ github.sha }}-setup-data-grid
       checkout_paths: packages scripts
       tag: ${{ github.event.inputs.npm-tag }}
   packages:
@@ -44,7 +44,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-setup-data-grid
       - name: Use "dist" cache
         id: dist-cache
         uses: actions/cache@v6

--- a/.github/workflows/publish_lab.yaml
+++ b/.github/workflows/publish_lab.yaml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/_setup.yml
     secrets: inherit
     with:
-      cacheKey: ${{ github.sha }}
+      cacheKey: ${{ github.sha }}-setup-lab
       checkout_paths: packages scripts
       tag: ${{ github.event.inputs.npm-tag }}
   packages:
@@ -44,7 +44,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-setup-lab
       - name: Use "dist" cache
         id: dist-cache
         uses: actions/cache@v6

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/_setup.yml
     secrets: inherit
     with:
-      cacheKey: ${{ github.sha }}
+      cacheKey: ${{ github.sha }}-setup-storybook
       checkout_paths: packages apps scripts
   packages:
     name: Process packages
@@ -42,7 +42,7 @@ jobs:
           path: |
             ./*
             ~/.pnpm-store
-          key: ${{ github.sha }}
+          key: ${{ github.sha }}-setup-storybook
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
Fixes #5214

## Why

`Checks` failed on push to main for 1243030ac (#5209): the AI component index freshness check reported all 23 components missing, even though `documentation/AI-COMPONENT-INDEX.md` on main is up to date.

Root cause: `checks.yaml`, `publish_core_react.yaml`, `publish_data_grid.yaml`, `publish_lab.yaml` and `publish_storybook.yaml` all pass the bare `${{ github.sha }}` as the `_setup.yml` cache key while checking out **different** sparse paths. Caches are immutable — first save wins. On that push, `Publish core-react storybook` saved the cache first (its checkout has no `documentation/`), the Checks setup logged "Unable to reserve cache … another job may be creating this cache", and the Checks `Process packages` job then restored the storybook workspace, where the index file doesn't exist.

## What

Suffix the setup cache key per workflow (`-setup-checks`, `-setup-storybook`, `-setup-core-react`, `-setup-data-grid`, `-setup-lab`) — the same pattern `publish_icons.yaml` and `publish_tokens.yaml` already use. Both the `cacheKey` input and the matching restore step in each workflow are updated, so key producer and consumer stay in sync. The `-dist-*` keys already had unique suffixes and are untouched.

Trade-off: workflows that previously (accidentally) shared a setup cache on the same push now each build their own. That costs one extra `pnpm install` per workflow run but guarantees every job restores the workspace its own setup created.