### PR TITLE
chore: replace HeaderMdx with Typography in icons preview story

### DIFF
--- a/packages/eds-core-react/stories/icons/IconPreview.stories.tsx
+++ b/packages/eds-core-react/stories/icons/IconPreview.stories.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react'
 import { StoryFn, Meta } from '@storybook/react-vite'
-import { HeaderMdx } from '@storybook/addon-docs/blocks'
 import styled from 'styled-components'
 import { Icon, Button, Typography, Search } from '../../src'
 import { download, IconData } from '@equinor/eds-icons'
@@ -115,9 +114,12 @@ export const Preview: StoryFn = () => {
       {Object.keys(iconsByGroup).map((key) => {
         return (
           <div key={key}>
-            <HeaderMdx id={key} as="h2">
+            {/* Docs-blocks components (HeaderMdx) must not render in the
+                canvas iframe — they read the Storybook manager theme, which
+                is undefined here (crashed with Storybook 10.5, #5213). */}
+            <Typography variant="h2" id={key}>
               {key}
-            </HeaderMdx>
+            </Typography>
             <Group>
               {iconsByGroup[key].map((icon: IconType) => {
                 const { name } = icon


### PR DESCRIPTION
## Why

The `icons-preview--preview` story crashes in production Storybook with `TypeError: Cannot read properties of undefined (reading 'secondary')` — reproduced with a clean browser profile, so it is baked into the deployed build.

Storybook 10.5.0 (#5185) changed MDX heading anchors for keyboard accessibility (storybookjs/storybook#34368): `HeaderMdx` now renders a Storybook-UI button that reads `theme.color.secondary` from the manager theme. The canvas iframe has no Storybook `ThemeProvider`, so the story throws on render.

## What

Replace `HeaderMdx` with an EDS `Typography` h2 carrying the same `id`, so anchor deep-links keep working. Only the hover copy-link button is lost. Docs-blocks components should not be rendered in canvas stories — a comment in the story now says why.

Closes #5213