### PR TITLE
ci: use shared cache-header deploy action for all storybook publishes

### DIFF
--- a/.github/actions/deploy-storybook/action.yml
+++ b/.github/actions/deploy-storybook/action.yml
@@ -1,0 +1,130 @@
+name: 'Deploy Storybook to Azure Blob Storage'
+description: >-
+  Zero-downtime upload of a static Storybook build to the $web container with
+  correct Cache-Control headers: content-hashed assets/* are cached forever,
+  everything else must be revalidated on every load. Without these headers
+  Azure Front Door applies its 48h default TTL and warm browser caches mix
+  bundles from two deploys, crashing the Manager UI (#5205, #5212).
+inputs:
+  folder:
+    description: 'Path to the built Storybook (static website root)'
+    required: true
+  connection-string:
+    description: 'Connection string for the target Azure Storage account'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Deploy to Azure Blob Storage 🚀
+      shell: bash
+      env:
+        AZURE_STORAGE_CONNECTION_STRING: ${{ inputs.connection-string }}
+        FOLDER: ${{ inputs.folder }}
+      run: |
+        set -euo pipefail
+        echo "Deploying to Azure Blob Storage..."
+
+        if [ ! -d "$FOLDER" ]; then
+          echo "❌ Error: folder '$FOLDER' not found"
+          exit 1
+        fi
+
+        FILE_COUNT=$(find "$FOLDER" -type f | wc -l)
+        echo "Uploading $FILE_COUNT files..."
+
+        # Capture the full set of blob names this deploy produces. Blobs not
+        # in this set are orphans from a previous deploy and are cleaned up
+        # after the upload (zero-downtime deploy: upload with --overwrite
+        # first, delete stale blobs afterwards). Deleting by name set is
+        # deterministic — timestamps would race the Azure server clock.
+        # Must run before the mv of assets/ below, or assets/* drops out of
+        # the set and the cleanup deletes all live assets.
+        (cd "$FOLDER" && find . -type f | sed 's|^\./||') \
+          | LC_ALL=C sort > "$RUNNER_TEMP/deployed-blobs.txt"
+
+        # 1) Content-hashed assets: cache forever. Uploaded first so the new
+        #    index.html never references chunks that don't exist yet.
+        if [ -d "$FOLDER/assets" ]; then
+          az storage blob upload-batch \
+            --destination '$web' \
+            --destination-path assets \
+            --source "$FOLDER/assets" \
+            --content-cache-control 'public, max-age=31536000, immutable' \
+            --overwrite \
+            --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+
+          # Move assets/ aside so it is not re-uploaded with the wrong header.
+          mv "$FOLDER/assets" "$RUNNER_TEMP/assets-uploaded"
+        fi
+
+        # 2) Un-hashed files (index.html, iframe.html, sb-manager/**,
+        #    sb-addons/** etc.): browsers must revalidate on every load, or a
+        #    stale bundle mix breaks the Manager UI after each deploy (#5205).
+        #    Revalidation is cheap 304s via ETag/Last-Modified.
+        az storage blob upload-batch \
+          --destination '$web' \
+          --source "$FOLDER" \
+          --content-cache-control 'no-cache' \
+          --overwrite \
+          --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+
+        UPLOADED=$(az storage blob list \
+          --container-name '$web' \
+          --num-results '*' \
+          --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+          --query 'length(@)' \
+          --output tsv)
+
+        echo "✅ Deployment completed successfully. Total blobs in container (before stale cleanup): $UPLOADED"
+
+    - name: Delete stale blobs from previous deploy 🗑️
+      shell: bash
+      env:
+        AZURE_STORAGE_CONNECTION_STRING: ${{ inputs.connection-string }}
+      run: |
+        set -euo pipefail
+        echo "Deleting blobs not part of this deploy..."
+
+        # An empty deploy set would classify every blob in the container as
+        # stale and wipe the live site — refuse to continue.
+        if [ ! -s "$RUNNER_TEMP/deployed-blobs.txt" ]; then
+          echo "❌ Deploy set is empty — refusing to run stale cleanup"
+          exit 1
+        fi
+
+        az storage blob list \
+          --container-name '$web' \
+          --num-results '*' \
+          --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+          --query '[].name' \
+          --output tsv \
+          | LC_ALL=C sort > "$RUNNER_TEMP/existing-blobs.txt"
+
+        # Blobs present in the container but not in this deploy's file set.
+        # Assumes this deploy is the sole writer to the $web container —
+        # anything uploaded out-of-band (e.g. a manual 404.html) is treated
+        # as stale and deleted on the next deploy.
+        LC_ALL=C comm -13 "$RUNNER_TEMP/deployed-blobs.txt" "$RUNNER_TEMP/existing-blobs.txt" > "$RUNNER_TEMP/stale-blobs.txt"
+
+        COUNT=$(wc -l < "$RUNNER_TEMP/stale-blobs.txt" | tr -d ' ')
+        echo "Deleting $COUNT stale blobs..."
+
+        # Every deploy renames all content-hashed assets, so the whole
+        # previous assets/* set is stale each run — parallelise the deletes.
+        # Cleanup is best-effort: the new content is already live at this
+        # point, and blobs that survive a transient delete failure are
+        # re-detected as stale on the next deploy. Don't fail the job.
+        set +e
+        xargs -r -P 8 -I{} az storage blob delete \
+          --container-name '$web' \
+          --name '{}' \
+          --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
+          --output none < "$RUNNER_TEMP/stale-blobs.txt"
+        rc=$?
+        set -e
+
+        if [ "$rc" -eq 0 ]; then
+          echo "✅ Stale blob cleanup completed. Deleted $COUNT stale blobs."
+        else
+          echo "⚠️ Some stale deletes failed (rc=$rc); orphans will be retried on the next deploy"
+        fi

--- a/.github/actions/deploy-storybook/action.yml
+++ b/.github/actions/deploy-storybook/action.yml
@@ -5,6 +5,16 @@ description: >-
   everything else must be revalidated on every load. Without these headers
   Azure Front Door applies its 48h default TTL and warm browser caches mix
   bundles from two deploys, crashing the Manager UI (#5205, #5212).
+
+  Requires Azure CLI on the runner (pre-installed on GitHub-hosted runners).
+  Static-website hosting and the container access policy are pre-existing
+  account configuration and are NOT (re)applied here — unlike the previous
+  tibor19/static-website-deploy action, this action will not self-heal an
+  account whose static-website config has been reset.
+
+  The stale cleanup assumes this deploy is the sole writer to the target
+  account's $web container, so each environment must point its
+  connection-string secret at a separate storage account.
 inputs:
   folder:
     description: 'Path to the built Storybook (static website root)'

--- a/.github/actions/deploy-storybook/action.yml
+++ b/.github/actions/deploy-storybook/action.yml
@@ -34,6 +34,11 @@ runs:
         set -euo pipefail
         echo "Deploying to Azure Blob Storage..."
 
+        # All az storage commands authenticate through the
+        # AZURE_STORAGE_CONNECTION_STRING env var set on the step. Never pass
+        # it as a --connection-string argument — argv is visible to every
+        # process on the runner (GitHub masks logs, not process args).
+
         if [ ! -d "$FOLDER" ]; then
           echo "❌ Error: folder '$FOLDER' not found"
           exit 1
@@ -60,8 +65,7 @@ runs:
             --destination-path assets \
             --source "$FOLDER/assets" \
             --content-cache-control 'public, max-age=31536000, immutable' \
-            --overwrite \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+            --overwrite
 
           # Move assets/ aside so it is not re-uploaded with the wrong header.
           mv "$FOLDER/assets" "$RUNNER_TEMP/assets-uploaded"
@@ -75,13 +79,11 @@ runs:
           --destination '$web' \
           --source "$FOLDER" \
           --content-cache-control 'no-cache' \
-          --overwrite \
-          --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
+          --overwrite
 
         UPLOADED=$(az storage blob list \
           --container-name '$web' \
           --num-results '*' \
-          --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
           --query 'length(@)' \
           --output tsv)
 
@@ -105,7 +107,6 @@ runs:
         az storage blob list \
           --container-name '$web' \
           --num-results '*' \
-          --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
           --query '[].name' \
           --output tsv \
           | LC_ALL=C sort > "$RUNNER_TEMP/existing-blobs.txt"
@@ -128,7 +129,6 @@ runs:
         xargs -r -P 8 -I{} az storage blob delete \
           --container-name '$web' \
           --name '{}' \
-          --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
           --output none < "$RUNNER_TEMP/stale-blobs.txt"
         rc=$?
         set -e

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -186,6 +186,13 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment || 'development' }}
     steps:
+      # The setup job's sparse checkout only includes packages/apps/scripts
+      # (and the workspace cache glob skips dot-directories), so .github and
+      # the local deploy action must be checked out here.
+      - name: Checkout deploy action
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github
       - name: Use cache with storybook files
         id: use-cache-storybook
         uses: actions/cache@v6
@@ -196,11 +203,9 @@ jobs:
           key: ${{ github.sha }}-dist-${{ github.event.inputs.environment }}-core-react
       - name: Deploy the website
         id: deploy-website
-        uses: tibor19/static-website-deploy@v4
+        uses: ./.github/actions/deploy-storybook
         with:
-          enabled-static-website: 'true'
-          folder: 'packages/eds-core-react/storybook-build'
-          public-access-policy: 'container'
+          folder: packages/eds-core-react/storybook-build
           connection-string: ${{ secrets.AZ_STORYBOOK_CONNECTION_STRING }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2

--- a/.github/workflows/publish_core_react.yaml
+++ b/.github/workflows/publish_core_react.yaml
@@ -188,7 +188,9 @@ jobs:
     steps:
       # The setup job's sparse checkout only includes packages/apps/scripts
       # (and the workspace cache glob skips dot-directories), so .github and
-      # the local deploy action must be checked out here.
+      # the local deploy action must be checked out here. Must stay the first
+      # step: checkout cleans the workspace and would wipe the restored
+      # storybook build otherwise.
       - name: Checkout deploy action
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish_data_grid.yaml
+++ b/.github/workflows/publish_data_grid.yaml
@@ -117,7 +117,9 @@ jobs:
     steps:
       # The setup job's sparse checkout only includes packages/apps/scripts
       # (and the workspace cache glob skips dot-directories), so .github and
-      # the local deploy action must be checked out here.
+      # the local deploy action must be checked out here. Must stay the first
+      # step: checkout cleans the workspace and would wipe the restored
+      # storybook build otherwise.
       - name: Checkout deploy action
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish_data_grid.yaml
+++ b/.github/workflows/publish_data_grid.yaml
@@ -115,6 +115,13 @@ jobs:
     name: Publish Storybook
     runs-on: ubuntu-latest
     steps:
+      # The setup job's sparse checkout only includes packages/apps/scripts
+      # (and the workspace cache glob skips dot-directories), so .github and
+      # the local deploy action must be checked out here.
+      - name: Checkout deploy action
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github
       - name: Use cache with storybook files
         id: use-cache-storybook
         uses: actions/cache@v6
@@ -125,11 +132,9 @@ jobs:
           key: ${{ github.sha }}-dist-${{ github.event.inputs.environment }}-data-grid
       - name: Deploy the website
         id: deploy-website
-        uses: tibor19/static-website-deploy@v4
+        uses: ./.github/actions/deploy-storybook
         with:
-          enabled-static-website: 'true'
-          folder: 'packages/eds-data-grid-react/storybook-build'
-          public-access-policy: 'container'
+          folder: packages/eds-data-grid-react/storybook-build
           connection-string: ${{ secrets.AZ_STORAGE_STORYBOOK_DATAGRID_CONNECTION_STRING }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2

--- a/.github/workflows/publish_lab.yaml
+++ b/.github/workflows/publish_lab.yaml
@@ -151,6 +151,13 @@ jobs:
     name: Publish Storybook
     runs-on: ubuntu-latest
     steps:
+      # The setup job's sparse checkout only includes packages/apps/scripts
+      # (and the workspace cache glob skips dot-directories), so .github and
+      # the local deploy action must be checked out here.
+      - name: Checkout deploy action
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github
       - name: Use cache with storybook files
         id: use-cache-storybook
         uses: actions/cache@v6
@@ -161,11 +168,9 @@ jobs:
           key: ${{ github.sha }}-dist-${{ github.event.inputs.environment }}-lab
       - name: Deploy the website
         id: deploy-website
-        uses: tibor19/static-website-deploy@v4
+        uses: ./.github/actions/deploy-storybook
         with:
-          enabled-static-website: 'true'
-          folder: 'packages/eds-lab-react/storybook-build'
-          public-access-policy: 'container'
+          folder: packages/eds-lab-react/storybook-build
           connection-string: ${{ secrets.AZ_STORAGE_STORYBOOK_LAB_CONNECTION_STRING }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v2

--- a/.github/workflows/publish_lab.yaml
+++ b/.github/workflows/publish_lab.yaml
@@ -153,7 +153,9 @@ jobs:
     steps:
       # The setup job's sparse checkout only includes packages/apps/scripts
       # (and the workspace cache glob skips dot-directories), so .github and
-      # the local deploy action must be checked out here.
+      # the local deploy action must be checked out here. Must stay the first
+      # step: checkout cleans the workspace and would wipe the restored
+      # storybook build otherwise.
       - name: Checkout deploy action
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -73,8 +73,11 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment || 'development' }}
     steps:
-      # The setup job's sparse checkout only includes packages/apps/scripts,
-      # so .github (and the local deploy action) must be checked out here.
+      # The setup job's sparse checkout only includes packages/apps/scripts
+      # (and the workspace cache glob skips dot-directories), so .github and
+      # the local deploy action must be checked out here. Must stay the first
+      # step: checkout cleans the workspace and would wipe the downloaded
+      # storybook build otherwise.
       - name: Checkout deploy action
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -73,6 +73,13 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment || 'development' }}
     steps:
+      # The setup job's sparse checkout only includes packages/apps/scripts,
+      # so .github (and the local deploy action) must be checked out here.
+      - name: Checkout deploy action
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github
+
       - name: Download storybook build
         uses: actions/download-artifact@v8
         with:
@@ -94,127 +101,12 @@ jobs:
           echo "=== All Foundation/Spacing entries ==="
           grep -o '"foundation-spacing--[^"]*"' packages/eds-core-react/storybook-build/index.json || echo "No Foundation/Spacing entries found"
 
-      - name: Az CLI login 🔑
-        uses: azure/login@v3
-        with:
-          client-id: d58b2e85-2d34-4cdb-ad70-5f2b767dd8e2
-          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
-          allow-no-subscriptions: true
-
-      - name: Deploy to Azure Blob Storage 🚀
+      - name: Deploy the website
         id: deploy-website
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZ_STORYBOOK_CONNECTION_STRING }}
-        run: |
-          set -euo pipefail
-          echo "Deploying to Azure Blob Storage..."
-
-          # Verify source directory exists and has content
-          if [ ! -d "packages/eds-core-react/storybook-build" ]; then
-            echo "❌ Error: storybook-build directory not found"
-            exit 1
-          fi
-
-          FILE_COUNT=$(find packages/eds-core-react/storybook-build -type f | wc -l)
-          echo "Uploading $FILE_COUNT files..."
-
-          # Capture the full set of blob names this deploy produces. Blobs not
-          # in this set are orphans from a previous deploy and are cleaned up
-          # after the upload (zero-downtime deploy: upload with --overwrite
-          # first, delete stale blobs afterwards). Deleting by name set is
-          # deterministic — timestamps would race the Azure server clock.
-          # Must run before the mv of assets/ below, or assets/* drops out of
-          # the set and the cleanup deletes all live assets.
-          (cd packages/eds-core-react/storybook-build && find . -type f | sed 's|^\./||') \
-            | LC_ALL=C sort > /tmp/deployed-blobs.txt
-
-          # 1) Content-hashed assets: cache forever. Uploaded first so the new
-          #    index.html never references chunks that don't exist yet.
-          az storage blob upload-batch \
-            --destination '$web' \
-            --destination-path assets \
-            --source packages/eds-core-react/storybook-build/assets \
-            --content-cache-control 'public, max-age=31536000, immutable' \
-            --overwrite \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
-
-          # 2) Un-hashed files (index.html, iframe.html, sb-manager/**,
-          #    sb-addons/** etc.): browsers must revalidate on every load, or a
-          #    stale bundle mix breaks the Manager UI after each deploy (#5205).
-          #    Revalidation is cheap 304s via ETag/Last-Modified. Move assets/
-          #    aside so it is not re-uploaded with the wrong header.
-          mv packages/eds-core-react/storybook-build/assets /tmp/assets-uploaded
-          az storage blob upload-batch \
-            --destination '$web' \
-            --source packages/eds-core-react/storybook-build \
-            --content-cache-control 'no-cache' \
-            --overwrite \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING"
-
-          # Verify upload
-          UPLOADED=$(az storage blob list \
-            --container-name '$web' \
-            --num-results '*' \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-            --query 'length(@)' \
-            --output tsv)
-
-          echo "✅ Deployment completed successfully. Total blobs in container (before stale cleanup): $UPLOADED"
-
-      - name: Delete stale blobs from previous deploy 🗑️
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZ_STORYBOOK_CONNECTION_STRING }}
-        run: |
-          set -euo pipefail
-          echo "Deleting blobs not part of this deploy..."
-
-          # An empty deploy set would classify every blob in the container as
-          # stale and wipe the live site — refuse to continue.
-          if [ ! -s /tmp/deployed-blobs.txt ]; then
-            echo "❌ Deploy set is empty — refusing to run stale cleanup"
-            exit 1
-          fi
-
-          az storage blob list \
-            --container-name '$web' \
-            --num-results '*' \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-            --query '[].name' \
-            --output tsv \
-            | LC_ALL=C sort > /tmp/existing-blobs.txt
-
-          # Blobs present in the container but not in this deploy's file set.
-          # Assumes this workflow is the sole writer to the $web container —
-          # anything uploaded out-of-band (e.g. a manual 404.html) is treated
-          # as stale and deleted on the next deploy.
-          LC_ALL=C comm -13 /tmp/deployed-blobs.txt /tmp/existing-blobs.txt > /tmp/stale-blobs.txt
-
-          COUNT=$(wc -l < /tmp/stale-blobs.txt | tr -d ' ')
-          echo "Deleting $COUNT stale blobs..."
-
-          # Every deploy renames all content-hashed assets, so the whole
-          # previous assets/* set is stale each run — parallelise the deletes.
-          # Cleanup is best-effort: the new content is already live at this
-          # point, and blobs that survive a transient delete failure are
-          # re-detected as stale on the next deploy. Don't fail the job.
-          set +e
-          xargs -r -P 8 -I{} az storage blob delete \
-            --container-name '$web' \
-            --name '{}' \
-            --connection-string "$AZURE_STORAGE_CONNECTION_STRING" \
-            --output none < /tmp/stale-blobs.txt
-          rc=$?
-          set -e
-
-          if [ "$rc" -eq 0 ]; then
-            echo "✅ Stale blob cleanup completed. Deleted $COUNT stale blobs."
-          else
-            echo "⚠️ Some stale deletes failed (rc=$rc); orphans will be retried on the next deploy"
-          fi
-
-      - name: logout 🔓
-        run: az logout
-        if: always()
+        uses: ./.github/actions/deploy-storybook
+        with:
+          folder: packages/eds-core-react/storybook-build
+          connection-string: ${{ secrets.AZ_STORYBOOK_CONNECTION_STRING }}
 
       - name: log-errors-to-slack
         uses: act10ns/slack@v2


### PR DESCRIPTION
## Why

The Manager UI crash from #5205 kept happening on https://storybook.eds.equinor.com after #5206 was merged. #5206 only changed `publish_storybook.yaml`, but push-to-main runs of that workflow deploy to the **development** environment — production Storybook is deployed by the `publish-storybook` job in `publish_core_react.yaml`, dispatched with `environment=production` on every release merge (verified: prod blob timestamps match the release run for #5135). That job — and the same jobs in `publish_lab.yaml` / `publish_data_grid.yaml` — used `tibor19/static-website-deploy@v4`, which sets no `Cache-Control` headers, so Azure Front Door falls back to its 48h default (`public, max-age=172800`, confirmed with curl) and warm browser caches mix bundles from two deploys after each release.

## What

- New composite action `.github/actions/deploy-storybook` with the deploy logic from #5206: immutable cache headers on hashed `assets/*`, `no-cache` on everything else, zero-downtime overwrite-then-delete-stale, and a guard refusing cleanup on an empty deploy set. One addition: the `assets/` upload is skipped when the build has no such directory.
- All four publish workflows use the action — `publish_storybook.yaml` (replacing its inline script, so there is a single source of truth), `publish_core_react.yaml`, `publish_lab.yaml`, `publish_data_grid.yaml`.
- The publish jobs check out `.github` explicitly (sparse), because the setup job's sparse checkout only includes `packages/apps/scripts` and the workspace cache glob skips dot-directories.
- The `az login`/`logout` steps in `publish_storybook.yaml` are dropped: `--connection-string` is complete authentication for the data plane on its own.

## Verification after merge

- Dispatch `publish_core_react.yaml` with `environment=production` (or wait for the next release), then `curl -sI` prod: expect `no-cache` on `index.html` and `max-age=31536000, immutable` on `assets/*`.
- If prod still serves `max-age=172800`, the Front Door caching rule overrides origin headers and needs an infra change outside this repo.

Closes #5212