### PR TITLE
chore: load the eds-tokens beta bundle in storybook for the /next migration

### DIFF
--- a/packages/eds-core-react/.storybook/preview.css
+++ b/packages/eds-core-react/.storybook/preview.css
@@ -1,3 +1,9 @@
+/* Tokens Studio beta bundle (ADR-0009: published consumers import
+   @equinor/eds-tokens/next/css/variables.css; the ./next/* exports are
+   injected at publish time only, hence the relative path locally).
+   Imported BEFORE the legacy bundle so legacy wins the name collisions
+   (--eds-typography-header-*-font-size) during the mixed period. */
+@import '../../eds-tokens/src/tokens/css/variables.css';
 @import '@equinor/eds-tokens/css/variables';
 
 /* Ensure form elements inherit EDS typography */

--- a/packages/eds-core-react/.storybook/preview.mjs
+++ b/packages/eds-core-react/.storybook/preview.mjs
@@ -47,9 +47,21 @@ const preview = {
         return () => document.body.classList.remove('eds-debug-grid')
       }, [debugGrid])
 
-      if (!isNext) return createElement(Story)
-
       const colorScheme = context.globals.colorScheme || 'light'
+
+      useEffect(() => {
+        // The Tokens Studio beta semantic tokens are declared at :root and
+        // reference step aliases that only exist under [data-color-scheme].
+        // Custom properties substitute where they are declared, so the
+        // attribute must sit on <html> for the semantic layer to resolve —
+        // the subtree wrapper below is not enough.
+        if (!isNext) return
+        document.documentElement.setAttribute('data-color-scheme', colorScheme)
+        return () =>
+          document.documentElement.removeAttribute('data-color-scheme')
+      }, [isNext, colorScheme])
+
+      if (!isNext) return createElement(Story)
 
       return createElement(
         'div',

--- a/packages/eds-core-react/.storybook/preview.mjs
+++ b/packages/eds-core-react/.storybook/preview.mjs
@@ -66,6 +66,11 @@ const preview = {
       return createElement(
         'div',
         {
+          // Kept alongside the <html> attribute on purpose: the legacy 2.x
+          // bundle scopes its tokens under [data-color-scheme] (nearest
+          // ancestor wins), so the wrapper and unmigrated /next components
+          // need it here — synchronously from first paint, independent of
+          // the effect above. Only the beta semantic layer needs <html>.
           'data-color-scheme': colorScheme,
           className: 'eds-storybook-wrapper',
         },


### PR DESCRIPTION
Part of #5119. Infrastructure for the component-by-component colour migration (first consumers: Button #5222, Chip) — extracted from #5222 so component PRs can merge independently.

## Changes

- **`.storybook/preview.css`** — imports the Tokens Studio beta bundle alongside the legacy one, so both variable sets resolve during the mixed migration period (ADR-0009). Relative path because the `./next/*` exports are injected at publish time only. Imported **before** the legacy bundle so legacy wins the 8 `--eds-typography-header-*-font-size` name collisions.
- **`.storybook/preview.mjs`** — mirrors the colour scheme onto `<html>` for EDS 2.0 stories. The beta semantic tokens are declared at `:root` and reference scale aliases that only exist under `[data-color-scheme]`; custom properties substitute where they are declared, so the attribute must sit on the root element for the semantic layer to resolve (captured as a learning on #5208, export-side fix tracked in #5221).

No component or published-package changes — Storybook config only.