### PR TITLE
docs: resolve dangling ADR-0010 references

### DIFF
--- a/.github/workflows/tokens_studio_release.yaml
+++ b/.github/workflows/tokens_studio_release.yaml
@@ -91,7 +91,8 @@ jobs:
       # src/tokens/css/semantic/*.css in place, so that selector change
       # is expected in this PR's diff), then concatenate the generated
       # CSS into one committed bundle (the bundler itself adds no
-      # behaviour, deliberately not minified — ADR-0010). Importable on
+      # behaviour, deliberately not minified — ADR-0010, proposed in
+      # #5199, acceptance tracked in #5202). Importable on
       # the beta line as @equinor/eds-tokens/next/css/variables.css via
       # the ./next/css/* wildcard publish_tokens.yaml already injects.
       - name: Widen semantic scope and bundle CSS into variables.css
@@ -107,7 +108,7 @@ jobs:
           # "Added" in the changelog, which is what a token update is.
           commit-message: 'feat: update tokens from Tokens Studio release'
           title: 'feat: update tokens from Tokens Studio release'
-          body: 'Automated pull of the token state after a Tokens Studio release: raw token sets via `studio tokens pull` (sources in `packages/eds-tokens/.studio.json`), generated CSS (EDS-CSS export) into `packages/eds-tokens/src/tokens/css/`, DTCG (EDS-DTCG export) into `src/tokens/dtcg/`, TypeScript modules generated from the two into `src/tokens/ts/`, and the bundled `src/tokens/css/variables.css` (concatenation of the CSS export, per ADR-0010). The `semantic/*.css` files are widened to `:root, [data-color-scheme]` by `scripts/widen-semantic-scope.mjs` before bundling (#5226) — that selector diff against the raw export is expected.'
+          body: 'Automated pull of the token state after a Tokens Studio release: raw token sets via `studio tokens pull` (sources in `packages/eds-tokens/.studio.json`), generated CSS (EDS-CSS export) into `packages/eds-tokens/src/tokens/css/`, DTCG (EDS-DTCG export) into `src/tokens/dtcg/`, TypeScript modules generated from the two into `src/tokens/ts/`, and the bundled `src/tokens/css/variables.css` (concatenation of the CSS export, per ADR-0010 — proposed in #5199). The `semantic/*.css` files are widened to `:root, [data-color-scheme]` by `scripts/widen-semantic-scope.mjs` before bundling (#5226) — that selector diff against the raw export is expected.'
           branch: tokens-studio-release
       # This workflow runs unattended (release-triggered) and the PR it
       # creates gets no CI runs, so a failed pull must not be silent

--- a/packages/eds-tokens/scripts/generate-css-bundle.mjs
+++ b/packages/eds-tokens/scripts/generate-css-bundle.mjs
@@ -2,8 +2,9 @@
  * Bundle the Tokens Studio CSS export into one committed file.
  *
  * Concatenates every generated CSS file under `src/tokens/css/` into
- * `src/tokens/css/variables.css` (ADR-0010). The bundle adds no
- * behaviour on top of the generated files — every mode file is
+ * `src/tokens/css/variables.css` (ADR-0010, proposed in #5199). The
+ * bundle adds no behaviour on top of the generated files — every mode
+ * file is
  * `:root`- or attribute-scoped, and `var()` references are late-bound.
  * Files are concatenated in sorted path order to keep the committed
  * artifact deterministic.


### PR DESCRIPTION
Closes #5244.

`tokens_studio_release.yaml` and `generate-css-bundle.mjs` cite "ADR-0010" for the CSS bundle, but only ADRs 0000–0009 exist on main — the ADR itself is still an open PR (#5199), deliberately kept open until the bundled CSS entry is validated in beta (#5202).

This updates the references to say the ADR is proposed in #5199 (with acceptance tracked in #5202), so the citation is traceable today and stays correct once the ADR lands.

- `.github/workflows/tokens_studio_release.yaml` — the bundle step comment and the generated PR body
- `packages/eds-tokens/scripts/generate-css-bundle.mjs` — the script header (same dangling reference, not listed in the issue but fixed alongside)

Comment-only change, no behaviour affected.