### PR TITLE
chore: fold in mobile's shared tsconfig, fix vector-icons peer dep

### DIFF
--- a/packages/eds-mobile-components/package.json
+++ b/packages/eds-mobile-components/package.json
@@ -44,6 +44,7 @@
     "license": "MIT",
     "main": "./dist/index.js",
     "peerDependencies": {
+        "@expo/vector-icons": "^15.1.1",
         "expo-font": "^55.0.8",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",

--- a/packages/eds-mobile-components/tsconfig.json
+++ b/packages/eds-mobile-components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig/base.json",
+    "extends": "../../tsconfig.mobile.base.json",
     "include": ["src"],
     "exclude": [
         "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,6 +935,9 @@ importers:
       '@equinor/eds-tokens':
         specifier: 2.3.0-beta.3
         version: 2.3.0-beta.3
+      '@expo/vector-icons':
+        specifier: ^15.1.1
+        version: 15.1.1(expo-font@55.0.8)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
       '@floating-ui/react-native':
         specifier: ^0.10.7
         version: 0.10.10(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)

--- a/tsconfig.mobile.base.json
+++ b/tsconfig.mobile.base.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "display": "Equinor Design System Mobile",
+  "compileOnSave": false,
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": false,
+    "allowUnreachableCode": false,
+    "importHelpers": false,
+    "lib": ["DOM", "ESNext"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Part of #5138 (step 3: fold in shared configs), re-scoped from the original plan — see the note on the issue.

Stacked on top of #5329 (this branch is `5138-drop-turbo-hand-sequence` + this PR's own commit), so this diff will look larger than just this step until #5329 merges into `5138-mobile-repo-migration` — targeting the integration branch directly rather than #5329's branch, since that branch will close once its own PR merges and I didn't want this PR's base pointing at something about to disappear.

## Summary

Unblocks `mobile:build`/`mobile:check-types`, which have failed since the subtree import landed.

## Changes

- **Shared tsconfig, landed as a root file, not a package.** The original plan called for bringing in `design-system-mobile`'s `packages/tsconfig` as its own workspace package. Checked this repo's actual existing convention first: `eds-core-react`/`eds-data-grid-react`/`eds-lab-react`/`eds-utils` all extend a single plain root file (`tsconfig.base.json`, `tsconfig.test.base.json`), not a dedicated package. Mobile's version has exactly one real consumer once imported — not enough to justify the package ceremony. Landed as `tsconfig.mobile.base.json` at root instead.
- **Fixed the extends path** in `packages/eds-mobile-components/tsconfig.json` (was pointing at a path that never existed in this repo, `../tsconfig/base.json`) to `../../tsconfig.mobile.base.json`.
- **Added `@expo/vector-icons` as a `peerDependency`** of `eds-mobile-components`, alongside `expo-font`/`react-native`/etc. It's a genuine runtime dependency (`Icon.tsx` renders `MaterialCommunityIcons`, `useEDS.ts` preloads its fonts) that was never declared in the source repo's own `package.json` either — it only worked there because `design-system-mobile`'s `.npmrc` sets `node-linker=hoisted`, silently hoisting it from `apps/storybook`'s own dependency. This repo's strict pnpm linking surfaced the gap as a real `Cannot find module` error.

## Not included

- **`eslint-config-eds-mobile` skipped entirely.** Confirmed neither `eds-mobile-components` nor `apps/mobile-storybook` reference it anywhere, even in the source repo — `eds-mobile-components` builds its ESLint config inline, `mobile-storybook` uses the third-party `eslint-config-expo/flat`. Nothing to import.
- **Merging mobile's linting into the root `eslint.config.mjs` remains deferred**, unchanged from the original plan. ESLint's flat config doesn't cascade per-directory — root's `lint:all` already applies its own style rules (not mobile's) to mobile's files today. Doing this properly means reconciling mobile's code style with root's Prettier conventions, a bigger call than this step should make.

## Verified

- `mobile:build` — exit 0, 80 `.d.ts` files generated (previously failing on cascading `Iterable`/`Symbol`/`Array.find` errors from the missing `target`/`lib` config, plus `@equinor/eds-tokens/ts/*` subpath resolution failures from the missing `moduleResolution`).
- `mobile:check-types` — exit 0.
- `test:mobile` — still 13/13 suites, 109/109 tests, no regression.