### PR TITLE
chore: switch mobile docs to workspace link, fix stale sourceUrls

### DIFF
--- a/packages/eds-core-react/package.json
+++ b/packages/eds-core-react/package.json
@@ -54,7 +54,7 @@
     "react"
   ],
   "devDependencies": {
-    "@equinor/eds-mobile-components": "^0.3.0",
+    "@equinor/eds-mobile-components": "workspace:^",
     "@figma/code-connect": "^1.4.9",
     "@playwright/test": "^1.62.0",
     "@rollup/plugin-babel": "^7.1.0",

--- a/packages/eds-core-react/src/components/EdsProvider/EdsProvider.docs.mdx
+++ b/packages/eds-core-react/src/components/EdsProvider/EdsProvider.docs.mdx
@@ -10,7 +10,7 @@ Provider used to set global values for EDS react components.
 
 <PlatformTabs mobile={<>
   <Links
-    sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/EDSProvider/EDSProvider.tsx"
+    sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/EDSProvider/EDSProvider.tsx"
     npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
   />
   <MobileDocs />

--- a/packages/eds-core-react/src/components/Typography/Typography.new.docs.mdx
+++ b/packages/eds-core-react/src/components/Typography/Typography.new.docs.mdx
@@ -9,7 +9,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Typography.mdx'
 
 <PlatformTabs mobile={<>
   <Links
-    sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/Typography/Typography.tsx"
+    sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/Typography/index.ts"
     npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
   />
   <MobileDocs />

--- a/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
@@ -14,7 +14,7 @@ Button component for triggering actions.
 
 <PlatformTabs mobile={<>
   <Links
-    sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/Button.tsx"
+    sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/Button/Button.tsx"
     npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
   />
   <MobileDocs />

--- a/packages/eds-core-react/src/components/next/Checkbox/Checkbox.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Checkbox/Checkbox.docs.mdx
@@ -11,7 +11,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Checkbox.mdx'
 
 <PlatformTabs mobile={<>
   <Links
-    sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/SelectionControls/Checkbox.tsx"
+    sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/SelectionControls/Checkbox.tsx"
     npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
   />
   <MobileDocs />

--- a/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
@@ -11,7 +11,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Input.mdx'
 
 <PlatformTabs mobile={<>
   <Links
-    sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/Input/Input.tsx"
+    sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/Input/Input.tsx"
     npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
   />
   <MobileDocs />

--- a/packages/eds-core-react/src/components/next/Radio/Radio.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.docs.mdx
@@ -11,7 +11,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Radio.mdx'
 
 <PlatformTabs mobile={<>
   <Links
-    sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/SelectionControls/Radio.tsx"
+    sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/SelectionControls/Radio.tsx"
     npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
   />
   <MobileDocs />

--- a/packages/eds-core-react/src/components/next/Switch/Switch.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Switch/Switch.docs.mdx
@@ -11,7 +11,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Switch.mdx'
 
 <PlatformTabs mobile={<>
   <Links
-    sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/SelectionControls/Switch.tsx"
+    sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/SelectionControls/Switch.tsx"
     npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
   />
   <MobileDocs />

--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -195,7 +195,7 @@ If the finding needs real work, open a dedicated issue and link it next to the c
 4. Create developer documentation in `docs/YourComponent.mdx` — run `/document-component` for the full workflow and structure
 5. Follow existing patterns for prop naming and component structure
 
-**MDX handoff to EDS Storybook:** Files in `docs/` ship via npm and are consumed by the EDS Storybook repo, which wraps each one with source/npm `<Links>` inside `<PlatformTabs>`. Mobile MDX should not import `<Links>` or `<PlatformTabs>` itself — write component-focused content only. The consumer-side wrapping pattern (in EDS Storybook's `next/<Component>/<Component>.docs.mdx`) is:
+**MDX handoff to EDS Storybook:** Files in `docs/` are consumed by `packages/eds-core-react` via a `workspace:^` link in this monorepo, which wraps each one with source/npm `<Links>` inside `<PlatformTabs>` — changes appear as soon as both packages are built, no release needed. Mobile MDX should not import `<Links>` or `<PlatformTabs>` itself — write component-focused content only. The consumer-side wrapping pattern (in `packages/eds-core-react/src/components/<Component>/<Component>.docs.mdx` — most under `next/`, but `EdsProvider` and `Typography.new` sit outside it) is:
 
 ```tsx
 <PlatformTabs

--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -202,7 +202,7 @@ If the finding needs real work, open a dedicated issue and link it next to the c
     mobile={
         <>
             <Links
-                sourceUrl="https://github.com/equinor/design-system-mobile/blob/main/packages/components/src/components/SelectionControls/Switch.tsx"
+                sourceUrl="https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/src/components/SelectionControls/Switch.tsx"
                 npmUrl="https://www.npmjs.com/package/@equinor/eds-mobile-components"
             />
             <MobileDocs />

--- a/packages/eds-mobile-components/docs/Introduction.mdx
+++ b/packages/eds-mobile-components/docs/Introduction.mdx
@@ -16,7 +16,7 @@ If your product could run as a web app, [`@equinor/eds-core-react`](https://stor
 
 EDS Mobile is pre-1.0. Expect minor breaking changes between releases, and pin exact versions if you need API stability today.
 
-Once we reach 1.0, the public API is stable and breaking changes follow semantic versioning. Until then, components may change as we work through the design migration — keep an eye on the [release notes](https://github.com/equinor/design-system-mobile/releases) for breaking-change details.
+Once we reach 1.0, the public API is stable and breaking changes follow semantic versioning. Until then, components may change as we work through the design migration — keep an eye on the [changelog](https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/CHANGELOG.md) for breaking-change details.
 
 ## Get started
 
@@ -66,8 +66,8 @@ import { Button } from '@equinor/eds-mobile-components'
 
 - [Design guidelines](https://eds.equinor.com/)
 - [Figma library](https://www.figma.com/files/682286909510540417/workspace/1404734309303602976/directory/teams)
-- [GitHub repository](https://github.com/equinor/design-system-mobile)
-- [Release notes](https://github.com/equinor/design-system-mobile/releases)
+- [GitHub repository](https://github.com/equinor/design-system/tree/main/packages/eds-mobile-components)
+- [Changelog](https://github.com/equinor/design-system/blob/main/packages/eds-mobile-components/CHANGELOG.md)
 
 ## Get in touch
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,8 +506,8 @@ importers:
         version: 3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@equinor/eds-mobile-components':
-        specifier: ^0.3.0
-        version: 0.3.0(expo-font@55.0.8)(react-dom@19.2.8(react@19.2.8))(react-native-gesture-handler@2.31.2(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native-reanimated@4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native-svg@15.15.5(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+        specifier: workspace:^
+        version: link:../eds-mobile-components
       '@figma/code-connect':
         specifier: ^1.4.9
         version: 1.4.9
@@ -3314,18 +3314,6 @@ packages:
 
   '@equinor/eds-icons@1.4.0':
     resolution: {integrity: sha512-7Igq79wUhL/3qVWUammmD9BvGX3/3+BuL6lP+sxiZrdDrdDnLV0QSrRsFF7mAycc1hqEzx9ZwcitKedyDWWnow==}
-
-  '@equinor/eds-mobile-components@0.3.0':
-    resolution: {integrity: sha512-jYYpNwOzcwEotrlwZPMV+OdJlxbrjm01+zbAeIPvRmM5ttN3j5UPSB2suoZ1m/oskyEpGxPxRC1cK1RVgQqXEg==}
-    peerDependencies:
-      expo-font: ^55.0.8
-      react: ^19.2.0
-      react-dom: ^19.2.0
-      react-native: ^0.83.6
-      react-native-gesture-handler: ^2.30.0
-      react-native-reanimated: ^4.2.1
-      react-native-svg: ^15.15.3
-      react-native-worklets: ^0.7.4
 
   '@equinor/eds-tokens@2.2.0':
     resolution: {integrity: sha512-MUbv83ppGHzRBSgaZTkPqMU+2cAQsaDiE/b22GsIXnmptVH4NV5tyHJdz7Yrd1U7yKWO4L7IUwK849IBixyVyg==}
@@ -12750,12 +12738,6 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-gesture-handler@2.31.2:
-    resolution: {integrity: sha512-rw5q74i2AfS7YGYdbxQDhOU7xqgY6WRM1132/CCm3erqjblhECZDZFHIm0tteHoC9ih24wogVBVVzcTBQtZ+5A==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-
   react-native-is-edge-to-edge@1.3.1:
     resolution: {integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==}
     peerDependencies:
@@ -12783,12 +12765,6 @@ packages:
 
   react-native-svg@15.15.3:
     resolution: {integrity: sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-
-  react-native-svg@15.15.5:
-    resolution: {integrity: sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -18993,20 +18969,6 @@ snapshots:
       styled-components: 6.4.4(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
 
   '@equinor/eds-icons@1.4.0': {}
-
-  '@equinor/eds-mobile-components@0.3.0(expo-font@55.0.8)(react-dom@19.2.8(react@19.2.8))(react-native-gesture-handler@2.31.2(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native-reanimated@4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native-svg@15.15.5(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@equinor/eds-tokens': 2.3.0-beta.3
-      '@floating-ui/react-native': 0.10.10(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
-      expo-font: 55.0.8(expo@55.0.23)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-error-boundary: 6.1.2(react@19.2.8)
-      react-native: 0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
-      react-native-gesture-handler: 2.31.2(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
-      react-native-reanimated: 4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
-      react-native-svg: 15.15.5(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
-      react-native-worklets: 0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
 
   '@equinor/eds-tokens@2.2.0': {}
 
@@ -30536,15 +30498,6 @@ snapshots:
       react: 19.2.8
       react-native: 0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
 
-  react-native-gesture-handler@2.31.2(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
-    dependencies:
-      '@egjs/hammerjs': 2.0.17
-      '@types/react-test-renderer': 19.1.0
-      hoist-non-react-statics: 3.3.2
-      invariant: 2.2.4
-      react: 19.2.8
-      react-native: 0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
-
   react-native-is-edge-to-edge@1.3.1(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -30577,13 +30530,6 @@ snapshots:
       react: 19.2.8
       react-native: 0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
       warn-once: 0.1.1
-
-  react-native-svg@15.15.5(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
-    dependencies:
-      css-select: 5.2.2
-      css-tree: 1.1.3
-      react: 19.2.8
-      react-native: 0.83.6(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
 
   react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
Part of #5138 (step 6: mobile docs via workspace link).

## Summary

Switches `eds-core-react`'s dependency on `@equinor/eds-mobile-components` from a real npm version to `workspace:^`, and fixes the hardcoded `sourceUrl` links that the dependency swap alone doesn't touch.

## Changes

- **Dependency swap:** `@equinor/eds-mobile-components` in `eds-core-react`'s `package.json` changed from `^0.3.0` to `workspace:^`. Verified via the lockfile and a direct symlink check that `docs/*.mdx` content now resolves from the local `packages/eds-mobile-components`, not a downloaded npm copy.
- **Scoped properly:** searched the whole repo for every consumer of the package rather than guessing filenames. Found 10 relevant files:
  - **7 files** import `MobileDocs`/`MobileIntro` *and* hardcode a `sourceUrl` pointing at the old external `design-system-mobile` repo — `Button`, `Checkbox`, `Input`, `Radio`, `Switch` (`packages/eds-core-react/src/components/next/`), `EdsProvider` (legacy tree, not under `next/` — it's version-agnostic, sitting above the EDS 1.0/2.0 split entirely), and `Typography.new.docs.mdx` (**not** `Foundation/Typography.docs.mdx`, a different, unrelated foundation/type-scale doc with no mobile content). Verified each target file actually exists at its new path before writing it — most just needed the repo/base-path swapped, but `Button`'s hardcoded path was flat (`src/components/Button.tsx`) while the real structure is now a nested folder (`src/components/Button/Button.tsx`).
  - **1 file** (`stories/mobile/About.mdx`) imports `MobileIntro` with no `sourceUrl` — the dependency swap alone was sufficient.
  - **2 files** (`stories/docs/Intro.mdx`, `stories/mobile/Components.mdx`) only reference the package by name/npm-badge/link — confirmed nothing to fix.
- **`Typography.new.docs.mdx` needed a judgment call, not a mechanical fix:** the original `sourceUrl` never pointed at a real file, even in the source repo — there's no flat `Typography.tsx`, only `TypographyUI.tsx` and `TypographyHeader.tsx`, composed together in `index.ts`. Pointed `sourceUrl` at `index.ts`, since that's where the actual exported `Typography`/`Typography.Header` pair is composed, and the embedded mobile docs on this page describe both.
- **Fixed a stale example in `packages/eds-mobile-components/CLAUDE.md`** (caught by self-review): its own "consumer-side wrapping pattern" documentation still showed the old `design-system-mobile` URL as the canonical pattern for future MDX handoffs — would have taught contributors to reintroduce this exact bug.

## Verified

- Dependency resolves via a real symlink (`node_modules/@equinor/eds-mobile-components -> ../../../eds-mobile-components`), confirmed in both the lockfile (`specifier: workspace:^`, `version: link:../eds-mobile-components`) and on disk.
- Every `sourceUrl` target file confirmed to exist at its new path — not just a syntax check.
- Self-review confirmed the `workspace:^` swap is isolated to `eds-core-react`'s own devDependencies, no other package affected, and the lockfile diff only reflects this one change.

## Not included

- Whether `TypographyNext`'s docs page should exist at all (reportedly the team has agreed EDS 2.0 won't have a `Typography` component) and what a fully standalone, web-less mobile doc page should look like if/when that page is removed — both flagged for team discussion, not actioned here.