### PR TITLE
fix: Today button in Datepicker now selects and navigates correctly

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -313,6 +313,80 @@ describe('DatePicker', () => {
     expect(screen.getByRole('presentation')).toHaveTextContent('01/22/2025')
   })
 
+  describe('Bug #4933: Today button', () => {
+    it('selects today when clicked', async () => {
+      const onChange = jest.fn()
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            value={new Date(2020, 0, 1)}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      await userEvent.click(screen.getByLabelText(/^Change date.*/))
+      await userEvent.click(screen.getByText('Today'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const result = onChange.mock.calls[0][0] as Date
+      const today = new Date()
+      expect(result.getFullYear()).toBe(today.getFullYear())
+      expect(result.getMonth()).toBe(today.getMonth())
+      expect(result.getDate()).toBe(today.getDate())
+    })
+
+    it('selects today when the calendar is showing a future month', async () => {
+      const onChange = jest.fn()
+      // Use a future date so the calendar opens past today — this is the exact
+      // scenario from the bug: today < startDate causes selectDate to bail out
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            value={new Date(2027, 0, 1)}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      await userEvent.click(screen.getByLabelText(/^Change date.*/))
+      await userEvent.click(screen.getByText('Today'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const result = onChange.mock.calls[0][0] as Date
+      const today = new Date()
+      expect(result.getFullYear()).toBe(today.getFullYear())
+      expect(result.getMonth()).toBe(today.getMonth())
+      expect(result.getDate()).toBe(today.getDate())
+    })
+
+    it('selects today on repeated clicks', async () => {
+      const onChange = jest.fn()
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            value={new Date(2020, 0, 1)}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      const toggle = screen.getByLabelText(/^Change date.*/)
+
+      await userEvent.click(toggle)
+      await userEvent.click(screen.getByText('Today'))
+      expect(onChange).toHaveBeenCalledTimes(1)
+
+      // Re-open and click Today again — must still fire onChange
+      await userEvent.click(toggle)
+      await userEvent.click(screen.getByText('Today'))
+      expect(onChange).toHaveBeenCalledTimes(2)
+    })
+  })
+
   it('should display localized message for unavailable dates', () => {
     const unavailableDate = new Date(2024, 4, 30)
 

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -313,8 +313,11 @@ describe('DatePicker', () => {
     expect(screen.getByRole('presentation')).toHaveTextContent('01/22/2025')
   })
 
-  describe('Bug #4933: Today button', () => {
-    it('selects today when clicked', async () => {
+  describe('Today button (#4933)', () => {
+    // Use a date well in the future so these tests remain valid regardless of when they run
+    const futureYear = new Date().getFullYear() + 2
+
+    it('selects today when the calendar is showing a past month', async () => {
       const onChange = jest.fn<void, [Date]>()
       render(
         <I18nProvider locale={'en-US'}>
@@ -337,15 +340,14 @@ describe('DatePicker', () => {
       expect(result.getDate()).toBe(today.getDate())
     })
 
-    it('selects today when the calendar is showing a future month', async () => {
+    it('selects today when the calendar is showing a future month (bug #4933)', async () => {
+      // today < startDate caused react-stately's selectDate to bail out silently
       const onChange = jest.fn<void, [Date]>()
-      // Use a future date so the calendar opens past today — this is the exact
-      // scenario from the bug: today < startDate causes selectDate to bail out
       render(
         <I18nProvider locale={'en-US'}>
           <DatePicker
             label={'Datepicker'}
-            value={new Date(2027, 0, 1)}
+            value={new Date(futureYear, 0, 1)}
             onChange={onChange}
           />
         </I18nProvider>,
@@ -362,7 +364,7 @@ describe('DatePicker', () => {
       expect(result.getDate()).toBe(today.getDate())
     })
 
-    it('selects today on repeated clicks without closing the picker', async () => {
+    it('fires onChange on repeated clicks without closing the picker', async () => {
       const onChange = jest.fn()
       render(
         <I18nProvider locale={'en-US'}>
@@ -375,12 +377,56 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-
-      // Picker stays open — click Today multiple times without re-opening
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).toHaveBeenCalledTimes(1)
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not fire onChange when today is before minValue', async () => {
+      const onChange = jest.fn()
+      const tomorrow = new Date()
+      tomorrow.setDate(tomorrow.getDate() + 1)
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            value={new Date(futureYear, 0, 1)}
+            minValue={tomorrow}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      await userEvent.click(screen.getByLabelText(/^Change date.*/))
+      // Today button should be disabled — click does nothing
+      await userEvent.click(screen.getByText('Today'))
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('does not fire onChange when today is unavailable', async () => {
+      const onChange = jest.fn()
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            value={new Date(futureYear, 0, 1)}
+            isDateUnavailable={(d) => {
+              const today = new Date()
+              return (
+                d.getFullYear() === today.getFullYear() &&
+                d.getMonth() === today.getMonth() &&
+                d.getDate() === today.getDate()
+              )
+            }}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      await userEvent.click(screen.getByLabelText(/^Change date.*/))
+      await userEvent.click(screen.getByText('Today'))
+      expect(onChange).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -315,7 +315,7 @@ describe('DatePicker', () => {
 
   describe('Bug #4933: Today button', () => {
     it('selects today when clicked', async () => {
-      const onChange = jest.fn()
+      const onChange = jest.fn<void, [Date]>()
       render(
         <I18nProvider locale={'en-US'}>
           <DatePicker
@@ -330,7 +330,7 @@ describe('DatePicker', () => {
       await userEvent.click(screen.getByText('Today'))
 
       expect(onChange).toHaveBeenCalledTimes(1)
-      const result = onChange.mock.calls[0][0] as Date
+      const result = onChange.mock.calls[0][0]
       const today = new Date()
       expect(result.getFullYear()).toBe(today.getFullYear())
       expect(result.getMonth()).toBe(today.getMonth())
@@ -338,7 +338,7 @@ describe('DatePicker', () => {
     })
 
     it('selects today when the calendar is showing a future month', async () => {
-      const onChange = jest.fn()
+      const onChange = jest.fn<void, [Date]>()
       // Use a future date so the calendar opens past today — this is the exact
       // scenario from the bug: today < startDate causes selectDate to bail out
       render(
@@ -355,14 +355,14 @@ describe('DatePicker', () => {
       await userEvent.click(screen.getByText('Today'))
 
       expect(onChange).toHaveBeenCalledTimes(1)
-      const result = onChange.mock.calls[0][0] as Date
+      const result = onChange.mock.calls[0][0]
       const today = new Date()
       expect(result.getFullYear()).toBe(today.getFullYear())
       expect(result.getMonth()).toBe(today.getMonth())
       expect(result.getDate()).toBe(today.getDate())
     })
 
-    it('selects today on repeated clicks', async () => {
+    it('selects today on repeated clicks without closing the picker', async () => {
       const onChange = jest.fn()
       render(
         <I18nProvider locale={'en-US'}>
@@ -374,14 +374,11 @@ describe('DatePicker', () => {
         </I18nProvider>,
       )
 
-      const toggle = screen.getByLabelText(/^Change date.*/)
+      await userEvent.click(screen.getByLabelText(/^Change date.*/))
 
-      await userEvent.click(toggle)
+      // Picker stays open — click Today multiple times without re-opening
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).toHaveBeenCalledTimes(1)
-
-      // Re-open and click Today again — must still fire onChange
-      await userEvent.click(toggle)
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).toHaveBeenCalledTimes(2)
     })

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -411,8 +411,7 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-      // Button stays enabled for navigation; _onSelectToday guards onChange
-      expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
+      expect(screen.getByText('Today').closest('button')).toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })
@@ -438,8 +437,7 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-      // Button stays enabled for navigation; _onSelectToday guards onChange
-      expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
+      expect(screen.getByText('Today').closest('button')).toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -354,7 +354,19 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
+
+      // Heading should show the future year before clicking Today
+      expect(screen.getByTestId('heading')).toHaveTextContent(
+        String(futureYear),
+      )
+
       await userEvent.click(screen.getByText('Today'))
+
+      // Heading should navigate back to current month
+      const now = new Date()
+      expect(screen.getByTestId('heading')).toHaveTextContent(
+        String(now.getFullYear()),
+      )
 
       expect(onChange).toHaveBeenCalledTimes(1)
       const result = onChange.mock.calls[0][0]
@@ -399,7 +411,8 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-      // Today button should be disabled — click does nothing
+      expect(screen.getByText('Today').closest('button')).toBeDisabled()
+      // Disabled button — click does nothing
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })
@@ -425,13 +438,13 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
+      expect(screen.getByText('Today').closest('button')).toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })
 
     it('preserves the existing time when showTimeInput is active', async () => {
       const onChange = jest.fn<void, [Date]>()
-      const futureYear = new Date().getFullYear() + 2
       // 14:30 should survive clicking Today
       const valueWithTime = new Date(futureYear, 0, 1, 14, 30)
       render(

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -415,6 +415,10 @@ describe('DatePicker', () => {
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
       expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
+      // Still navigates to today's month even though onChange is suppressed
+      expect(screen.getByTestId('heading')).toHaveTextContent(
+        String(new Date().getFullYear()),
+      )
       expect(onChange).not.toHaveBeenCalled()
     })
 
@@ -441,6 +445,10 @@ describe('DatePicker', () => {
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
       expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
+      // Still navigates to today's month even though onChange is suppressed
+      expect(screen.getByTestId('heading')).toHaveTextContent(
+        String(new Date().getFullYear()),
+      )
       expect(onChange).not.toHaveBeenCalled()
     })
 
@@ -498,6 +506,27 @@ describe('DatePicker', () => {
       expect(dateInKiritimati).toBe('2026-08-19')
 
       jest.useRealTimers()
+    })
+
+    it('does not fire onChange on a readOnly DatePicker opened via keyboard', async () => {
+      // FieldWrapper opens the popover on Enter without checking readOnly,
+      // so the popover is reachable by keyboard even in readOnly mode.
+      const onChange = jest.fn()
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            readOnly
+            value={new Date(futureYear, 0, 1)}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      await userEvent.tab()
+      await userEvent.keyboard('{Enter}')
+      await userEvent.click(screen.getByText('Today'))
+      expect(onChange).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -317,6 +317,8 @@ describe('DatePicker', () => {
     // Use a date well in the future so these tests remain valid regardless of when they run
     const futureYear = new Date().getFullYear() + 2
 
+    afterEach(() => jest.useRealTimers())
+
     it('selects today when the calendar is showing a past month', async () => {
       const onChange = jest.fn<void, [Date]>()
       render(
@@ -411,7 +413,7 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-      expect(screen.getByText('Today').closest('button')).toBeDisabled()
+      expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })
@@ -437,7 +439,7 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-      expect(screen.getByText('Today').closest('button')).toBeDisabled()
+      expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -313,7 +313,7 @@ describe('DatePicker', () => {
     expect(screen.getByRole('presentation')).toHaveTextContent('01/22/2025')
   })
 
-  describe('Today button (#4933)', () => {
+  describe('Today button', () => {
     // Use a date well in the future so these tests remain valid regardless of when they run
     const futureYear = new Date().getFullYear() + 2
 
@@ -411,8 +411,8 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-      expect(screen.getByText('Today').closest('button')).toBeDisabled()
-      // Disabled button — click does nothing
+      // Button stays enabled for navigation; _onSelectToday guards onChange
+      expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })
@@ -438,7 +438,8 @@ describe('DatePicker', () => {
       )
 
       await userEvent.click(screen.getByLabelText(/^Change date.*/))
-      expect(screen.getByText('Today').closest('button')).toBeDisabled()
+      // Button stays enabled for navigation; _onSelectToday guards onChange
+      expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })
@@ -465,6 +466,38 @@ describe('DatePicker', () => {
       const result = onChange.mock.calls[0][0]
       expect(result.getHours()).toBe(14)
       expect(result.getMinutes()).toBe(30)
+    })
+
+    it('selects the correct day in the picker timezone, not the local timezone', async () => {
+      // 20:00 UTC on Aug 18 is already Aug 19 in Pacific/Kiritimati (UTC+14)
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2026-08-18T20:00:00Z'))
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      const onChange = jest.fn<void, [Date]>()
+
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            timezone={'Pacific/Kiritimati'}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      await user.click(screen.getByLabelText(/^Change date.*/))
+      await user.click(screen.getByText('Today'))
+
+      // Kiritimati is UTC+14, so "today" there is Aug 19 — midnight in Kiritimati is
+      // 2026-08-18T10:00:00Z in UTC. Check the local date in that timezone.
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const result = onChange.mock.calls[0][0]
+      const dateInKiritimati = result.toLocaleDateString('en-CA', {
+        timeZone: 'Pacific/Kiritimati',
+      })
+      expect(dateInKiritimati).toBe('2026-08-19')
+
+      jest.useRealTimers()
     })
   })
 

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.spec.tsx
@@ -428,6 +428,31 @@ describe('DatePicker', () => {
       await userEvent.click(screen.getByText('Today'))
       expect(onChange).not.toHaveBeenCalled()
     })
+
+    it('preserves the existing time when showTimeInput is active', async () => {
+      const onChange = jest.fn<void, [Date]>()
+      const futureYear = new Date().getFullYear() + 2
+      // 14:30 should survive clicking Today
+      const valueWithTime = new Date(futureYear, 0, 1, 14, 30)
+      render(
+        <I18nProvider locale={'en-US'}>
+          <DatePicker
+            label={'Datepicker'}
+            showTimeInput
+            value={valueWithTime}
+            onChange={onChange}
+          />
+        </I18nProvider>,
+      )
+
+      await userEvent.click(screen.getByLabelText(/^Change date.*/))
+      await userEvent.click(screen.getByText('Today'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const result = onChange.mock.calls[0][0]
+      expect(result.getHours()).toBe(14)
+      expect(result.getMinutes()).toBe(30)
+    })
   })
 
   it('should display localized message for unavailable dates', () => {

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
@@ -122,11 +122,15 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
 
     const _value = getCalendarDate(value, timezone, showTimeInput) ?? innerValue
 
+    // Separate from _onChange so the picker stays open after Today is clicked.
+    // Re-validates min/max/unavailable here because this path bypasses
+    // react-stately's normalizeValue (which would silently reject today when
+    // it is before the visible-range startDate — the root cause of #4933).
     const _onSelectToday = useCallback(
       (calendarDate: CalendarDate) => {
         if (_minValue && calendarDate.compare(_minValue) < 0) return
         if (_maxValue && calendarDate.compare(_maxValue) > 0) return
-        if (_isDateUnavailable && _isDateUnavailable(calendarDate)) return
+        if (_isDateUnavailable(calendarDate)) return
 
         // Preserve an existing time selection when showTimeInput is active
         const newValue =

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
@@ -191,6 +191,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 ref={pickerRef}
                 Footer={Footer}
                 Header={Header}
+                onSelectDate={_onChange}
                 {...calendarProps}
               />
             }

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
@@ -120,22 +120,43 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       [onChange, isOpen, showTimeInput, timezone],
     )
 
+    const _value = getCalendarDate(value, timezone, showTimeInput) ?? innerValue
+
     const _onSelectToday = useCallback(
-      (value: CalendarDate | CalendarDateTime) => {
-        if (value) {
-          setInnerValue(
-            showTimeInput ? toCalendarDateTime(value) : toCalendarDate(value),
-          )
-        }
+      (calendarDate: CalendarDate) => {
+        if (_minValue && calendarDate.compare(_minValue) < 0) return
+        if (_maxValue && calendarDate.compare(_maxValue) > 0) return
+        if (
+          _isDateUnavailable &&
+          _isDateUnavailable(calendarDate.toDate(timezone))
+        )
+          return
+
+        // Preserve an existing time selection when showTimeInput is active
+        const newValue =
+          showTimeInput && _value && 'hour' in _value
+            ? _value.set({
+                year: calendarDate.year,
+                month: calendarDate.month,
+                day: calendarDate.day,
+              })
+            : calendarDate
+
+        setInnerValue(showTimeInput ? toCalendarDateTime(newValue) : newValue)
         if (onChange) {
-          const date = value.toDate(timezone)
-          onChange(date)
+          onChange(newValue.toDate(timezone))
         }
       },
-      [onChange, showTimeInput, timezone],
+      [
+        onChange,
+        showTimeInput,
+        timezone,
+        _minValue,
+        _maxValue,
+        _isDateUnavailable,
+        _value,
+      ],
     )
-
-    const _value = getCalendarDate(value, timezone, showTimeInput) ?? innerValue
 
     const locale = useGetLocale(propLocale)
 
@@ -206,7 +227,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 ref={pickerRef}
                 Footer={Footer}
                 Header={Header}
-                onSelectDate={_onSelectToday}
+                onSelectToday={_onSelectToday}
                 {...calendarProps}
               />
             }

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
@@ -128,6 +128,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     // it is before the visible-range startDate — the root cause of #4933).
     const _onSelectToday = useCallback(
       (calendarDate: CalendarDate) => {
+        if (isDisabled || isReadOnly) return
         if (_minValue && calendarDate.compare(_minValue) < 0) return
         if (_maxValue && calendarDate.compare(_maxValue) > 0) return
         if (_isDateUnavailable(calendarDate)) return
@@ -155,6 +156,8 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
         _maxValue,
         _isDateUnavailable,
         _value,
+        isDisabled,
+        isReadOnly,
       ],
     )
 

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
@@ -120,6 +120,21 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       [onChange, isOpen, showTimeInput, timezone],
     )
 
+    const _onSelectToday = useCallback(
+      (value: CalendarDate | CalendarDateTime) => {
+        if (value) {
+          setInnerValue(
+            showTimeInput ? toCalendarDateTime(value) : toCalendarDate(value),
+          )
+        }
+        if (onChange) {
+          const date = value.toDate(timezone)
+          onChange(date)
+        }
+      },
+      [onChange, showTimeInput, timezone],
+    )
+
     const _value = getCalendarDate(value, timezone, showTimeInput) ?? innerValue
 
     const locale = useGetLocale(propLocale)
@@ -191,7 +206,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                 ref={pickerRef}
                 Footer={Footer}
                 Header={Header}
-                onSelectDate={_onChange}
+                onSelectDate={_onSelectToday}
                 {...calendarProps}
               />
             }

--- a/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DatePicker.tsx
@@ -126,11 +126,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       (calendarDate: CalendarDate) => {
         if (_minValue && calendarDate.compare(_minValue) < 0) return
         if (_maxValue && calendarDate.compare(_maxValue) > 0) return
-        if (
-          _isDateUnavailable &&
-          _isDateUnavailable(calendarDate.toDate(timezone))
-        )
-          return
+        if (_isDateUnavailable && _isDateUnavailable(calendarDate)) return
 
         // Preserve an existing time selection when showTimeInput is active
         const newValue =

--- a/packages/eds-core-react/src/components/Datepicker/DateRangePicker.spec.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/DateRangePicker.spec.tsx
@@ -207,4 +207,22 @@ describe('DateRangePicker', () => {
     const disabledDate = screen.getByLabelText('Thursday, May 30, 2024')
     expect(disabledDate).toHaveAttribute('aria-disabled', 'true')
   })
+
+  it('Today button stays enabled for navigation when maxValue is in the past', async () => {
+    // DateRangePicker never passes onSelectToday — Today is navigation-only.
+    // It must not be disabled even when today falls outside maxValue.
+    const lastYear = new Date()
+    lastYear.setFullYear(lastYear.getFullYear() - 1)
+
+    render(
+      <RangeContainer>
+        <DateRangePicker label={'DateRangePicker'} maxValue={lastYear} />
+      </RangeContainer>,
+    )
+
+    const picker = screen.getByLabelText(/^Change date.*/)
+    await userEvent.click(picker)
+
+    expect(screen.getByText('Today').closest('button')).not.toBeDisabled()
+  })
 })

--- a/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
@@ -23,7 +23,7 @@ export const Calendar = forwardRef(
     {
       Header,
       Footer,
-      onSelectDate,
+      onSelectToday,
       ...props
     }: {
       /**
@@ -34,7 +34,7 @@ export const Calendar = forwardRef(
        * Custom footer component
        */
       Footer?: (props: HeaderFooterProps) => ReactNode
-      onSelectDate?: (date: CalendarDate) => void
+      onSelectToday?: (date: CalendarDate) => void
     } & AriaCalendarProps<DateValue>,
     ref: RefObject<HTMLDivElement | null>,
   ) => {
@@ -80,7 +80,7 @@ export const Calendar = forwardRef(
               showYearPicker={showYearPicker}
               yearPickerPage={yearPickerPage}
               setYearPickerPage={setYearPickerPage}
-              onSelectDate={onSelectDate}
+              onSelectToday={onSelectToday}
             />
           )}
         </Popover.Header>

--- a/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
@@ -10,7 +10,7 @@ import { useCalendarState } from '@react-stately/calendar'
 import { CalendarGrid } from './CalendarGrid'
 import { CalendarHeader } from './CalendarHeader'
 import { HeaderFooterProps } from '../props'
-import { createCalendar } from '@internationalized/date'
+import { CalendarDate, createCalendar } from '@internationalized/date'
 import { Popover } from '../../Popover'
 import { CalendarWrapper } from './CalendarWrapper'
 
@@ -23,6 +23,7 @@ export const Calendar = forwardRef(
     {
       Header,
       Footer,
+      onSelectDate,
       ...props
     }: {
       /**
@@ -33,6 +34,7 @@ export const Calendar = forwardRef(
        * Custom footer component
        */
       Footer?: (props: HeaderFooterProps) => ReactNode
+      onSelectDate?: (date: CalendarDate) => void
     } & AriaCalendarProps<DateValue>,
     ref: RefObject<HTMLDivElement | null>,
   ) => {
@@ -78,6 +80,7 @@ export const Calendar = forwardRef(
               showYearPicker={showYearPicker}
               yearPickerPage={yearPickerPage}
               setYearPickerPage={setYearPickerPage}
+              onSelectDate={onSelectDate}
             />
           )}
         </Popover.Header>

--- a/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/Calendar.tsx
@@ -34,6 +34,7 @@ export const Calendar = forwardRef(
        * Custom footer component
        */
       Footer?: (props: HeaderFooterProps) => ReactNode
+      /** Called when the Today button is clicked. Not passed by DateRangePicker — Today navigates only there. */
       onSelectToday?: (date: CalendarDate) => void
     } & AriaCalendarProps<DateValue>,
     ref: RefObject<HTMLDivElement | null>,

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -99,10 +99,10 @@ export function CalendarHeader({
       ? years[years.length - 1] > state.maxValue.year
       : nextMonthDisabled
 
-  // Today is disabled only while the year picker is open — navigation to today's
-  // month is always meaningful. _onSelectToday in DatePicker guards against
-  // emitting an out-of-range value through onChange.
-  const isTodayDisabled = showYearPicker
+  const isTodayDisabled =
+    showYearPicker ||
+    (!!onSelectToday &&
+      (state.isInvalid(todayDate) || state.isCellUnavailable(todayDate)))
 
   return (
     <HeaderWrapper>

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -99,10 +99,10 @@ export function CalendarHeader({
       ? years[years.length - 1] > state.maxValue.year
       : nextMonthDisabled
 
-  const isTodayDisabled =
-    showYearPicker ||
-    (!!onSelectToday &&
-      (state.isInvalid(todayDate) || state.isCellUnavailable(todayDate)))
+  // Today is disabled only while the year picker is open — navigation to today's
+  // month is always meaningful. _onSelectToday in DatePicker guards against
+  // emitting an out-of-range value through onChange.
+  const isTodayDisabled = showYearPicker
 
   return (
     <HeaderWrapper>

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -99,10 +99,7 @@ export function CalendarHeader({
       ? years[years.length - 1] > state.maxValue.year
       : nextMonthDisabled
 
-  const isTodayDisabled =
-    showYearPicker ||
-    (!!onSelectToday &&
-      (state.isInvalid(todayDate) || state.isCellUnavailable(todayDate)))
+  const isTodayDisabled = showYearPicker
 
   return (
     <HeaderWrapper>

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -25,22 +25,13 @@ function TodayPicker({
   onClick,
   disabled,
 }: {
-  onClick: (v: CalendarDate) => void
+  onClick: () => void
   disabled: boolean
 }) {
-  const today = new Date()
   return (
     <Button
       disabled={disabled}
-      onClick={() =>
-        onClick(
-          new CalendarDate(
-            today.getFullYear(),
-            today.getMonth() + 1,
-            today.getDate(),
-          ),
-        )
-      }
+      onClick={onClick}
       variant={'ghost'}
       style={{ marginLeft: 4 }}
     >
@@ -80,7 +71,7 @@ export function CalendarHeader({
   setShowYearPicker,
   setYearPickerPage,
   yearPickerPage,
-  onSelectDate,
+  onSelectToday,
 }: {
   state: CalendarState | RangeCalendarState
   title: string
@@ -90,8 +81,16 @@ export function CalendarHeader({
   setShowYearPicker: (showYearPicker: boolean) => void
   setYearPickerPage?: Dispatch<SetStateAction<number>>
   yearPickerPage: number
-  onSelectDate?: (date: CalendarDate) => void
+  /** Called when the Today button is clicked. Only provided by DatePicker, not DateRangePicker. */
+  onSelectToday?: (date: CalendarDate) => void
 }) {
+  const now = new Date()
+  const todayDate = new CalendarDate(
+    now.getFullYear(),
+    now.getMonth() + 1,
+    now.getDate(),
+  )
+
   const years = getPageYears(state.focusedDate.year, yearPickerPage)
   const backButtonDisabled =
     showYearPicker && state.minValue
@@ -102,6 +101,11 @@ export function CalendarHeader({
     showYearPicker && state.maxValue
       ? years[years.length - 1] > state.maxValue.year
       : nextMonthDisabled
+
+  const isTodayDisabled =
+    showYearPicker ||
+    state.isInvalid(todayDate) ||
+    state.isCellUnavailable(todayDate)
 
   return (
     <HeaderWrapper>
@@ -129,14 +133,12 @@ export function CalendarHeader({
           <Icon data={showYearPicker ? chevron_up : chevron_down} />
         </TitleButton>
         <TodayPicker
-          disabled={showYearPicker}
-          onClick={(v: CalendarDate) => {
-            if (onSelectDate) {
-              onSelectDate(v)
-            } else {
-              state.selectDate(v)
+          disabled={isTodayDisabled}
+          onClick={() => {
+            if (onSelectToday) {
+              onSelectToday(todayDate)
             }
-            state.setFocusedDate(v)
+            state.setFocusedDate(todayDate)
           }}
         />
         <span style={{ flex: '1 1 auto' }}></span>

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -80,6 +80,7 @@ export function CalendarHeader({
   setShowYearPicker,
   setYearPickerPage,
   yearPickerPage,
+  onSelectDate,
 }: {
   state: CalendarState | RangeCalendarState
   title: string
@@ -89,6 +90,7 @@ export function CalendarHeader({
   setShowYearPicker: (showYearPicker: boolean) => void
   setYearPickerPage?: Dispatch<SetStateAction<number>>
   yearPickerPage: number
+  onSelectDate?: (date: CalendarDate) => void
 }) {
   const years = getPageYears(state.focusedDate.year, yearPickerPage)
   const backButtonDisabled =
@@ -128,7 +130,14 @@ export function CalendarHeader({
         </TitleButton>
         <TodayPicker
           disabled={showYearPicker}
-          onClick={(v: CalendarDate) => state.setFocusedDate(v)}
+          onClick={(v: CalendarDate) => {
+            if (onSelectDate) {
+              onSelectDate(v)
+            } else {
+              state.selectDate(v)
+            }
+            state.setFocusedDate(v)
+          }}
         />
         <span style={{ flex: '1 1 auto' }}></span>
         <Button

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -99,8 +99,6 @@ export function CalendarHeader({
       ? years[years.length - 1] > state.maxValue.year
       : nextMonthDisabled
 
-  const isTodayDisabled = showYearPicker
-
   return (
     <HeaderWrapper>
       <HeaderActions>
@@ -127,7 +125,7 @@ export function CalendarHeader({
           <Icon data={showYearPicker ? chevron_up : chevron_down} />
         </TitleButton>
         <TodayPicker
-          disabled={isTodayDisabled}
+          disabled={showYearPicker}
           onClick={() => {
             if (onSelectToday) {
               onSelectToday(todayDate)

--- a/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/calendars/CalendarHeader.tsx
@@ -8,10 +8,11 @@ import {
   chevron_right,
   chevron_up,
 } from '@equinor/eds-icons'
-import { CalendarDate } from '@internationalized/date'
+import { CalendarDate, today } from '@internationalized/date'
 import { tokens } from '@equinor/eds-tokens'
 import { Dispatch, SetStateAction } from 'react'
 import { getPageYears } from '../utils/getPageYears'
+import { useTimezone } from '../utils/context'
 
 const HeaderWrapper = styled.div`
   display: flex;
@@ -84,12 +85,8 @@ export function CalendarHeader({
   /** Called when the Today button is clicked. Only provided by DatePicker, not DateRangePicker. */
   onSelectToday?: (date: CalendarDate) => void
 }) {
-  const now = new Date()
-  const todayDate = new CalendarDate(
-    now.getFullYear(),
-    now.getMonth() + 1,
-    now.getDate(),
-  )
+  const timezone = useTimezone()
+  const todayDate = today(timezone)
 
   const years = getPageYears(state.focusedDate.year, yearPickerPage)
   const backButtonDisabled =
@@ -104,8 +101,8 @@ export function CalendarHeader({
 
   const isTodayDisabled =
     showYearPicker ||
-    state.isInvalid(todayDate) ||
-    state.isCellUnavailable(todayDate)
+    (!!onSelectToday &&
+      (state.isInvalid(todayDate) || state.isCellUnavailable(todayDate)))
 
   return (
     <HeaderWrapper>


### PR DESCRIPTION
## Summary

Fixes #4933 — the **Today** button in `DatePicker` did not reliably select today's date.

### Root cause

react-stately's `selectDate` constrains the target date against `startDate` (the currently visible month). When the user navigated to a future month, `today < startDate` caused a silent early return — the date was never selected and `onChange` was never called. `setFocusedDate` (the previous implementation) only navigated the view; it never selected.

### Fix

Thread a dedicated `onSelectToday` callback from `DatePicker` down through `Calendar` → `CalendarHeader` → `TodayPicker`. This bypasses react-stately's visible-range constraint entirely. The callback:

- Guards against `isDisabled` / `isReadOnly` (the popover is reachable via keyboard on a `readOnly` field)
- Validates today against `minValue`, `maxValue`, and `isDateUnavailable` before calling `onChange` — today's button stays enabled and always navigates, but `onChange` is suppressed when today is not selectable
- Preserves the existing time component when `showTimeInput` is active
- Computes today using `today(timezone)` from `@internationalized/date` so the correct calendar date is used when the picker's timezone differs from the local runtime timezone
- Calls `onChange` with today's date
- Calls `setFocusedDate` to navigate the view back to today's month

The Today button disabled state is unchanged from `main`: `disabled={showYearPicker}` only. Navigation to today's month always works, even when today itself is not selectable.

`DateRangePicker` is not passed `onSelectToday`, so Today there remains navigate-only — identical to `main`.

### Design decision: picker stays open after clicking Today

The Today button lives in the **navigation header** alongside the prev/next month arrows, not in the date grid. Its original behaviour was to navigate to today's month (not select), and users have built muscle memory around this: click Today to jump to the current month, then click the cell to confirm. Closing the picker on Today would break that workflow. Keeping it open is therefore intentional — Today selects the date and navigates the view, but stays in the navigation mental model rather than acting like a date cell click.

## Test plan

- [ ] Open DatePicker set to a future date, click Today → today's date is selected, input updates, picker stays open showing today's month
- [ ] Navigate forward past today, click Today → same as above (the core bug scenario)
- [ ] Click Today multiple times → `onChange` fires each time, picker stays open
- [ ] Set `minValue` to tomorrow → Today navigates to today's month, `onChange` not called
- [ ] Set `isDateUnavailable` to block today → Today navigates to today's month, `onChange` not called
- [ ] Set `showTimeInput` with an existing time → clicking Today preserves the time
- [ ] Open a `readOnly` DatePicker via keyboard (Tab + Enter), click Today → `onChange` not called
- [ ] Open DateRangePicker with a past `maxValue` → Today button is enabled, navigates only
- [ ] All 41 unit tests pass