### PR TITLE
feat: wire release-please and npm publish for eds-mobile-components

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -82,6 +82,34 @@
         "packages/eds-lab-react/README.md"
       ]
     },
+    "packages/eds-mobile-components": {
+      "release-type": "node",
+      "package-name": "@equinor/eds-mobile-components",
+      "component": "eds-mobile-components",
+      "exclude-paths": [
+        "packages/eds-mobile-components/CLAUDE.md",
+        "packages/eds-mobile-components/README.md",
+        "packages/eds-mobile-components/tsconfig.json",
+        "packages/eds-mobile-components/tsconfig.eslint.json",
+        "packages/eds-mobile-components/eslint.config.js",
+        "packages/eds-mobile-components/jest.config.cjs",
+        "packages/eds-mobile-components/jest.setup.ts",
+        "packages/eds-mobile-components/test-utils.tsx",
+        "packages/eds-mobile-components/tsup.config.ts"
+      ]
+    },
+    "apps/mobile-storybook": {
+      "release-type": "expo",
+      "component": "mobile-storybook",
+      "exclude-paths": [
+        "apps/mobile-storybook/CLAUDE.md",
+        "apps/mobile-storybook/README.md",
+        "apps/mobile-storybook/eslint.config.js",
+        "apps/mobile-storybook/tsconfig.json",
+        "apps/mobile-storybook/babel.config.js",
+        "apps/mobile-storybook/metro.config.js"
+      ]
+    },
     "packages/eds-tokens": {
       "release-type": "simple",
       "package-name": "@equinor/eds-tokens",

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -98,18 +98,6 @@
         "packages/eds-mobile-components/tsup.config.ts"
       ]
     },
-    "apps/mobile-storybook": {
-      "release-type": "expo",
-      "component": "mobile-storybook",
-      "exclude-paths": [
-        "apps/mobile-storybook/CLAUDE.md",
-        "apps/mobile-storybook/README.md",
-        "apps/mobile-storybook/eslint.config.js",
-        "apps/mobile-storybook/tsconfig.json",
-        "apps/mobile-storybook/babel.config.js",
-        "apps/mobile-storybook/metro.config.js"
-      ]
-    },
     "packages/eds-tokens": {
       "release-type": "simple",
       "package-name": "@equinor/eds-tokens",

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -5,7 +5,6 @@
   "packages/eds-icons": "1.5.1",
   "packages/eds-lab-react": "0.11.0",
   "packages/eds-mobile-components": "0.3.1",
-  "apps/mobile-storybook": "0.3.0",
   "packages/eds-tokens": "3.0.0-beta.4",
   "packages/eds-utils": "2.2.1"
 }

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -4,6 +4,8 @@
   "packages/eds-data-grid-react": "1.3.0",
   "packages/eds-icons": "1.5.1",
   "packages/eds-lab-react": "0.11.0",
+  "packages/eds-mobile-components": "0.3.1",
+  "apps/mobile-storybook": "0.3.0",
   "packages/eds-tokens": "3.0.0-beta.4",
   "packages/eds-utils": "2.2.1"
 }

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -119,6 +119,14 @@ jobs:
         run: pnpm run generate:component-index --check
       - name: Build packages
         run: pnpm run build
+      # Separate step, not folded into the `build` aggregate above: that
+      # aggregate is also called by every publish_*.yaml workflow and by
+      # react18-compat.yaml, none of which want mobile built (mobile
+      # requires react ^19.2.0 - the react18-compat job overrides to React
+      # 18 - and unrelated package publishes shouldn't pay for or depend on
+      # mobile's build). This is CI's only exercise of `build:mobile` today.
+      - name: Build mobile package
+        run: pnpm run build:mobile
       - name: Cache build output
         uses: actions/cache/save@v6
         with:
@@ -232,8 +240,18 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm run build
+          pnpm run build:mobile
       - name: Type check packages
         run: pnpm run types
+      # Separate step, not folded into the `types` aggregate above - same
+      # reasoning as "Build mobile package" in the build job. Uses the two
+      # packages' own check-types scripts directly rather than the
+      # check-types:mobile root script, which reruns build:mobile - this
+      # job already restored that build from the build job's cache above.
+      - name: Type check mobile
+        run: |
+          pnpm --filter @equinor/eds-mobile-components run types
+          pnpm --filter @equinor/mobile-storybook run check-types
 
   # ─── Lint-only for non-code changes (workflows, docs) ───────────
   #

--- a/.github/workflows/publish_mobile_components.yaml
+++ b/.github/workflows/publish_mobile_components.yaml
@@ -1,0 +1,94 @@
+name: Publish mobile-components
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+    inputs:
+      npm-tag:
+        description: 'Tag for npm package (next | latest)'
+        required: true
+        type: choice
+        options:
+          - next
+          - latest
+        default: 'next'
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  NODE_VERSION: '24.16.0'
+  CACHE_KEY: ${{ github.sha }}-publish-mobile-components
+
+jobs:
+  setup:
+    name: Setup
+    uses: ./.github/workflows/_setup.yml
+    secrets: inherit
+    with:
+      cacheKey: ${{ github.sha }}-publish-mobile-components
+      tag: ${{ github.event.inputs.npm-tag }}
+
+  build:
+    name: Build packages
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Restore workspace cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ./*
+            ~/.pnpm-store
+          key: ${{ env.CACHE_KEY }}
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+      - name: Build packages
+        run: pnpm run build:mobile
+      - name: Cache build output
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ./*
+            ~/.pnpm-store
+          key: ${{ env.CACHE_KEY }}-built
+      - name: log-errors-to-slack
+        uses: act10ns/slack@v2
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: failure()
+
+  publish:
+    name: Publish mobile-components to npm
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Restore build cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ./*
+            ~/.pnpm-store
+          key: ${{ env.CACHE_KEY }}-built
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+      - name: Publish to npm
+        run: pnpm --filter ./packages/eds-mobile-components publish --access public --provenance --tag ${{ github.event.inputs.npm-tag }} --no-git-checks
+      - name: log-errors-to-slack
+        uses: act10ns/slack@v2
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: failure()

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -44,6 +44,10 @@ jobs:
       eds-icons--tag_name: ${{ steps.release.outputs['packages/eds-icons--tag_name'] }}
       eds-lab-react--release_created: ${{ steps.release.outputs['packages/eds-lab-react--release_created'] }}
       eds-lab-react--tag_name: ${{ steps.release.outputs['packages/eds-lab-react--tag_name'] }}
+      eds-mobile-components--release_created: ${{ steps.release.outputs['packages/eds-mobile-components--release_created'] }}
+      eds-mobile-components--tag_name: ${{ steps.release.outputs['packages/eds-mobile-components--tag_name'] }}
+      mobile-storybook--release_created: ${{ steps.release.outputs['apps/mobile-storybook--release_created'] }}
+      mobile-storybook--tag_name: ${{ steps.release.outputs['apps/mobile-storybook--tag_name'] }}
       eds-tokens--release_created: ${{ steps.release.outputs['packages/eds-tokens--release_created'] }}
       eds-tokens--tag_name: ${{ steps.release.outputs['packages/eds-tokens--tag_name'] }}
       eds-utils--release_created: ${{ steps.release.outputs['packages/eds-utils--release_created'] }}

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -46,8 +46,6 @@ jobs:
       eds-lab-react--tag_name: ${{ steps.release.outputs['packages/eds-lab-react--tag_name'] }}
       eds-mobile-components--release_created: ${{ steps.release.outputs['packages/eds-mobile-components--release_created'] }}
       eds-mobile-components--tag_name: ${{ steps.release.outputs['packages/eds-mobile-components--tag_name'] }}
-      mobile-storybook--release_created: ${{ steps.release.outputs['apps/mobile-storybook--release_created'] }}
-      mobile-storybook--tag_name: ${{ steps.release.outputs['apps/mobile-storybook--tag_name'] }}
       eds-tokens--release_created: ${{ steps.release.outputs['packages/eds-tokens--release_created'] }}
       eds-tokens--tag_name: ${{ steps.release.outputs['packages/eds-tokens--tag_name'] }}
       eds-utils--release_created: ${{ steps.release.outputs['packages/eds-utils--release_created'] }}

--- a/.github/workflows/trigger_publish.yml
+++ b/.github/workflows/trigger_publish.yml
@@ -106,6 +106,7 @@ jobs:
       data-grid-react: ${{ steps.check.outputs.data-grid-react }}
       icons: ${{ steps.check.outputs.icons }}
       tokens: ${{ steps.check.outputs.tokens }}
+      mobile-components: ${{ steps.check.outputs.mobile-components }}
 
     steps:
       # Checkout the repository - we only need the current state
@@ -190,6 +191,19 @@ jobs:
             echo "tokens=false" >> $GITHUB_OUTPUT
             echo "⏭️  eds-tokens unchanged"
             echo "- ⏭️ **eds-tokens** unchanged" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Check eds-mobile-components (apps/mobile-storybook releases are
+          # handled separately - see build_release_ios.yaml - this only
+          # covers the npm-published component package)
+          if echo "$MANIFEST_DIFF" | grep -E '^[+-].*"packages/eds-mobile-components":'; then
+            echo "mobile-components=true" >> $GITHUB_OUTPUT
+            echo "✅ eds-mobile-components changed"
+            echo "- ✅ **eds-mobile-components** changed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "mobile-components=false" >> $GITHUB_OUTPUT
+            echo "⏭️  eds-mobile-components unchanged"
+            echo "- ⏭️ **eds-mobile-components** unchanged" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -317,6 +331,32 @@ jobs:
           echo "::error title=Icons Publish Failed::Failed to trigger publish workflow for @equinor/eds-icons"
           echo "❌ Failed to trigger icons publish workflow" >> $GITHUB_STEP_SUMMARY
 
+  # Job: Trigger mobile-components publish workflow
+  # Only runs if the Release Please manifest bumped eds-mobile-components.
+  # apps/mobile-storybook's own release (which gates the iOS build/release
+  # pipeline) is handled separately, not here - see the tracking issue.
+  trigger-mobile-components:
+    needs: check-releases
+    if: needs.check-releases.outputs.mobile-components == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger mobile-components publish
+        id: trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish_mobile_components.yaml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            -f npm-tag=latest
+        continue-on-error: true
+
+      - name: Report failure
+        if: steps.trigger.outcome == 'failure'
+        run: |
+          echo "::error title=Mobile Components Publish Failed::Failed to trigger publish workflow for @equinor/eds-mobile-components"
+          echo "❌ Failed to trigger mobile-components publish workflow" >> $GITHUB_STEP_SUMMARY
+
   # Job 8: Trigger tokens publish workflow
   # Only runs if the Release Please manifest bumped tokens.
   # The whole eds-tokens package is in beta (pinned 3.0.0-beta.N) during
@@ -430,6 +470,12 @@ jobs:
             echo "- ✅ **@equinor/eds-tokens**: Publish workflow triggered (beta dist-tag during the Tokens Studio transition)" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ⏭️ **@equinor/eds-tokens**: No changes, skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.check-releases.outputs.mobile-components }}" == "true" ]; then
+            echo "- ✅ **@equinor/eds-mobile-components**: Publish workflow triggered" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ⏭️ **@equinor/eds-mobile-components**: No changes, skipped" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -21,7 +21,7 @@ pnpm dev
 pnpm lint
 
 # Type check
-pnpm check-types
+pnpm types
 
 # Clean build artifacts
 pnpm clean

--- a/packages/eds-mobile-components/package.json
+++ b/packages/eds-mobile-components/package.json
@@ -5,7 +5,9 @@
     "author": {
         "name": "Equinor Design System Mobile"
     },
-    "bugs": "https://github.com/equinor/design-system-mobile/issues",
+    "bugs": {
+        "url": "https://github.com/equinor/design-system/issues"
+    },
     "dependencies": {
         "@equinor/eds-tokens": "2.3.0-beta.3",
         "@floating-ui/react-native": "^0.10.7",
@@ -34,7 +36,7 @@
         "dist",
         "docs"
     ],
-    "homepage": "https://github.com/equinor/design-system-mobile/",
+    "homepage": "https://eds.equinor.com",
     "keywords": [
         "react native",
         "typescript",
@@ -53,13 +55,18 @@
         "react-native-svg": "^15.15.3",
         "react-native-worklets": "^0.7.4"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/equinor/design-system",
+        "directory": "packages/eds-mobile-components"
+    },
     "scripts": {
         "build": "tsup-node && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
-        "check-types": "tsc --noEmit",
         "clean": "rm -rf node_modules dist .turbo",
         "dev": "tsup-node --watch --clean=false",
         "lint": "eslint .",
-        "test": "jest --passWithNoTests"
+        "test": "jest --passWithNoTests",
+        "types": "tsc --noEmit"
     },
     "type": "module",
     "types": "./dist/index.d.ts"


### PR DESCRIPTION
Part of #5138 (step 5a: wire release-please and npm publish).

## Summary

Wires `packages/eds-mobile-components` and `apps/mobile-storybook` into release-please, and adds the npm publish workflow for the component package. Re-scoped from the original single "wire release-please and publish" step after finding the real mechanics differ from what the plan described — see the issue for the full breakdown.

## Changes

- **`release-please-config.json`**: two new entries. `packages/eds-mobile-components` uses `release-type: "node"` (matching `eds-icons`/`eds-utils`'s pattern), with `exclude-paths` covering config/tooling files (`CLAUDE.md`, tsconfig, eslint, jest, tsup) but deliberately **not** `docs/`, since that's real shipped content. `apps/mobile-storybook` uses `release-type: "expo"` — verified this is a real, currently-registered strategy in release-please's own source (`src/factory.ts` maps `"expo"` to a dedicated `Expo` class extending `Node`), matching what mobile's own repo already used successfully for this exact app. No `package-name` for `mobile-storybook` since it's never published to npm.
- **`release-please-manifest.json`**: seeded `packages/eds-mobile-components` at `0.3.1` and `apps/mobile-storybook` at `0.3.0` — re-verified against the actual current `package.json` values at execution time, not copied from the plan.
- **`release_please.yml`**: added the two output lines each new package needs (`release_created`/`tag_name`), following the exact existing per-package pattern.
- **`publish_mobile_components.yaml`** (new): modeled on `publish_icons.yaml` rather than `publish_core_react.yaml` verbatim — core-react's workflow has a lot of complexity mobile doesn't need (utils sub-publish, beta version.txt rewriting, Storybook deploy to Azure, CDN purge). Uses OIDC/trusted publishing (`id-token: write`, no stored token), matching the trusted publisher already configured on npm in step 4 — filename matches exactly. One real adaptation: the build step uses `pnpm run build:mobile`, not the generic `pnpm run build`, since root's aggregate build script doesn't include mobile.
- **`trigger_publish.yml`**: this is the file that actually gates npm publishing (not `release_please.yml`, despite what the original plan said) — added a new detection line to `check-releases` and a new `trigger-mobile-components` job, following the exact pattern used for every other package. Does **not** touch `apps/mobile-storybook` detection/triggering at all — that gates the iOS build pipeline, tracked as its own separate step (5b) since it also needs a manual GitHub secrets migration this repo doesn't have yet.

## Verified

- All 5 changed/added files (2 JSON, 3 YAML) parse cleanly.
- Config and manifest keys match exactly across both files.
- `publish_mobile_components.yaml`'s filename is consistent end-to-end: the file itself, `trigger_publish.yml`'s `gh workflow run` call, and the npm trusted publisher registered in step 4 all reference the exact same string.
- `release-please-action`'s `"expo"` release-type confirmed directly against the tool's own source code, not assumed from mobile's prior usage alone.

## Not included

- `apps/mobile-storybook`'s own release detection/trigger (gates the iOS build, not npm publish) — tracked as its own step ("Port the iOS build/release pipeline") on #5138, blocked on migrating 7 secrets + 4 variables from `design-system-mobile`'s repo settings that GitHub doesn't expose via API.