### PR TITLE
docs: 📝 mark ADR 0007 as accepted

### DIFF
--- a/documentation/adr/0007-token-variable-architecture-spacing-typography.md
+++ b/documentation/adr/0007-token-variable-architecture-spacing-typography.md
@@ -1,7 +1,7 @@
 # Token variable architecture (typography & spacing) for the redefined token system
 
-- **Status:** Proposed
-- **Date:** 2026-06-26 (revised 2026-07-01 — mode-free semantic consumption layer; revised 2026-07-13 — aligned to ADR template, unified `header`/`color` naming)
+- **Status:** Accepted
+- **Date:** 2026-06-26 (revised 2026-07-01 — mode-free semantic consumption layer; revised 2026-07-13 — aligned to ADR template, unified `header`/`color` naming; revised 2026-08-19 — status set to Accepted)
 - **Decision makers:** EDS core team (design + engineering)
 
 ## Context


### PR DESCRIPTION
## What

Flips `0007-token-variable-architecture-spacing-typography.md` from **Status: Proposed** to **Status: Accepted**, and records the change in the Date line's revision history.

## Why

The decision has been in effect for a while — the three-layer structure and the `compact` / `comfortable` / `relaxed` density modes it defines are built in Tokens Studio, synced to the *EDS Redefined Foundation* Figma file, and shipped in `@equinor/eds-tokens@3.0.0-beta.6`. The status header just never got flipped when the ADR merged in #5161, so anyone reading it still sees a proposal.

It was also the only ADR in `documentation/adr/` still marked `Proposed` — every other one reads `Accepted`.

## How

Two lines changed. No content edits — the decision text is unchanged.

Note on the date: I appended `revised 2026-08-19 — status set to Accepted` rather than back-dating, since the actual sign-off date isn't recorded anywhere. If you'd rather it read the merge date of #5161 (2026-07-14) or another date, say so and I'll amend.

Related: #4743 (density mode rename), #5107, #4740