### PR TITLE
feat: port iOS build/release pipeline for mobile storybook

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,6 +2,18 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "tag-separator": "@",
   "packages": {
+    "apps/mobile-storybook": {
+      "release-type": "expo",
+      "component": "mobile-storybook",
+      "exclude-paths": [
+        "apps/mobile-storybook/CLAUDE.md",
+        "apps/mobile-storybook/README.md",
+        "apps/mobile-storybook/eslint.config.js",
+        "apps/mobile-storybook/tsconfig.json",
+        "apps/mobile-storybook/babel.config.js",
+        "apps/mobile-storybook/metro.config.js"
+      ]
+    },
     "packages/eds-core-react": {
       "release-type": "node",
       "package-name": "@equinor/eds-core-react",

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -8,6 +8,7 @@
       "exclude-paths": [
         "apps/mobile-storybook/CLAUDE.md",
         "apps/mobile-storybook/README.md",
+        "apps/mobile-storybook/.gitignore",
         "apps/mobile-storybook/eslint.config.js",
         "apps/mobile-storybook/tsconfig.json",
         "apps/mobile-storybook/babel.config.js",

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "apps/mobile-storybook": "0.3.0",
   "packages/eds-core-react": "2.6.1",
   "packages/eds-core-react/src/components/next": "3.0.0-beta.1",
   "packages/eds-data-grid-react": "1.3.0",

--- a/.github/workflows/build_release_ios.yaml
+++ b/.github/workflows/build_release_ios.yaml
@@ -1,0 +1,141 @@
+name: Build and Release Storybook iOS App
+#
+# Ported from design-system-mobile's build-release-ios.yml. Triggered via
+# `gh workflow run` from trigger_publish.yml (same pattern as the npm
+# publish workflows), not via a direct workflow_call from release_please.yml
+# like the source repo did - see #5138 for the reasoning.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and upload IPA
+    runs-on: macos-26
+    permissions:
+      contents: read
+    env:
+      CERTIFICATE_FILE: build_certificate.p12
+      PROVISIONING_PROFILE_FILE: build_pp.mobileprovision
+      KEYCHAIN_FILE: app-signing.keychain-db
+
+    steps:
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
+        with:
+          xcode-version: '26.2'
+
+      - name: Set build number
+        id: set-build-number
+        run: |
+          build_number="$(date +'%Y%m%d').${{ github.run_number }}"
+          echo "BUILD_NUMBER=$build_number" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Apple certificate and provisioning profile
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.P12SECRET }}
+          P12_PASSWORD: ${{ secrets.P12PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH="$RUNNER_TEMP/$CERTIFICATE_FILE"
+          PROVISIONING_PROFILE_PATH="$RUNNER_TEMP/$PROVISIONING_PROFILE_FILE"
+          KEYCHAIN_PATH="$RUNNER_TEMP/$KEYCHAIN_FILE"
+
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PROVISIONING_PROFILE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH login.keychain
+
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PROVISIONING_PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/build_pp.mobileprovision"
+
+      - name: Generate ExportOptions.plist
+        working-directory: apps/mobile-storybook
+        run: |
+          FILE=ExportOptions.plist
+          /usr/libexec/PlistBuddy -c "add :method string app-store" $FILE
+          /usr/libexec/PlistBuddy -c "add :provisioningProfiles dict" $FILE
+          /usr/libexec/PlistBuddy -c "add :provisioningProfiles:${{ vars.APPLE_BUNDLE_IDENTIFIER }} string ${{ vars.APPLE_PROVISIONING_PROFILE_NAME }}" $FILE
+          /usr/libexec/PlistBuddy -c "add :signingStyle string manual" $FILE
+          /usr/libexec/PlistBuddy -c "add :teamId string ${{ vars.APPLE_TEAM_ID }}" $FILE
+          cat $FILE
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.16.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Patch app.json
+        run: |
+          jq --arg buildNumber "${{ env.BUILD_NUMBER }}" \
+            '.expo.ios.buildNumber = $buildNumber' \
+            apps/mobile-storybook/app.json > /tmp/app.json.tmp
+          mv /tmp/app.json.tmp apps/mobile-storybook/app.json
+
+      # NOT `pnpm build:storybook` - that root script already means
+      # something else in this repo (builds eds-core-react's own Storybook)
+      - name: Prebuild Expo project
+        run: pnpm --filter @equinor/mobile-storybook run build
+
+      - name: Xcode archive
+        working-directory: apps/mobile-storybook
+        run: |
+          /usr/bin/xcodebuild archive \
+            -workspace ios/EDSMobile.xcworkspace \
+            -scheme EDSMobile \
+            -destination 'generic/platform=iOS' \
+            -archivePath build/EDSMobile.xcarchive \
+            CODE_SIGN_STYLE="Manual" \
+            CODE_SIGN_IDENTITY="${{ vars.APPLE_CODE_SIGN_IDENTITY }}" \
+            PROVISIONING_PROFILE_SPECIFIER="${{ vars.APPLE_PROVISIONING_PROFILE_NAME }}"
+
+      - name: Export IPA
+        working-directory: apps/mobile-storybook
+        run: |
+          /usr/bin/xcodebuild -exportArchive \
+            -archivePath build/EDSMobile.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath build
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: EDSMobile-${{ env.BUILD_NUMBER }}
+          path: apps/mobile-storybook/build/*.ipa
+
+      - name: Upload to TestFlight
+        uses: apple-actions/upload-testflight-build@v5
+        with:
+          app-path: ${{ github.workspace }}/apps/mobile-storybook/build/EDSMobile.ipa
+          issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
+          api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+
+      - name: Clean up signing artifacts
+        if: ${{ always() }}
+        run: |
+          PROVISIONING_PROFILE_PATH="$RUNNER_TEMP/$PROVISIONING_PROFILE_FILE"
+          KEYCHAIN_PATH="$RUNNER_TEMP/$KEYCHAIN_FILE"
+
+          security delete-keychain "$KEYCHAIN_PATH" || true
+          rm -f "$PROVISIONING_PROFILE_PATH"
+          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/build_pp.mobileprovision"

--- a/.github/workflows/build_release_ios.yaml
+++ b/.github/workflows/build_release_ios.yaml
@@ -11,12 +11,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  NODE_VERSION: '24.16.0'
+
 jobs:
   build:
     name: Build and upload IPA
     runs-on: macos-26
-    permissions:
-      contents: read
+    timeout-minutes: 45
     env:
       CERTIFICATE_FILE: build_certificate.p12
       PROVISIONING_PROFILE_FILE: build_pp.mobileprovision
@@ -29,7 +36,6 @@ jobs:
           xcode-version: '26.2'
 
       - name: Set build number
-        id: set-build-number
         run: |
           build_number="$(date +'%Y%m%d').${{ github.run_number }}"
           echo "BUILD_NUMBER=$build_number" >> $GITHUB_ENV
@@ -63,13 +69,19 @@ jobs:
 
       - name: Generate ExportOptions.plist
         working-directory: apps/mobile-storybook
+        env:
+          APPLE_BUNDLE_IDENTIFIER: ${{ vars.APPLE_BUNDLE_IDENTIFIER }}
+          APPLE_PROVISIONING_PROFILE_NAME: ${{ vars.APPLE_PROVISIONING_PROFILE_NAME }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: |
           FILE=ExportOptions.plist
-          /usr/libexec/PlistBuddy -c "add :method string app-store" $FILE
+          # app-store-connect: Apple deprecated the "app-store" value in
+          # Xcode 15.4. Still accepted with a warning as of Xcode 16.
+          /usr/libexec/PlistBuddy -c "add :method string app-store-connect" $FILE
           /usr/libexec/PlistBuddy -c "add :provisioningProfiles dict" $FILE
-          /usr/libexec/PlistBuddy -c "add :provisioningProfiles:${{ vars.APPLE_BUNDLE_IDENTIFIER }} string ${{ vars.APPLE_PROVISIONING_PROFILE_NAME }}" $FILE
+          /usr/libexec/PlistBuddy -c "add :provisioningProfiles:$APPLE_BUNDLE_IDENTIFIER string $APPLE_PROVISIONING_PROFILE_NAME" $FILE
           /usr/libexec/PlistBuddy -c "add :signingStyle string manual" $FILE
-          /usr/libexec/PlistBuddy -c "add :teamId string ${{ vars.APPLE_TEAM_ID }}" $FILE
+          /usr/libexec/PlistBuddy -c "add :teamId string $APPLE_TEAM_ID" $FILE
           cat $FILE
 
       - name: Setup pnpm
@@ -78,7 +90,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: '24.16.0'
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
@@ -98,6 +110,9 @@ jobs:
 
       - name: Xcode archive
         working-directory: apps/mobile-storybook
+        env:
+          APPLE_CODE_SIGN_IDENTITY: ${{ vars.APPLE_CODE_SIGN_IDENTITY }}
+          APPLE_PROVISIONING_PROFILE_NAME: ${{ vars.APPLE_PROVISIONING_PROFILE_NAME }}
         run: |
           /usr/bin/xcodebuild archive \
             -workspace ios/EDSMobile.xcworkspace \
@@ -105,8 +120,8 @@ jobs:
             -destination 'generic/platform=iOS' \
             -archivePath build/EDSMobile.xcarchive \
             CODE_SIGN_STYLE="Manual" \
-            CODE_SIGN_IDENTITY="${{ vars.APPLE_CODE_SIGN_IDENTITY }}" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ vars.APPLE_PROVISIONING_PROFILE_NAME }}"
+            CODE_SIGN_IDENTITY="$APPLE_CODE_SIGN_IDENTITY" \
+            PROVISIONING_PROFILE_SPECIFIER="$APPLE_PROVISIONING_PROFILE_NAME"
 
       - name: Export IPA
         working-directory: apps/mobile-storybook
@@ -116,16 +131,26 @@ jobs:
             -exportOptionsPlist ExportOptions.plist \
             -exportPath build
 
+      # Resolved once and reused below rather than hardcoding EDSMobile.ipa
+      # in one step and globbing *.ipa in the other - if the exported
+      # product name ever changes, this step fails with a clear "no IPA
+      # found" instead of the artifact upload silently passing and only
+      # the TestFlight step failing later.
+      - name: Locate IPA
+        id: ipa
+        working-directory: apps/mobile-storybook
+        run: echo "path=$(ls build/*.ipa)" >> "$GITHUB_OUTPUT"
+
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v7
         with:
           name: EDSMobile-${{ env.BUILD_NUMBER }}
-          path: apps/mobile-storybook/build/*.ipa
+          path: apps/mobile-storybook/${{ steps.ipa.outputs.path }}
 
       - name: Upload to TestFlight
         uses: apple-actions/upload-testflight-build@v5
         with:
-          app-path: ${{ github.workspace }}/apps/mobile-storybook/build/EDSMobile.ipa
+          app-path: ${{ github.workspace }}/apps/mobile-storybook/${{ steps.ipa.outputs.path }}
           issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
           api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
           api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
@@ -133,9 +158,18 @@ jobs:
       - name: Clean up signing artifacts
         if: ${{ always() }}
         run: |
+          CERTIFICATE_PATH="$RUNNER_TEMP/$CERTIFICATE_FILE"
           PROVISIONING_PROFILE_PATH="$RUNNER_TEMP/$PROVISIONING_PROFILE_FILE"
           KEYCHAIN_PATH="$RUNNER_TEMP/$KEYCHAIN_FILE"
 
           security delete-keychain "$KEYCHAIN_PATH" || true
+          rm -f "$CERTIFICATE_PATH"
           rm -f "$PROVISIONING_PROFILE_PATH"
           rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/build_pp.mobileprovision"
+
+      - name: log-errors-to-slack
+        uses: act10ns/slack@v2
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: failure()

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -48,6 +48,8 @@ jobs:
       eds-tokens--tag_name: ${{ steps.release.outputs['packages/eds-tokens--tag_name'] }}
       eds-utils--release_created: ${{ steps.release.outputs['packages/eds-utils--release_created'] }}
       eds-utils--tag_name: ${{ steps.release.outputs['packages/eds-utils--tag_name'] }}
+      mobile-storybook--release_created: ${{ steps.release.outputs['apps/mobile-storybook--release_created'] }}
+      mobile-storybook--tag_name: ${{ steps.release.outputs['apps/mobile-storybook--tag_name'] }}
 
     steps:
       # Main step: Run the release-please action

--- a/.github/workflows/trigger_publish.yml
+++ b/.github/workflows/trigger_publish.yml
@@ -106,6 +106,7 @@ jobs:
       data-grid-react: ${{ steps.check.outputs.data-grid-react }}
       icons: ${{ steps.check.outputs.icons }}
       tokens: ${{ steps.check.outputs.tokens }}
+      mobile-storybook: ${{ steps.check.outputs.mobile-storybook }}
 
     steps:
       # Checkout the repository - we only need the current state
@@ -190,6 +191,18 @@ jobs:
             echo "tokens=false" >> $GITHUB_OUTPUT
             echo "⏭️  eds-tokens unchanged"
             echo "- ⏭️ **eds-tokens** unchanged" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Check apps/mobile-storybook (gates the iOS TestFlight build,
+          # not an npm publish - see build_release_ios.yaml)
+          if echo "$MANIFEST_DIFF" | grep -E '^[+-].*"apps/mobile-storybook":'; then
+            echo "mobile-storybook=true" >> $GITHUB_OUTPUT
+            echo "✅ apps/mobile-storybook changed"
+            echo "- ✅ **apps/mobile-storybook** changed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "mobile-storybook=false" >> $GITHUB_OUTPUT
+            echo "⏭️  apps/mobile-storybook unchanged"
+            echo "- ⏭️ **apps/mobile-storybook** unchanged" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -317,6 +330,31 @@ jobs:
           echo "::error title=Icons Publish Failed::Failed to trigger publish workflow for @equinor/eds-icons"
           echo "❌ Failed to trigger icons publish workflow" >> $GITHUB_STEP_SUMMARY
 
+  # Job: Trigger the iOS TestFlight build/release workflow
+  # Only runs if the Release Please manifest bumped apps/mobile-storybook.
+  # This isn't an npm publish - it builds the Expo app and uploads it to
+  # TestFlight - see build_release_ios.yaml.
+  trigger-mobile-ios:
+    needs: check-releases
+    if: needs.check-releases.outputs.mobile-storybook == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger iOS build/release
+        id: trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build_release_ios.yaml \
+            --repo ${{ github.repository }} \
+            --ref main
+        continue-on-error: true
+
+      - name: Report failure
+        if: steps.trigger.outcome == 'failure'
+        run: |
+          echo "::error title=Mobile iOS Build Failed::Failed to trigger iOS build/release workflow for apps/mobile-storybook"
+          echo "❌ Failed to trigger iOS build/release workflow" >> $GITHUB_STEP_SUMMARY
+
   # Job 8: Trigger tokens publish workflow
   # Only runs if the Release Please manifest bumped tokens.
   # The whole eds-tokens package is in beta (pinned 3.0.0-beta.N) during
@@ -430,6 +468,12 @@ jobs:
             echo "- ✅ **@equinor/eds-tokens**: Publish workflow triggered (beta dist-tag during the Tokens Studio transition)" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ⏭️ **@equinor/eds-tokens**: No changes, skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.check-releases.outputs.mobile-storybook }}" == "true" ]; then
+            echo "- ✅ **apps/mobile-storybook**: iOS build/release workflow triggered" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ⏭️ **apps/mobile-storybook**: No changes, skipped" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Part of #5138 (step: port the iOS build/release pipeline).

## Summary

Ports `design-system-mobile`'s `build-release-ios.yml` (the iOS TestFlight build workflow for the Storybook app) into this repo as `build_release_ios.yaml`, updated to this repo's current conventions rather than a verbatim copy. Also wires `apps/mobile-storybook` into release-please, moved here from PR #5341 so release tracking for storybook ships together with the pipeline that actually consumes it.

## Changes

- **`build_release_ios.yaml`** (new): ported from mobile's `build-release-ios.yml`. Action versions bumped to match what the rest of this repo currently uses — `actions/checkout@v4`→`v7`, `pnpm/action-setup@v4`→`v6`, `actions/setup-node@v4`→`v7` (node `22.x`→`24.16.0`), `actions/upload-artifact@v4`→`v7`. `apple-actions/upload-testflight-build@v5` left as-is — nothing else in this repo uses it, so there's no existing convention to align to. Trigger changed from mobile's `workflow_call` to `workflow_dispatch`, matching how `trigger_publish.yml` invokes every other publish workflow in this repo. Working-directory paths updated from `apps/storybook` to `apps/mobile-storybook`; the prebuild step uses `pnpm --filter @equinor/mobile-storybook run build` instead of mobile's `pnpm build:storybook`, since that script name is already taken in this repo (builds eds-core-react's own Storybook).
- **Dropped `onlyutkarsh/patch-files-action`**: replaced the third-party action (used only to patch `expo.ios.buildNumber` into `app.json`) with a plain `jq` command in a `run:` step. `jq` is preinstalled on GitHub-hosted runners; this removes a dependency on a small, single-maintainer action for what's really a one-line JSON patch. `maxim-lobanov/setup-xcode`'s SHA pin was checked and confirmed to be the actual `v1.7.0` release tag, not a stale/arbitrary commit — left unchanged.
- **`trigger_publish.yml`**: added the `mobile-storybook` output, detection block (checks the manifest diff for `"apps/mobile-storybook":`), and a new `trigger-mobile-ios` job that calls `gh workflow run build_release_ios.yaml` — mirrors the existing per-package trigger pattern. This gates the iOS build on a `mobile-storybook` release, not an npm publish.
- **`release-please-config.json` / `.release-please-manifest.json` / `release_please.yml`**: re-added `apps/mobile-storybook`'s entries (originally added in PR #5341, moved here after review — see #5138 for the reasoning: bundling release tracking with the pipeline that consumes it avoids version bumps and GitHub releases with nothing downstream reading them in the meantime). Ordered alphabetically this time (`apps/` before `packages/` in the config/manifest; `mobile-storybook` after `eds-utils` by component name in the outputs, since those are keyed by component name, not path).

## Verified

- `expo prebuild --platform ios` (run locally) generates `ios/EDSMobile.xcworkspace` and the `EDSMobile` scheme exactly as the workflow references — confirmed Expo strips the space from `app.json`'s `"EDS Mobile"` name, and CocoaPods installs automatically as part of the same step (no separate `pod install` step needed, matching mobile's original, previously-successful CI runs).
- Actual current action versions used elsewhere in this repo, checked via grep across `.github/workflows/*.yaml` rather than assumed.
- `maxim-lobanov/setup-xcode`'s SHA pin checked against the action's own tag list — matches `v1.7.0`, the latest release.
- All 3 modified/added workflow/JSON files parse and format correctly.

## Not included / blocked

- End-to-end verification of the actual iOS build/TestFlight upload — blocked on migrating the remaining GitHub secrets from `design-system-mobile`'s repo settings (`PROVISIONING_PROFILE_BASE64`, `APPSTORE_API_PRIVATE_KEY` still outstanding; 5 of 7 secrets and all 4 variables are already in place). GitHub doesn't expose secret values via API, so this is a manual step tracked separately on #5138.