### PR TITLE
chore: fix remaining stale design-system-mobile references

### DIFF
--- a/apps/mobile-storybook/README.md
+++ b/apps/mobile-storybook/README.md
@@ -6,7 +6,7 @@ This is an [Expo](https://expo.dev) project using [file-based routing](https://d
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) (v18 or higher)
+- [Node.js](https://nodejs.org/) (v22 or higher)
 - [pnpm](https://pnpm.io/) (v10 or higher)
 - For iOS: [Xcode](https://developer.apple.com/xcode/) and CocoaPods
 - For Android: [Android Studio](https://developer.android.com/studio) with an emulator configured
@@ -22,13 +22,13 @@ This is an [Expo](https://expo.dev) project using [file-based routing](https://d
 2. Build the components package:
 
     ```bash
-    pnpm build
+    pnpm build:mobile
     ```
 
 3. Run the storybook app:
 
     ```bash
-    pnpm dev:storybook
+    pnpm dev:mobile
     ```
 
 4. Press `i` to open in iOS Simulator or `a` for Android Emulator.
@@ -38,7 +38,7 @@ This is an [Expo](https://expo.dev) project using [file-based routing](https://d
 For iOS development, install CocoaPods dependencies:
 
 ```bash
-cd apps/storybook/ios && pod install
+cd apps/mobile-storybook/ios && pod install
 ```
 
 ### Running on a Physical Device
@@ -47,7 +47,7 @@ Use Expo's development build to run on a physical device:
 
 ```bash
 # iOS
-pnpm dev:storybook -- --device
+pnpm dev:mobile -- --device
 
 # Or scan the QR code with the Expo Go app (limited functionality)
 ```
@@ -55,7 +55,7 @@ pnpm dev:storybook -- --device
 ## Project Structure
 
 ```
-apps/storybook/
+apps/mobile-storybook/
 ├── app/                    # Expo Router pages
 │   ├── _layout.tsx         # Root layout with EDSProvider
 │   └── (tabs)/
@@ -76,7 +76,7 @@ apps/storybook/
 1. Create a new file in `app/(tabs)/components/` (e.g., `mycomponent.tsx`)
 2. Register the screen in `app/(tabs)/components/_layout.tsx`
 3. Add it to the component list in `app/(tabs)/components/index.tsx`
-4. Export the component from `packages/components/src/index.ts` if not already exported
+4. Export the component from `packages/eds-mobile-components/src/index.ts` if not already exported
 
 ## Troubleshooting
 
@@ -89,7 +89,7 @@ This error appears in the iOS Simulator because it doesn't support haptic feedba
 If you encounter iOS build errors after updating dependencies:
 
 ```bash
-cd apps/storybook/ios
+cd apps/mobile-storybook/ios
 rm -rf Pods Podfile.lock
 pod install
 ```
@@ -99,11 +99,11 @@ pod install
 Clear the cache and restart:
 
 ```bash
-pnpm dev:storybook -- --clear
+pnpm dev:mobile -- --clear
 ```
 
 ## Learn more
 
 - [Expo documentation](https://docs.expo.dev/)
-- [EDS Mobile Components](../../packages/components/README.md)
+- [EDS Mobile Components](../../packages/eds-mobile-components/README.md)
 - [Equinor Design System](https://eds.equinor.com/)

--- a/apps/mobile-storybook/app/(tabs)/about.tsx
+++ b/apps/mobile-storybook/app/(tabs)/about.tsx
@@ -21,7 +21,7 @@ const LINKS = [
     },
     {
         label: "GitHub repository",
-        url: "https://github.com/equinor/design-system-mobile",
+        url: "https://github.com/equinor/design-system",
     },
 ];
 

--- a/apps/mobile-storybook/app/(tabs)/components/link.tsx
+++ b/apps/mobile-storybook/app/(tabs)/components/link.tsx
@@ -4,7 +4,7 @@ import { Link, Typography } from "@equinor/eds-mobile-components";
 import { Linking, ScrollView } from "react-native";
 import { useState } from "react";
 
-const GITHUB_URL = "https://github.com/equinor/design-system-mobile";
+const GITHUB_URL = "https://github.com/equinor/design-system";
 const DOCS_URL = "https://eds.equinor.com/docs/Next/components/navigation/link";
 
 export default function LinkScreen() {

--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -175,7 +175,7 @@ export default function App() {
 
 While working on a component (migration, docs, bug fix, or review), you may notice gaps that aren't in scope for the current PR — things the Figma design doesn't account for, patterns missing from the EDS web Storybook, accessibility gaps, or API inconsistencies across components. Do not silently drop these.
 
-Append them as a checklist item to the tracking issue: **[#152 — Tracking: Findings from component migration](https://github.com/equinor/design-system-mobile/issues/152)**. Each item should include:
+Append them as a checklist item to the tracking issue: **[#152 — Tracking: Findings from component migration](https://github.com/equinor/design-system-mobile/issues/152)** (this issue will be transferred to this repo once `design-system-mobile` is archived — see equinor/design-system#5138). Each item should include:
 
 - **What** — one-line description of the gap
 - **Rationale** — why it matters (a11y, parity with web, dev ergonomics, etc.)
@@ -191,7 +191,7 @@ If the finding needs real work, open a dedicated issue and link it next to the c
     - Styles using `EDSStyleSheet.create`
     - Test file: `YourComponent.test.tsx` — write it alongside the component, not as a follow-up. See `Divider.test.tsx` for the minimal shape: render via `test-utils` (wraps `@testing-library/react-native` with `EDSProvider`) and assert it renders plus any accessibility basics.
 2. Export from `src/index.ts`
-3. Add storybook story in `../../apps/storybook/app/(tabs)/YourComponent.tsx`
+3. Add storybook story in `../../apps/mobile-storybook/app/(tabs)/YourComponent.tsx`
 4. Create developer documentation in `docs/YourComponent.mdx` — run `/document-component` for the full workflow and structure
 5. Follow existing patterns for prop naming and component structure
 

--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -191,7 +191,9 @@ If the finding needs real work, open a dedicated issue and link it next to the c
     - Styles using `EDSStyleSheet.create`
     - Test file: `YourComponent.test.tsx` — write it alongside the component, not as a follow-up. See `Divider.test.tsx` for the minimal shape: render via `test-utils` (wraps `@testing-library/react-native` with `EDSProvider`) and assert it renders plus any accessibility basics.
 2. Export from `src/index.ts`
-3. Add storybook story in `../../apps/mobile-storybook/app/(tabs)/YourComponent.tsx`
+3. Add a storybook screen in `../../apps/mobile-storybook/app/(tabs)/components/yourcomponent.tsx`
+   (lowercase filename — Expo Router derives the route from it), then register it in that
+   directory's `_layout.tsx` and `index.tsx`
 4. Create developer documentation in `docs/YourComponent.mdx` — run `/document-component` for the full workflow and structure
 5. Follow existing patterns for prop naming and component structure
 


### PR DESCRIPTION
Part of #5138 (cleanup follow-up from the earlier review on the "Mobile docs via workspace link" step).

## Summary

`@claude`'s review on an earlier PR caught 4 stale references to the old `design-system-mobile` repo that were logged but not fixed at the time. One of them (`eds-mobile-components/package.json`'s `bugs`/`homepage` fields) is already fixed as part of the release-please PR (#5341). This PR fixes the remaining 3.

## Changes

- **`apps/mobile-storybook/app/(tabs)/about.tsx`**: the app's real "About" screen hardcoded a "GitHub repository" link to `design-system-mobile` — user-visible in the running app itself. Updated to point at this repo.
- **`apps/mobile-storybook/app/(tabs)/components/link.tsx`**: the `Link` component's demo screen used the same old URL as example content for its "external link" showcase. Updated for consistency, even though it's just demo content.
- **`packages/eds-mobile-components/CLAUDE.md`**: fixed a path typo (`../../apps/storybook/app/(tabs)/` → `../../apps/mobile-storybook/app/(tabs)/`) in the "Adding New Components" instructions, and added a note to the `design-system-mobile#152` tracking-issue link explaining it'll be transferred to this repo during the "close out" step rather than leaving a link that silently breaks once that repo is archived.

## Note

Found while making these fixes: Claude Code's format-on-edit hook (and Copilot CLI's equivalent) runs ESLint from the repo root regardless of which file is being edited, so any `.tsx`/`.ts` edit under `packages/eds-mobile-components/` or `apps/mobile-storybook/` gets silently reformatted to the *root* ESLint config instead of the package's own — exactly the failure mode already documented in this package's own `CLAUDE.md` for manually running `lint:all`, just happening automatically on every AI-assisted edit instead. Reverted the incorrect reformatting here and applied the actual content fixes via a plain `sed` command instead. This is a repo-wide harness tooling bug, unrelated to the mobile migration itself — tracked and fixed separately.