### PR TITLE
docs: add Dependabot alerts reminder to guide and Slack rotation message

### DIFF
--- a/.github/workflows/dependabot-rotation.yml
+++ b/.github/workflows/dependabot-rotation.yml
@@ -27,6 +27,6 @@ jobs:
             -H 'Content-type: application/json' \
             -d @- <<EOF
           {
-            "text": ":robot_face: *<@$MENTION>, you're on Dependabot duty this week!* (week $WEEK)\n\n:broom: Time to sweep through those dependency PRs — most take under 5 min!\n:warning: Any critical or high severity alerts on the alerts page? Handle those too.\n\n:point_right: <https://github.com/equinor/design-system/pulls/app%2Fdependabot|Open Dependabot PRs> · <https://github.com/orgs/equinor/security/alerts/dependabot?q=is%3Aopen+team%3Aeds-core+sort%3Aseverity+repo%3Adesign-system|Dependabot alerts> · <https://github.com/equinor/design-system/blob/main/documentation/how-to/DEPENDABOT_GUIDE.md|Dependabot guide>"
+            "text": ":robot_face: *<@$MENTION>, you're on Dependabot duty this week!* (week $WEEK)\n\n:broom: Time to sweep through those dependency PRs — most take under 5 min!\n:warning: Any critical or high severity alerts on the alerts page? Tackle those too.\n\n:point_right: <https://github.com/equinor/design-system/pulls/app%2Fdependabot|Open Dependabot PRs> · <https://github.com/orgs/equinor/security/alerts/dependabot?q=is%3Aopen+team%3Aeds-core+sort%3Aseverity+repo%3Adesign-system|Dependabot alerts> · <https://github.com/equinor/design-system/blob/main/documentation/how-to/DEPENDABOT_GUIDE.md|Dependabot guide>"
           }
           EOF

--- a/.github/workflows/dependabot-rotation.yml
+++ b/.github/workflows/dependabot-rotation.yml
@@ -27,6 +27,6 @@ jobs:
             -H 'Content-type: application/json' \
             -d @- <<EOF
           {
-            "text": ":robot_face: *<@$MENTION>, you're on Dependabot duty this week!* (week $WEEK)\n\n:broom: Time to sweep through those dependency PRs — most take under 5 min!\n:warning: Also check the alerts page for any critical or high severity vulnerabilities.\n\n:point_right: <https://github.com/equinor/design-system/pulls/app%2Fdependabot|Open Dependabot PRs> · <https://github.com/orgs/equinor/security/alerts/dependabot?q=is%3Aopen+team%3Aeds-core+sort%3Aseverity+repo%3Adesign-system|Dependabot alerts> · <https://github.com/equinor/design-system/blob/main/documentation/how-to/DEPENDABOT_GUIDE.md|Dependabot guide>"
+            "text": ":robot_face: *<@$MENTION>, you're on Dependabot duty this week!* (week $WEEK)\n\n:broom: Time to sweep through those dependency PRs — most take under 5 min!\n:warning: Any critical or high severity alerts on the alerts page? Handle those too.\n\n:point_right: <https://github.com/equinor/design-system/pulls/app%2Fdependabot|Open Dependabot PRs> · <https://github.com/orgs/equinor/security/alerts/dependabot?q=is%3Aopen+team%3Aeds-core+sort%3Aseverity+repo%3Adesign-system|Dependabot alerts> · <https://github.com/equinor/design-system/blob/main/documentation/how-to/DEPENDABOT_GUIDE.md|Dependabot guide>"
           }
           EOF

--- a/.github/workflows/dependabot-rotation.yml
+++ b/.github/workflows/dependabot-rotation.yml
@@ -27,6 +27,6 @@ jobs:
             -H 'Content-type: application/json' \
             -d @- <<EOF
           {
-            "text": ":robot_face: *<@$MENTION>, you're on Dependabot duty this week!* (week $WEEK)\n\n:broom: Time to sweep through those dependency PRs — most take under 5 min!\n\n:point_right: <https://github.com/equinor/design-system/pulls/app%2Fdependabot|Open Dependabot PRs> · <https://github.com/equinor/design-system/blob/main/documentation/how-to/DEPENDABOT_GUIDE.md|Dependabot guide>"
+            "text": ":robot_face: *<@$MENTION>, you're on Dependabot duty this week!* (week $WEEK)\n\n:broom: Time to sweep through those dependency PRs — most take under 5 min!\n:warning: Also check the alerts page for any critical or high severity vulnerabilities.\n\n:point_right: <https://github.com/equinor/design-system/pulls/app%2Fdependabot|Open Dependabot PRs> · <https://github.com/orgs/equinor/security/alerts/dependabot?q=is%3Aopen+team%3Aeds-core+sort%3Aseverity+repo%3Adesign-system|Dependabot alerts> · <https://github.com/equinor/design-system/blob/main/documentation/how-to/DEPENDABOT_GUIDE.md|Dependabot guide>"
           }
           EOF

--- a/documentation/how-to/DEPENDABOT_GUIDE.md
+++ b/documentation/how-to/DEPENDABOT_GUIDE.md
@@ -99,6 +99,13 @@ These come from `dependabot alerts` and may arrive outside the Monday schedule. 
 
 You can recognize them by the group name `npm_and_yarn` in the PR title or by the "security" label.
 
+## Dependabot alerts (no PR)
+
+Not all vulnerabilities auto-create a PR. Also check the [Dependabot alerts page](https://github.com/orgs/equinor/security/alerts/dependabot?q=is%3Aopen+team%3Aeds-core+sort%3Aseverity+repo%3Adesign-system) — sorted by severity — for alerts without a corresponding PR.
+
+- **High/critical with no PR?** Investigate and handle manually (see "When CI fails" for options).
+- **Low/moderate with no PR?** Log it and move on — these are often transitive dependencies Dependabot can't auto-fix.
+
 ## FAQ
 
 **Q: Can I just approve without reviewing?**

--- a/documentation/how-to/DEPENDABOT_GUIDE.md
+++ b/documentation/how-to/DEPENDABOT_GUIDE.md
@@ -103,7 +103,7 @@ You can recognize them by the group name `npm_and_yarn` in the PR title or by th
 
 Not all vulnerabilities auto-create a PR. Also check the [Dependabot alerts page](https://github.com/orgs/equinor/security/alerts/dependabot?q=is%3Aopen+team%3Aeds-core+sort%3Aseverity+repo%3Adesign-system) — sorted by severity — for alerts without a corresponding PR.
 
-- **High/critical with no PR?** Investigate and handle manually (see "When CI fails" for options).
+- **High/critical with no PR?** Fix it manually, open a PR, and get a review before merging to main.
 - **Low/moderate with no PR?** Log it and move on — these are often transitive dependencies Dependabot can't auto-fix.
 
 ## FAQ


### PR DESCRIPTION
## Summary

Dependabot security alerts that haven't auto-created a PR are easy to miss during Dependabot duty. This PR makes them harder to forget by adding a direct link and a severity-focused reminder in both the Slack rotation message and the Dependabot guide.

## Changes

- **Dependabot guide** — new \"Dependabot alerts (no PR)\" section after \"Security updates\" with a direct link to the org-level alerts page and guidance on how to prioritise by severity
- **Slack rotation workflow** — adds a \"Dependabot alerts\" link alongside the existing PR and guide links, plus a short reminder to handle any critical or high severity alerts

## Test plan

- [ ] Read through the updated guide section and verify it fits naturally after \"Security updates\"
- [ ] Check the Slack message output below looks right
- [ ] Optionally trigger the workflow manually via Actions → \"Dependabot rotation reminder\" → Run workflow to verify the Slack message