### PR TITLE
fix: override nanoid to >=3.3.18 to resolve high severity CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
       "uuid": "^11.1.1",
       "react-stately": "3.49.0",
       "@types/react": ">=19.2.17",
-      "@internationalized/date": "3.12.3"
+      "@internationalized/date": "3.12.3",
+      "nanoid@^3": ">=3.3.18"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ overrides:
   react-stately: 3.49.0
   '@types/react': '>=19.2.17'
   '@internationalized/date': 3.12.3
+  nanoid@^3: '>=3.3.18'
 
 importers:
 
@@ -10491,16 +10492,6 @@ packages:
 
   multitars@1.0.2:
     resolution: {integrity: sha512-6GwVw5eLi9sThdtlS4PKwC7yRLaf45pYhIEzKBHdKxi+YOXGKFX8acIniH+Uh/+k9mS2lQOupTccjoe5r0/1IQ==}
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -26457,10 +26448,6 @@ snapshots:
 
   multitars@1.0.2: {}
 
-  nanoid@3.3.16: {}
-
-  nanoid@3.3.17: {}
-
   nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
@@ -27621,13 +27608,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #548 — nanoid < 3.3.18 has a high severity vulnerability where custom generators can loop indefinitely when size is zero.

nanoid is a transitive dependency pulled in by `postcss` (via `stylelint`) so Dependabot cannot auto-create a PR. Fixed by adding a `pnpm.overrides` entry to force all instances to `>=3.3.18`.

## Changes

- Added `"nanoid": ">=3.3.18"` to `pnpm.overrides` in root `package.json`
- Updated `pnpm-lock.yaml`

## Test plan

- [ ] CI passes
- [ ] Verify nanoid resolves to 3.3.18: `pnpm why nanoid`