### PR TITLE
feat: also trigger iOS build on eds-mobile-components releases

### DIFF
--- a/.github/workflows/trigger_publish.yml
+++ b/.github/workflows/trigger_publish.yml
@@ -344,10 +344,11 @@ jobs:
           echo "::error title=Icons Publish Failed::Failed to trigger publish workflow for @equinor/eds-icons"
           echo "❌ Failed to trigger icons publish workflow" >> $GITHUB_STEP_SUMMARY
 
-  # Job: Trigger mobile-components publish workflow
+  # Job 8: Trigger mobile-components publish workflow
   # Only runs if the Release Please manifest bumped eds-mobile-components.
-  # apps/mobile-storybook's own release (which gates the iOS build/release
-  # pipeline) is handled separately, not here - see the tracking issue.
+  # The npm publish itself is handled here; the iOS build/release pipeline
+  # this release also gates is a separate job (trigger-mobile-ios) below,
+  # since a components release triggers both.
   trigger-mobile-components:
     needs: check-releases
     if: needs.check-releases.outputs.mobile-components == 'true'
@@ -370,13 +371,19 @@ jobs:
           echo "::error title=Mobile Components Publish Failed::Failed to trigger publish workflow for @equinor/eds-mobile-components"
           echo "❌ Failed to trigger mobile-components publish workflow" >> $GITHUB_STEP_SUMMARY
 
-  # Job: Trigger the iOS TestFlight build/release workflow
-  # Only runs if the Release Please manifest bumped apps/mobile-storybook.
-  # This isn't an npm publish - it builds the Expo app and uploads it to
-  # TestFlight - see build_release_ios.yaml.
+  # Job 9: Trigger the iOS TestFlight build/release workflow
+  # Runs if the Release Please manifest bumped apps/mobile-storybook OR
+  # packages/eds-mobile-components. This isn't an npm publish - it builds
+  # the Expo app and uploads it to TestFlight - see build_release_ios.yaml.
+  # Triggering on a components-only release too (no app version bump,
+  # no npm involvement on the app's side) means a component change gets
+  # validated on a real device without anyone having to remember to kick
+  # off a TestFlight build manually - see #5138 for the reasoning. This
+  # never ships to the public App Store by itself - that's always a
+  # separate, manual submission-for-review step in App Store Connect.
   trigger-mobile-ios:
     needs: check-releases
-    if: needs.check-releases.outputs.mobile-storybook == 'true'
+    if: needs.check-releases.outputs.mobile-storybook == 'true' || needs.check-releases.outputs.mobile-components == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger iOS build/release
@@ -395,7 +402,7 @@ jobs:
           echo "::error title=Mobile iOS Build Failed::Failed to trigger iOS build/release workflow for apps/mobile-storybook"
           echo "❌ Failed to trigger iOS build/release workflow" >> $GITHUB_STEP_SUMMARY
 
-  # Job 8: Trigger tokens publish workflow
+  # Job 10: Trigger tokens publish workflow
   # Only runs if the Release Please manifest bumped tokens.
   # The whole eds-tokens package is in beta (pinned 3.0.0-beta.N) during
   # the Tokens Studio rewrite — every release publishes to the `beta`
@@ -423,7 +430,7 @@ jobs:
           echo "::error title=Tokens Publish Failed::Failed to trigger publish workflow for @equinor/eds-tokens"
           echo "❌ Failed to trigger tokens publish workflow" >> $GITHUB_STEP_SUMMARY
 
-  # Job 9: Summary report of all publish triggers
+  # Job 11: Summary report of all publish triggers
   # Runs independently after check-releases completes
   # Provides a clear overview of which packages were triggered for publishing
   publish-summary:
@@ -516,7 +523,11 @@ jobs:
             echo "- ⏭️ **@equinor/eds-mobile-components**: No changes, skipped" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ needs.check-releases.outputs.mobile-storybook }}" == "true" ]; then
+          # iOS build fires on either package's release (see trigger-mobile-ios's
+          # own if: condition) - check both, not just mobile-storybook's own
+          # output, or this summary would wrongly say "skipped" on a
+          # components-only release that still triggered a real iOS build.
+          if [ "${{ needs.check-releases.outputs.mobile-storybook }}" == "true" ] || [ "${{ needs.check-releases.outputs.mobile-components }}" == "true" ]; then
             echo "- ✅ **apps/mobile-storybook**: iOS build/release workflow triggered" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ⏭️ **apps/mobile-storybook**: No changes, skipped" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/trigger_publish.yml
+++ b/.github/workflows/trigger_publish.yml
@@ -194,9 +194,9 @@ jobs:
             echo "- ⏭️ **eds-tokens** unchanged" >> $GITHUB_STEP_SUMMARY
           fi
 
-          # Check eds-mobile-components (apps/mobile-storybook releases are
-          # handled separately - see build_release_ios.yaml - this only
-          # covers the npm-published component package)
+          # Check eds-mobile-components - gates both the npm publish below
+          # and (see trigger-mobile-ios) the iOS TestFlight build, since a
+          # components-only release still warrants a fresh build.
           if echo "$MANIFEST_DIFF" | grep -E '^[+-].*"packages/eds-mobile-components":'; then
             echo "mobile-components=true" >> $GITHUB_OUTPUT
             echo "✅ eds-mobile-components changed"
@@ -399,7 +399,7 @@ jobs:
       - name: Report failure
         if: steps.trigger.outcome == 'failure'
         run: |
-          echo "::error title=Mobile iOS Build Failed::Failed to trigger iOS build/release workflow for apps/mobile-storybook"
+          echo "::error title=Mobile iOS Build Failed::Failed to trigger the iOS TestFlight build workflow"
           echo "❌ Failed to trigger iOS build/release workflow" >> $GITHUB_STEP_SUMMARY
 
   # Job 10: Trigger tokens publish workflow
@@ -527,10 +527,15 @@ jobs:
           # own if: condition) - check both, not just mobile-storybook's own
           # output, or this summary would wrongly say "skipped" on a
           # components-only release that still triggered a real iOS build.
-          if [ "${{ needs.check-releases.outputs.mobile-storybook }}" == "true" ] || [ "${{ needs.check-releases.outputs.mobile-components }}" == "true" ]; then
-            echo "- ✅ **apps/mobile-storybook**: iOS build/release workflow triggered" >> $GITHUB_STEP_SUMMARY
+          # Report which package(s) actually caused it, not just yes/no.
+          if [ "${{ needs.check-releases.outputs.mobile-storybook }}" == "true" ] && [ "${{ needs.check-releases.outputs.mobile-components }}" == "true" ]; then
+            echo "- ✅ **iOS TestFlight build**: triggered (both apps/mobile-storybook and eds-mobile-components released)" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.check-releases.outputs.mobile-storybook }}" == "true" ]; then
+            echo "- ✅ **iOS TestFlight build**: triggered by apps/mobile-storybook's release" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.check-releases.outputs.mobile-components }}" == "true" ]; then
+            echo "- ✅ **iOS TestFlight build**: triggered by eds-mobile-components's release" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- ⏭️ **apps/mobile-storybook**: No changes, skipped" >> $GITHUB_STEP_SUMMARY
+            echo "- ⏭️ **iOS TestFlight build**: No changes, skipped" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Part of #5138 (resolves finding #8 from the earlier iOS pipeline review).

## Summary

Previously, the iOS TestFlight build only fired when `apps/mobile-storybook` itself got a release-please release. A component-only change (bug fix, refactor - no new demo screen) would publish to npm without triggering a fresh TestFlight build, meaning nobody would see it running on a real device until some unrelated app-side change eventually pulled it along.

## Decision

Considered and rejected release-please's `linked-versions` plugin (checked its actual source: it forces every package in a group to share one version number, propagating the highest bump to all members - even ones with zero real changes, via a synthetic commit). That's bidirectional: it would also force an app-only change to trigger a meaningless `eds-mobile-components` npm republish under a new version number - real semver pollution for a published package, with no corresponding benefit.

Instead: widened `trigger-mobile-ios`'s condition to fire on *either* package's release-please release, with no other change.

- No version bump or npm publish happens on `apps/mobile-storybook`'s side - it isn't published to npm at all.
- No versioning/semver concept is touched. This is purely a CI trigger change.
- `build_release_ios.yaml`'s build number is already independent of any committed app version (it's `date + CI run number`, computed fresh per run), so there's nothing for this to conflict with.
- Uploading a build to TestFlight is always separate from submitting a build for public App Store review, which stays a deliberate, manual step in App Store Connect - this can't accidentally ship anything to the public.

## Changes

- `trigger_publish.yml`: `trigger-mobile-ios`'s `if:` condition now checks `mobile-storybook == 'true' || mobile-components == 'true'`
- Updated the job's own comment and the neighbouring `trigger-mobile-components` job's comment to reflect that a components release now triggers two things (npm publish + iOS build), not one
- Updated `publish-summary`'s reporting logic to match - it now checks both outputs before saying "iOS build triggered", so a components-only release doesn't get wrongly reported as "skipped" for the app

## Verified

- YAML parses correctly, all 12 jobs present with no gaps/duplicates
- Embedded bash in the summary job syntax-checks clean
- Traced through `check-releases`' actual output names to confirm `mobile-components` exists and is spelled correctly

## Not testable yet

`trigger_publish.yml` has no manual trigger at all - it only fires on `pull_request: types: [closed]` for a real merged release-please PR against `main`. This can't be exercised live until the whole migration is merged to `main` and a subsequent real `eds-mobile-components` release happens. Static/logical verification is all that's possible before then.