### PR TITLE
fix: Datepicker toggle icon alignment and stacking

### DIFF
--- a/packages/eds-core-react/src/components/Datepicker/fields/Toggle.tsx
+++ b/packages/eds-core-react/src/components/Datepicker/fields/Toggle.tsx
@@ -11,6 +11,12 @@ const StyledButton = styled(Button)`
   width: 24px;
 `
 
+const StyledToggle = styled.div`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+`
+
 /**
  * Toggle component encapsulates the reset and open calendar buttons
  */
@@ -36,7 +42,9 @@ export const Toggle = ({
   showClearButton: boolean
 }) => {
   return (
-    <div style={{ visibility: readonly || disabled ? 'hidden' : 'visible' }}>
+    <StyledToggle
+      style={{ visibility: readonly || disabled ? 'hidden' : 'visible' }}
+    >
       {showClearButton && (
         <StyledButton
           disabled={disabled}
@@ -69,6 +77,6 @@ export const Toggle = ({
       >
         <Icon data={icon} />
       </StyledButton>
-    </div>
+    </StyledToggle>
   )
 }


### PR DESCRIPTION
Closes #4064

## Summary

The Datepicker toggle buttons (clear × and calendar icon) had two layout issues: they could render misaligned vertically within the input field, and at narrow input widths they could stack on top of each other rather than sitting side by side.

## Changes

- `Toggle.tsx` — replaced the plain `div` wrapper with a `StyledToggle` styled component that adds `display: flex`, `align-items: center`, and `flex-shrink: 0`

## Design decisions

`display: flex` is the fix for both symptoms:

- **Alignment:** the old `div` was a block container with inline-block children, so its height was a line box — taller than 24px due to half-leading inherited from the parent's `line-height`. The parent `StyledInputFieldWrapper` already has `align-items: center`, but it was centring the tall div, not the buttons inside it. `display: flex` collapses the line box so the div is exactly as tall as its content, and the parent's existing centring does the rest.
- **Stacking:** as a block container with inline-block children, the toggle's min-content width was 24px (one button), so the parent flex container could squeeze it below the combined 48px and cause the buttons to wrap. With `display: flex`, flex children can't wrap, so min-content becomes 48px and stacking can no longer happen.

`flex-shrink: 0` is an additional defensive guard — it pins the toggle at 48px rather than just its min-content floor, and prevents a future `min-width` override from reintroducing the squeeze.

The rendered HTML element is still a `div`, so this is not a breaking change for consumers.

## Test plan

- [ ] Open the Datepicker **DateTime** story — the × and calendar icons should be vertically centred within the input field
- [ ] Resize the input to a narrow width — icons should stay side by side and not stack
- [ ] Check disabled and read-only states — the toggle should still be hidden correctly via `visibility`