### PR TITLE
fix: lint mobile packages with their own eslint config

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -209,8 +209,8 @@ jobs:
       # Separate step, not folded into `lint:all` above - same reasoning as
       # "Type check mobile" in the types job below. lint:all's root
       # eslint.config.mjs ignores these two packages (they ship their own
-      # eslint.config.js with a different style) so they need their own
-      # lint script run explicitly.
+      # eslint.config.js and are written in a different style) so they need
+      # their own lint script run explicitly.
       - name: Lint mobile
         run: |
           pnpm --filter @equinor/eds-mobile-components run lint

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -206,6 +206,15 @@ jobs:
           pnpm run build
       - name: Lint packages
         run: pnpm run lint:all
+      # Separate step, not folded into `lint:all` above - same reasoning as
+      # "Type check mobile" in the types job below. lint:all's root
+      # eslint.config.mjs ignores these two packages (they ship their own
+      # eslint.config.js with a different style) so they need their own
+      # lint script run explicitly.
+      - name: Lint mobile
+        run: |
+          pnpm --filter @equinor/eds-mobile-components run lint
+          pnpm --filter @equinor/mobile-storybook run lint
 
   # ─── Type check (parallel, depends on build) ────────────────────
   types:

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,9 @@ packages/eds-tokens/build/*
 packages/eds-tokens/src/tokens/*
 packages/eds-icons/src/data.ts
 packages/eds-core-react/src/components/Select/NativeSelect.tsx
+# These packages are written in their own (pre-migration) style —
+# double quotes, semicolons — and are linted by their own eslint.config.js,
+# not root's. Without this, editor.formatOnSave still rewrites them to
+# root's Prettier style (see eslint.config.mjs's matching ignores entry).
+packages/eds-mobile-components/**
+apps/mobile-storybook/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ The expected behaviour after any edit to a `.ts`, `.tsx`, or `/components/next/*
 | Copilot in IDE | `.vscode/settings.json` `editor.formatOnSave: true` (Prettier) — does NOT run eslint/stylelint auto-fix  |
 | OpenCode       | No enforced hook — run `pnpm run lint <file>` manually after edits, or configure an equivalent post-hook |
 
-If you edit code in a harness without enforced auto-fix, run `pnpm run lint <file>` before considering the change done. **Exception:** `packages/eds-mobile-components` and `apps/mobile-storybook` are excluded from root's ESLint config (see below) — root's `lint` command silently exits 0 on their files without checking anything. Use `pnpm --filter @equinor/eds-mobile-components run lint` or `pnpm --filter @equinor/mobile-storybook run lint` instead.
+If you edit code in a harness without enforced auto-fix, run `pnpm run lint <file>` before considering the change done.
+
+**Exception:** `packages/eds-mobile-components` and `apps/mobile-storybook` are excluded from root's ESLint config — root's `lint` command exits 0 on their files (with an easy-to-miss "File ignored" warning) without actually checking anything. Use the per-package commands below instead.
 
 ## Build/Lint/Test Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ The expected behaviour after any edit to a `.ts`, `.tsx`, or `/components/next/*
 | Copilot in IDE | `.vscode/settings.json` `editor.formatOnSave: true` (Prettier) — does NOT run eslint/stylelint auto-fix  |
 | OpenCode       | No enforced hook — run `pnpm run lint <file>` manually after edits, or configure an equivalent post-hook |
 
-If you edit code in a harness without enforced auto-fix, run `pnpm run lint <file>` before considering the change done.
+If you edit code in a harness without enforced auto-fix, run `pnpm run lint <file>` before considering the change done. **Exception:** `packages/eds-mobile-components` and `apps/mobile-storybook` are excluded from root's ESLint config (see below) — root's `lint` command silently exits 0 on their files without checking anything. Use `pnpm --filter @equinor/eds-mobile-components run lint` or `pnpm --filter @equinor/mobile-storybook run lint` instead.
 
 ## Build/Lint/Test Commands
 
@@ -67,8 +67,11 @@ Package manager: `pnpm@10.28.0`
 ```bash
 pnpm run build                    # Build all packages
 pnpm run build:core-react         # Build eds-core-react only
-pnpm run lint:all                 # Lint entire codebase
+pnpm run lint:all                 # Lint entire codebase, except packages/eds-mobile-components and apps/mobile-storybook (they ship their own eslint.config.js — see below)
 pnpm run lint ./path/to/file.tsx  # Lint specific file
+
+pnpm --filter @equinor/eds-mobile-components run lint  # Lint eds-mobile-components with its own config
+pnpm --filter @equinor/mobile-storybook run lint       # Lint mobile-storybook with its own config
 
 pnpm run test:core-react          # Run eds-core-react tests
 pnpm run test:watch:core-react    # Watch mode

--- a/README.md
+++ b/README.md
@@ -201,8 +201,11 @@ pnpm build
 # Run all tests
 pnpm test
 
-# Lint entire codebase
+# Lint entire codebase, except packages/eds-mobile-components and
+# apps/mobile-storybook (they ship their own eslint.config.js)
 pnpm lint:all
+pnpm --filter @equinor/eds-mobile-components run lint
+pnpm --filter @equinor/mobile-storybook run lint
 
 # Start Storybook for component development
 pnpm storybook

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,14 @@ export default tseslint.config(
       '**/playwright-report/**',
       '**/test-results/**',
       '**/.turbo/**',
+      // These packages ship their own eslint.config.js with a different
+      // style (double quotes, semicolons). Flat config doesn't cascade
+      // per-directory — running `eslint .` from the root would otherwise
+      // apply this file's Prettier rules to their code instead of theirs.
+      // Linted separately via each package's own `lint` script (see the
+      // "Lint mobile" step in .github/workflows/checks.yaml).
+      'packages/eds-mobile-components/**',
+      'apps/mobile-storybook/**',
     ],
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,8 +29,8 @@ export default tseslint.config(
       '**/playwright-report/**',
       '**/test-results/**',
       '**/.turbo/**',
-      // These packages ship their own eslint.config.js with a different
-      // style (double quotes, semicolons). Flat config doesn't cascade
+      // These packages ship their own eslint.config.js and are written in a
+      // different style (double quotes, semicolons). Flat config doesn't cascade
       // per-directory — running `eslint .` from the root would otherwise
       // apply this file's Prettier rules to their code instead of theirs.
       // Linted separately via each package's own `lint` script (see the

--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -27,7 +27,7 @@ pnpm types
 pnpm clean
 ```
 
-From the monorepo root, the equivalents are `pnpm build:mobile`, `pnpm watch:mobile`, and `pnpm check-types:mobile` (hand-sequenced to build this package first). There's no root-level lint equivalent — and don't rely on `pnpm lint:all` for this package: ESLint's flat config doesn't cascade per-directory, so it lints these files with root's config instead of this package's own `eslint.config.js`, applying root's Prettier-style rules (single quotes, no semicolons) to code written in this package's own style. It runs without crashing, but produces thousands of style-only findings that aren't meaningful signal. Use `pnpm --filter @equinor/eds-mobile-components run lint` (or run it from this directory) to get this package's own config.
+From the monorepo root, the equivalents are `pnpm build:mobile`, `pnpm watch:mobile`, and `pnpm check-types:mobile` (hand-sequenced to build this package first). There's no root-level lint equivalent — root's `eslint.config.mjs` ignores this package outright (ESLint's flat config doesn't cascade per-directory, so linting it from the root would otherwise apply root's Prettier-style rules — single quotes, no semicolons — to code written in this package's own style). `pnpm lint:all` silently skips these files rather than checking them. Use `pnpm --filter @equinor/eds-mobile-components run lint` (or run it from this directory) to get this package's own config.
 
 ## Architecture
 

--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -27,7 +27,7 @@ pnpm types
 pnpm clean
 ```
 
-From the monorepo root, the equivalents are `pnpm build:mobile`, `pnpm watch:mobile`, and `pnpm check-types:mobile` (hand-sequenced to build this package first). There's no root-level lint equivalent — root's `eslint.config.mjs` ignores this package outright (ESLint's flat config doesn't cascade per-directory, so linting it from the root would otherwise apply root's Prettier-style rules — single quotes, no semicolons — to code written in this package's own style). `pnpm lint:all` silently skips these files rather than checking them. Use `pnpm --filter @equinor/eds-mobile-components run lint` (or run it from this directory) to get this package's own config.
+From the monorepo root, the equivalents are `pnpm build:mobile`, `pnpm watch:mobile`, and `pnpm check-types:mobile` (hand-sequenced to build this package first). There's no root-level lint equivalent — root's `eslint.config.mjs` ignores this package outright (ESLint's flat config doesn't cascade per-directory, so linting it from the root would otherwise apply root's Prettier-style rules — single quotes, no semicolons — to code written in this package's own style). `pnpm lint:all` exits 0 on these files (with an easy-to-miss "File ignored" warning) rather than actually checking them. Use `pnpm --filter @equinor/eds-mobile-components run lint` (or run it from this directory) to get this package's own config.
 
 ## Architecture
 


### PR DESCRIPTION
## Why

Root's `eslint.config.mjs` had no `ignores` entry for `packages/eds-mobile-components` or `apps/mobile-storybook`. ESLint's flat config doesn't cascade per-directory, so `pnpm run lint:all` (`eslint .` from the repo root) applied root's Prettier style (single quotes, no semicolons) to mobile's code instead of deferring to each package's own `eslint.config.js` (double quotes, semicolons — matching their pre-migration conventions).

This surfaced as the `Lint` check failing on #5384 with ~10,669 problems, almost entirely style noise on mobile files.

## What

- Add `packages/eds-mobile-components/**` and `apps/mobile-storybook/**` to root's `ignores`, so `lint:all` skips them cleanly.
- Add a dedicated "Lint mobile" step to the `lint` job in `checks.yaml` that runs each package's own `lint` script — mirroring the existing `build:mobile` step in Build and the "Type check mobile" step in Type check.

## Verification

- `pnpm run lint packages/eds-mobile-components apps/mobile-storybook` → confirmed ignored by root's config.
- `pnpm --filter @equinor/eds-mobile-components run lint` → clean (1 pre-existing warning, 0 errors).
- `pnpm --filter @equinor/mobile-storybook run lint` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)