### PR TITLE
docs: soften EDS 2.0 beta messaging in Storybook and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,8 @@ import '@equinor/eds-core-react/next/index.css'
 
 #### Important Notes
 
-- **Beta components are under active development** and may have breaking changes
-- **Not production-ready** until they graduate to the stable package
+- **Safe to adopt alongside EDS 1.0** - the API may still change in small ways before the stable 3.0 release; every change is listed in the beta changelog
+- **EDS 1.0 stays supported** until EDS 2.0 ships as the stable 3.0 release, and mixing EDS 1.0 and `/next` components in one application is expected
 - **Visible in Storybook** - browse components at [storybook.eds.equinor.com](https://storybook.eds.equinor.com/) under "EDS 2.0"
 - **Requires beta installation** - viewing in Storybook doesn't enable usage, you must install `@beta`
 - **Separate changelog** - see `src/components/next/CHANGELOG.md` for beta changes

--- a/README.md
+++ b/README.md
@@ -301,8 +301,8 @@ import '@equinor/eds-core-react/next/index.css'
 
 #### Important Notes
 
-- **Safe to adopt alongside EDS 1.0** - the API may still change in small ways before the stable 3.0 release; every change is listed in the beta changelog
-- **EDS 1.0 stays supported** until EDS 2.0 ships as the stable 3.0 release, and mixing EDS 1.0 and `/next` components in one application is expected
+- **Safe to adopt alongside EDS 1.0** - the API may still change in small ways before EDS 2.0 becomes stable; every change is listed in the beta changelog
+- **EDS 1.0 stays supported** until EDS 2.0 becomes stable (published as `eds-core-react@3.0.0`), and mixing EDS 1.0 and `/next` components in one application is expected
 - **Visible in Storybook** - browse components at [storybook.eds.equinor.com](https://storybook.eds.equinor.com/) under "EDS 2.0"
 - **Requires beta installation** - viewing in Storybook doesn't enable usage, you must install `@beta`
 - **Separate changelog** - see `src/components/next/CHANGELOG.md` for beta changes

--- a/documentation/agent-instructions/BUILDING_EDS_2_COMPONENTS.md
+++ b/documentation/agent-instructions/BUILDING_EDS_2_COMPONENTS.md
@@ -393,7 +393,7 @@ const meta: Meta<typeof ComponentName> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** — this component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { ComponentName } from '@equinor/eds-core-react/next'

--- a/documentation/agent-instructions/BUILDING_EDS_2_COMPONENTS.md
+++ b/documentation/agent-instructions/BUILDING_EDS_2_COMPONENTS.md
@@ -393,7 +393,7 @@ const meta: Meta<typeof ComponentName> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { ComponentName } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Accordion> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 Built on the native \`<details>\`/\`<summary>\` elements for free accessibility,
 keyboard support and CSS-only open/close animation.

--- a/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Accordion/Accordion.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Accordion> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 Built on the native \`<details>\`/\`<summary>\` elements for free accessibility,
 keyboard support and CSS-only open/close animation.

--- a/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.stories.tsx
@@ -259,7 +259,7 @@ const meta: Meta<typeof Autocomplete> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 An Autocomplete input that filters a list of options as the user types. Supports string arrays, object arrays, custom option rendering, and async search.
 

--- a/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Autocomplete/Autocomplete.stories.tsx
@@ -259,7 +259,7 @@ const meta: Meta<typeof Autocomplete> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 An Autocomplete input that filters a list of options as the user types. Supports string arrays, object arrays, custom option rendering, and async search.
 

--- a/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Badge> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** — this component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Badge } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Badge/Badge.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Badge> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Badge } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
@@ -9,7 +9,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Button.mdx'
 
 Button component for triggering actions.
 
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 
 <PlatformTabs mobile={<>

--- a/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Button/Button.docs.mdx
@@ -9,7 +9,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Button.mdx'
 
 Button component for triggering actions.
 
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 
 <PlatformTabs mobile={<>

--- a/packages/eds-core-react/src/components/next/Checkbox/Checkbox.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Checkbox/Checkbox.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Checkbox.mdx'
 
 # Checkbox
 
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/Checkbox/Checkbox.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Checkbox/Checkbox.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Checkbox.mdx'
 
 # Checkbox
 
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<StoryArgs> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Chip } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Chip/Chip.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<StoryArgs> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Chip } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Dialog> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 Built on the native \`<dialog>\` element with \`showModal()\` for free focus
 trapping, Escape-key handling and inert background. Backdrop clicks close

--- a/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Dialog/Dialog.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Dialog> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 Built on the native \`<dialog>\` element with \`showModal()\` for free focus
 trapping, Escape-key handling and inert background. Backdrop clicks close

--- a/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Divider> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Divider } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Divider/Divider.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Divider> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Divider } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Field/Field.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof Field> = {
   parameters: {
     docs: {
       description: {
-        component: `**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+        component: `**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 A layout primitive for building accessible form fields with labels, descriptions, and helper messages.
 

--- a/packages/eds-core-react/src/components/next/Field/Field.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Field/Field.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof Field> = {
   parameters: {
     docs: {
       description: {
-        component: `**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+        component: `**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 A layout primitive for building accessible form fields with labels, descriptions, and helper messages.
 

--- a/packages/eds-core-react/src/components/next/Icon/Icon.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Icon/Icon.stories.tsx
@@ -100,7 +100,7 @@ const meta: Meta<typeof Icon> = {
     docs: {
       description: {
         component: `
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/Icon/Icon.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Icon/Icon.stories.tsx
@@ -100,7 +100,7 @@ const meta: Meta<typeof Icon> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Input.mdx'
 
 # Input
 
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Input/Input.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Input.mdx'
 
 # Input
 
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/Link/Link.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Link/Link.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Link> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Link } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Link/Link.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Link/Link.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Link> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Link } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Radio/Radio.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Radio.mdx'
 
 # Radio
 
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/Radio/Radio.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Radio/Radio.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Radio.mdx'
 
 # Radio
 
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/Search/Search.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Search/Search.stories.tsx
@@ -85,7 +85,7 @@ const meta: Meta<typeof Search> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Search } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Search/Search.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Search/Search.stories.tsx
@@ -85,7 +85,7 @@ const meta: Meta<typeof Search> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`tsx
 import { Search } from '@equinor/eds-core-react/next'

--- a/packages/eds-core-react/src/components/next/Select/Select.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Select/Select.stories.tsx
@@ -186,7 +186,7 @@ const meta: Meta<typeof Select> = {
     docs: {
       description: {
         component: `
-**⚠️ Beta Component** — This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/Select/Select.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Select/Select.stories.tsx
@@ -186,7 +186,7 @@ const meta: Meta<typeof Select> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/Switch/Switch.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Switch/Switch.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Switch.mdx'
 
 # Switch
 
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/Switch/Switch.docs.mdx
+++ b/packages/eds-core-react/src/components/next/Switch/Switch.docs.mdx
@@ -7,7 +7,7 @@ import MobileDocs from '@equinor/eds-mobile-components/docs/Switch.mdx'
 
 # Switch
 
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 <PlatformTabs mobile={<>
   <Links

--- a/packages/eds-core-react/src/components/next/TextArea/TextArea.stories.tsx
+++ b/packages/eds-core-react/src/components/next/TextArea/TextArea.stories.tsx
@@ -104,7 +104,7 @@ const meta: Meta<typeof TextArea> = {
     docs: {
       description: {
         component: `
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/TextArea/TextArea.stories.tsx
+++ b/packages/eds-core-react/src/components/next/TextArea/TextArea.stories.tsx
@@ -104,7 +104,7 @@ const meta: Meta<typeof TextArea> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/TextField/TextField.stories.tsx
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.stories.tsx
@@ -183,7 +183,7 @@ const meta: Meta<typeof TextField> = {
     docs: {
       description: {
         component: `
-**⚠️ Beta Component** - This component is under active development and may have breaking changes.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/TextField/TextField.stories.tsx
+++ b/packages/eds-core-react/src/components/next/TextField/TextField.stories.tsx
@@ -183,7 +183,7 @@ const meta: Meta<typeof TextField> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 \`\`\`bash
 npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/src/components/next/Tooltip/Tooltip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Tooltip/Tooltip.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Tooltip> = {
     docs: {
       description: {
         component: `
-⚠️ **Beta Component** - This component is under active development.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 Uses the native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) (\`popover="hint"\`)
 and [CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning)

--- a/packages/eds-core-react/src/components/next/Tooltip/Tooltip.stories.tsx
+++ b/packages/eds-core-react/src/components/next/Tooltip/Tooltip.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Tooltip> = {
     docs: {
       description: {
         component: `
-**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before the stable 3.0 release. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
+**Beta:** safe to adopt alongside EDS 1.0. The API may still change in small ways before EDS 2.0 becomes stable. See [About EDS 2.0](?path=/docs/eds-2-0-beta-about--docs) for what beta means.
 
 Uses the native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) (\`popover="hint"\`)
 and [CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning)

--- a/packages/eds-core-react/src/index.next.ts
+++ b/packages/eds-core-react/src/index.next.ts
@@ -1,8 +1,9 @@
 /**
  * EDS 2.0 Beta Components
  *
- * These components are experimental and under active development.
- * Breaking changes may occur between beta releases.
+ * These components are safe to adopt alongside EDS 1.0. The API may still
+ * change in small ways between beta releases before the stable 3.0 release;
+ * see src/components/next/CHANGELOG.md for every change.
  *
  * Install: npm install @equinor/eds-core-react@beta
  *

--- a/packages/eds-core-react/src/index.next.ts
+++ b/packages/eds-core-react/src/index.next.ts
@@ -2,7 +2,7 @@
  * EDS 2.0 Beta Components
  *
  * These components are safe to adopt alongside EDS 1.0. The API may still
- * change in small ways between beta releases before the stable 3.0 release;
+ * change in small ways between beta releases before EDS 2.0 becomes stable;
  * see src/components/next/CHANGELOG.md for every change.
  *
  * Install: npm install @equinor/eds-core-react@beta

--- a/packages/eds-core-react/stories/docs/EDS2.mdx
+++ b/packages/eds-core-react/stories/docs/EDS2.mdx
@@ -20,14 +20,14 @@ EDS 2.0 is a complete redesign of our component library, bringing:
 - 🔧 **Refined APIs** - Cleaner, more intuitive component interfaces
 
 <br />
-## Current Status: Beta
+## What Beta Means
 
-All components in the **"EDS 2.0"** section are currently in **beta testing**. This means:
+All components in the **"EDS 2.0"** section are in **beta**. Beta is not a warning against using them:
 
-- ⚠️ **Breaking changes may occur** - APIs are not yet finalized
-- 🧪 **Testing phase** - We're gathering feedback and iterating
-- 📝 **Documentation evolving** - Stories and examples are being refined
-- 🎨 **Design alignment ongoing** - Ensuring perfect match with Figma
+- ✅ **Safe to adopt** - The components are tested and ready for production use. The API may still change in small ways before the stable release; every change is listed in the [beta changelog](https://github.com/equinor/design-system/blob/main/packages/eds-core-react/src/components/next/CHANGELOG.md)
+- 🤝 **EDS 1.0 is still supported** - The current components in `@equinor/eds-core-react` are maintained until EDS 2.0 ships as the stable 3.0 release. There is no need to stop using them
+- 🧩 **Mixing is expected** - Use EDS 1.0 and `/next` components side by side in the same application, and adopt the new ones as they fit your work
+- 🛠️ **Tooling for the 3.0 migration** - We plan to provide codemods and AI-assisted rewrites so that moving from EDS 1.0 to 3.0 is not a manual job
 
 <br />
 ## How to Use Beta Components
@@ -112,6 +112,8 @@ import { Button } from '@equinor/eds-core-react'
 ```
 
 That's it! No component name changes, just update the import path.
+
+Applications still on EDS 1.0 components get a migration guide with the 3.0 release, and we plan to ship codemods and AI-assisted rewrites so the move is not a manual job. Until then, EDS 1.0 stays supported and you can adopt `/next` components at your own pace.
 
 <br />
 ## Provide Feedback

--- a/packages/eds-core-react/stories/docs/EDS2.mdx
+++ b/packages/eds-core-react/stories/docs/EDS2.mdx
@@ -24,10 +24,10 @@ EDS 2.0 is a complete redesign of our component library, bringing:
 
 All components in the **"EDS 2.0"** section are in **beta**. Beta is not a warning against using them:
 
-- ✅ **Safe to adopt** - The components are tested and ready for production use. The API may still change in small ways before the stable release; every change is listed in the [beta changelog](https://github.com/equinor/design-system/blob/main/packages/eds-core-react/src/components/next/CHANGELOG.md)
-- 🤝 **EDS 1.0 is still supported** - The current components in `@equinor/eds-core-react` are maintained until EDS 2.0 ships as the stable 3.0 release. There is no need to stop using them
+- ✅ **Safe to adopt** - The components are published on the `beta` tag so that teams can start using them now. Expect small API changes before EDS 2.0 becomes stable, all listed in the [beta changelog](https://github.com/equinor/design-system/blob/main/packages/eds-core-react/src/components/next/CHANGELOG.md) with breaking ones marked. The theming layer (design tokens and the `data-*` attributes for density and colour scheme) is being reworked, so keep those references few and centralised
+- 🤝 **EDS 1.0 is still supported** - The current components in `@equinor/eds-core-react` are maintained until EDS 2.0 becomes stable (published as `eds-core-react@3.0.0`). There is no need to stop using them
 - 🧩 **Mixing is expected** - Use EDS 1.0 and `/next` components side by side in the same application, and adopt the new ones as they fit your work
-- 🛠️ **Tooling for the 3.0 migration** - We plan to provide codemods and AI-assisted rewrites so that moving from EDS 1.0 to 3.0 is not a manual job
+- 🛠️ **Tooling for the EDS 1.0 to EDS 2.0 migration** - We plan to provide codemods and AI-assisted rewrites so that moving from EDS 1.0 to EDS 2.0 is not a manual job
 
 <br />
 ## How to Use Beta Components
@@ -113,7 +113,7 @@ import { Button } from '@equinor/eds-core-react'
 
 That's it! No component name changes, just update the import path.
 
-Applications still on EDS 1.0 components get a migration guide with the 3.0 release, and we plan to ship codemods and AI-assisted rewrites so the move is not a manual job. Until then, EDS 1.0 stays supported and you can adopt `/next` components at your own pace.
+Applications still on EDS 1.0 components get a migration guide when EDS 2.0 becomes stable, and we plan to ship codemods and AI-assisted rewrites so the move is not a manual job. Until then, EDS 1.0 stays supported and you can adopt `/next` components at your own pace.
 
 <br />
 ## Provide Feedback


### PR DESCRIPTION
Part of #4942.

Consumers read the Storybook beta warning ("under active development and may have breaking changes") together with the EDS 1.0 deprecation label as "neither version is safe to use". This PR reframes the beta messaging so it says what we mean: the components are ready to adopt, and the API may still change in small ways before the stable 3.0 release.

## Changes

- One shared beta note in all 18 `/next` component stories and docs pages, replacing four different wordings. It links to the About EDS 2.0 page in Storybook.
- Same note in the story template in `BUILDING_EDS_2_COMPONENTS.md`, so new components pick it up.
- `EDS2.mdx` (About EDS 2.0): "Current Status: Beta" rewritten as "What Beta Means" with the points from #4942: safe to adopt, EDS 1.0 stays supported until 3.0, mixing 1.0 and `/next` is expected, codemods and AI-assisted rewrites planned for the 3.0 migration. Migration Path gets a paragraph on the same.
- Root README: removed "Not production-ready", replaced "may have breaking changes".
- JSDoc header in `index.next.ts`: replaced "experimental" and "breaking changes may occur".

## Still to do in this PR

- The docs site (`apps/design-system-docs`): the same explanation in the Versioning section, a beta note and `@beta` install on the getting started page, and a sentence on the `/next` token setup being reworked. Waits for #4989 so we edit the files that PR creates rather than the ones it replaces.
- The EDS 1.0 deprecation label is not in this repo (no legacy story or docs page sets it). Pending confirmation of where it lives in #4942.

## Draft

Kept in draft until #4989 is merged. The docs site changes are added here afterwards, then the PR is ready for review.


