### PR TITLE
chore: stop shipping docs in the eds-mobile-components package

### DIFF
--- a/packages/eds-mobile-components/CLAUDE.md
+++ b/packages/eds-mobile-components/CLAUDE.md
@@ -213,6 +213,8 @@ If the finding needs real work, open a dedicated issue and link it next to the c
 />
 ```
 
+**`docs/` is not published.** It is left out of `files` in `package.json` on purpose, because every consumer reads it through the workspace symlink. Do not add it back (equinor/design-system#5452).
+
 ### Component Development Checklist
 
 - [ ] Uses `EDSStyleSheet.create` for all theming

--- a/packages/eds-mobile-components/package.json
+++ b/packages/eds-mobile-components/package.json
@@ -33,8 +33,7 @@
     "files": [
         "LICENSE",
         "CHANGELOG.md",
-        "dist",
-        "docs"
+        "dist"
     ],
     "homepage": "https://eds.equinor.com",
     "keywords": [


### PR DESCRIPTION
Closes #5452

## What

Removes `"docs"` from the `files` array in `packages/eds-mobile-components/package.json`, so the 14 MDX files stop going into the npm tarball. Adds a two-sentence note to the package's `CLAUDE.md` so the entry does not get added back.

## Why

`docs/` shipped in the tarball because that was how `eds-core-react` obtained the files while the two projects lived in separate repositories. Since the monorepo migration it reads them through the `workspace:^` devDependency, so the published copy is never read and drifts out of date between releases. Two sources of the same document is a trap for whoever finds them later. The 40KB saving is incidental.

## Why it is safe

| Check | Result |
| --- | --- |
| Importers | All 8 live in `eds-core-react`, 5 of them under `/next`. Every one resolves through the workspace symlink, which `files` does not affect |
| Published surface of the consumer | `eds-core-react` publishes only `dist/*` and `build/*` behind an `exports` map with a single `.` entry, so its `.docs.mdx` files never leave the repo and no external consumer ever sees the `@equinor/eds-mobile-components/docs/*.mdx` specifier |
| Other routes into the tarball | None. No `.npmignore`, no `exports` map, no `publishConfig`, and the build config never copies `docs` into `dist` |
| CI, turbo, docs site | No workflow or task reads the docs from an installed copy |
| Lockfile | Unchanged. `files` is publish metadata, not a dependency field |

## Verification

`npm pack --dry-run` against the published 0.3.2 listing:

| | Published 0.3.2 | This branch |
| --- | --- | --- |
| Entries | 394 | 380 |
| `.mdx` files | 14 | 0 |

The only difference between the two file lists is the 14 `docs/*.mdx` removals. `README.md` and `package.json` remain, as npm always includes those regardless of `files`.

Resolution was checked with the change applied. `packages/eds-core-react/node_modules/@equinor/eds-mobile-components` is a symlink to the workspace directory and all 14 MDX files stay reachable through it.

## Notes

Consistent with the rest of the repo. No other EDS package publishes its documentation, and `/next` in particular builds to `dist/esm-next` plus `build/` CSS with no MDX. The one apparent exception, `eds-tokens` shipping `instructions/*`, is the opposite case, since those exist for consumers' AI tooling to read out of `node_modules`.

`chore` is a hidden type, so this triggers no release. The slimmer tarball first reaches npm with the next `feat` or `fix` in mobile.

One caveat carried over from the issue: we cannot tell whether an external consumer reads the MDX out of `node_modules`. The package is pre-1.0 and mobile has not been announced widely, so the risk is low.

A follow-up worth deciding separately: neither the `/next` release unit nor `eds-mobile-components` excludes its co-located docs from `exclude-paths` in `release-please-config.json`, so a doc-only edit still bumps a version and republishes an identical `dist`. Stable `eds-core-react` does exclude its `stories` directory. Logging this on #5442 rather than fixing it here, so it gets decided once for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)